### PR TITLE
Change order of closing conns in ssh case.

### DIFF
--- a/exec/postgres/postgres.go
+++ b/exec/postgres/postgres.go
@@ -109,13 +109,15 @@ func (e *PostgresExecutor) Exec(ctx context.Context, q string) error {
 
 func (e *PostgresExecutor) Close() error {
 	var errs []error
+	if err := e.db.Close(); err != nil {
+		errs = append(errs, err)
+	}
+
 	if e.sshTunnelDialer != nil {
 		if err := e.sshTunnelDialer.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	if err := e.db.Close(); err != nil {
-		errs = append(errs, err)
-	}
+
 	return errors.Join(errs...)
 }

--- a/exec/redshift/redshift.go
+++ b/exec/redshift/redshift.go
@@ -103,13 +103,15 @@ func (e *RedshiftExecutor) Exec(ctx context.Context, q string) error {
 
 func (e *RedshiftExecutor) Close() error {
 	var errs []error
+	if err := e.db.Close(); err != nil {
+		errs = append(errs, err)
+	}
+
 	if e.sshTunnelDialer != nil {
 		if err := e.sshTunnelDialer.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	if err := e.db.Close(); err != nil {
-		errs = append(errs, err)
-	}
+
 	return errors.Join(errs...)
 }


### PR DESCRIPTION
# Why
When we are closing executor connection we want to 1st close DB conn and then ssh conn