### PR TITLE
Fix aggretation aliases.

### DIFF
--- a/metrics/SegmentsListQuery/bigquery.snap
+++ b/metrics/SegmentsListQuery/bigquery.snap
@@ -11,8 +11,8 @@ where
   timestamp(created_at) < timestamp '2025-03-16T00:00:00Z' and 
   1=1
 group by
-  SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100) as segment, 
-  SUBSTR(SAFE_CAST(run_status AS STRING), 1, 100) as segment2, 
-  SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100) as segment3
+  SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), 
+  SUBSTR(SAFE_CAST(run_status AS STRING), 1, 100), 
+  SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100)
 order by count(*) desc limit 10
 ---

--- a/metrics/SegmentsListQuery/mysql.snap
+++ b/metrics/SegmentsListQuery/mysql.snap
@@ -11,8 +11,8 @@ where
   created_at < '2025-03-16T00:00:00Z' and 
   1=1
 group by
-  SUBSTRING(CAST(workspace AS CHAR), 1, 100), 
-  SUBSTRING(CAST(run_status AS CHAR), 1, 100), 
-  SUBSTRING(CAST(run_type AS CHAR), 1, 100)
-order by count(*) desc limit 10
+  segment, 
+  segment2, 
+  segment3
+order by num_rows desc limit 10
 ---

--- a/metrics/SegmentsListQuery/mysql.snap
+++ b/metrics/SegmentsListQuery/mysql.snap
@@ -11,8 +11,8 @@ where
   created_at < '2025-03-16T00:00:00Z' and 
   1=1
 group by
-  segment, 
-  segment2, 
-  segment3
-order by num_rows desc limit 10
+  SUBSTRING(CAST(workspace AS CHAR), 1, 100), 
+  SUBSTRING(CAST(run_status AS CHAR), 1, 100), 
+  SUBSTRING(CAST(run_type AS CHAR), 1, 100)
+order by count(*) desc limit 10
 ---

--- a/metrics/SegmentsListQuery/mysql.snap
+++ b/metrics/SegmentsListQuery/mysql.snap
@@ -11,8 +11,8 @@ where
   created_at < '2025-03-16T00:00:00Z' and 
   1=1
 group by
-  SUBSTRING(CAST(workspace AS CHAR), 1, 100) as segment, 
-  SUBSTRING(CAST(run_status AS CHAR), 1, 100) as segment2, 
-  SUBSTRING(CAST(run_type AS CHAR), 1, 100) as segment3
+  SUBSTRING(CAST(workspace AS CHAR), 1, 100), 
+  SUBSTRING(CAST(run_status AS CHAR), 1, 100), 
+  SUBSTRING(CAST(run_type AS CHAR), 1, 100)
 order by count(*) desc limit 10
 ---

--- a/metrics/SegmentsListQuery/postgres.snap
+++ b/metrics/SegmentsListQuery/postgres.snap
@@ -11,8 +11,8 @@ where
   created_at < '2025-03-16T00:00:00Z' and 
   1=1
 group by
-  SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), 
-  SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), 
-  SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)
-order by count(*) desc limit 10
+  segment, 
+  segment2, 
+  segment3
+order by num_rows desc limit 10
 ---

--- a/metrics/SegmentsListQuery/postgres.snap
+++ b/metrics/SegmentsListQuery/postgres.snap
@@ -11,8 +11,8 @@ where
   created_at < '2025-03-16T00:00:00Z' and 
   1=1
 group by
-  SUBSTRING(CAST(workspace AS VARCHAR), 1, 100) as segment, 
-  SUBSTRING(CAST(run_status AS VARCHAR), 1, 100) as segment2, 
-  SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment3
+  SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), 
+  SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), 
+  SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)
 order by count(*) desc limit 10
 ---

--- a/metrics/SegmentsListQuery/postgres.snap
+++ b/metrics/SegmentsListQuery/postgres.snap
@@ -11,8 +11,8 @@ where
   created_at < '2025-03-16T00:00:00Z' and 
   1=1
 group by
-  segment, 
-  segment2, 
-  segment3
-order by num_rows desc limit 10
+  SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), 
+  SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), 
+  SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)
+order by count(*) desc limit 10
 ---

--- a/sqldialect/dialect.go
+++ b/sqldialect/dialect.go
@@ -460,7 +460,7 @@ func (d *PostgresDialect) Coalesce(exprs ...Expr) Expr {
 }
 
 func (d *PostgresDialect) AggregationColumnReference(expression Expr, alias string) Expr {
-	return expression
+	return Identifier(alias)
 }
 
 func (d *PostgresDialect) SubString(expr Expr, start int64, length int64) Expr {
@@ -643,7 +643,7 @@ func (d *MySQLDialect) Coalesce(exprs ...Expr) Expr {
 }
 
 func (d *MySQLDialect) AggregationColumnReference(expression Expr, alias string) Expr {
-	return expression
+	return Identifier(alias)
 }
 
 func (d *MySQLDialect) SubString(expr Expr, start int64, length int64) Expr {

--- a/sqldialect/dialect.go
+++ b/sqldialect/dialect.go
@@ -460,7 +460,7 @@ func (d *PostgresDialect) Coalesce(exprs ...Expr) Expr {
 }
 
 func (d *PostgresDialect) AggregationColumnReference(expression Expr, alias string) Expr {
-	return Identifier(alias)
+	return expression
 }
 
 func (d *PostgresDialect) SubString(expr Expr, start int64, length int64) Expr {
@@ -643,7 +643,7 @@ func (d *MySQLDialect) Coalesce(exprs ...Expr) Expr {
 }
 
 func (d *MySQLDialect) AggregationColumnReference(expression Expr, alias string) Expr {
-	return Identifier(alias)
+	return expression
 }
 
 func (d *MySQLDialect) SubString(expr Expr, start int64, length int64) Expr {


### PR DESCRIPTION
# Why
Aliases in aggregation part of query (`group by`) is not supported.

I have also updated dialect for mysql and postgres to use aliases in aggs.