### PR TITLE
Fix closing ssh connections.

### DIFF
--- a/exec/postgres/query.go
+++ b/exec/postgres/query.go
@@ -6,5 +6,5 @@ import (
 )
 
 func NewQuerier[T any](conn *PostgresExecutor) querier.Querier[T] {
-	return stdsql.NewQuerier[T](conn.db)
+	return stdsql.NewQuerier(conn.db, stdsql.Querier_WithSshTunnelDialer[T](conn.sshTunnelDialer))
 }

--- a/exec/redshift/query.go
+++ b/exec/redshift/query.go
@@ -6,5 +6,5 @@ import (
 )
 
 func NewQuerier[T any](conn *RedshiftExecutor) querier.Querier[T] {
-	return stdsql.NewQuerier[T](conn.db)
+	return stdsql.NewQuerier(conn.db, stdsql.Querier_WithSshTunnelDialer[T](conn.sshTunnelDialer))
 }

--- a/exec/stdsql/querier.go
+++ b/exec/stdsql/querier.go
@@ -3,7 +3,6 @@ package stdsql
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/getsynq/dwhsupport/exec"
 	"github.com/getsynq/dwhsupport/exec/querier"
@@ -64,9 +63,7 @@ func (s StdSqlQuerier[T]) Close() error {
 	}
 
 	if s.sshTunnelDialer != nil {
-		fmt.Println("closing ssh tunnel")
 		if err := s.sshTunnelDialer.Close(); err != nil {
-			fmt.Println("error closing ssh tunnel", err)
 			errs = append(errs, err)
 		}
 	}

--- a/exec/stdsql/querier.go
+++ b/exec/stdsql/querier.go
@@ -2,27 +2,50 @@ package stdsql
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/getsynq/dwhsupport/exec"
 	"github.com/getsynq/dwhsupport/exec/querier"
+	"github.com/getsynq/dwhsupport/sshtunnel"
 	"github.com/jmoiron/sqlx"
 )
 
 var _ querier.Querier[interface{}] = (*StdSqlQuerier[interface{}])(nil)
 
-func NewQuerier[T any](conn *sqlx.DB) *StdSqlQuerier[T] {
-	return &StdSqlQuerier[T]{conn: conn}
+type Querier_Opts[T any] func(querier *StdSqlQuerier[T])
+
+func Querier_WithSshTunnelDialer[T any](sshTunnelDialer *sshtunnel.SshTunnelDialer) Querier_Opts[T] {
+	return func(querier *StdSqlQuerier[T]) {
+		querier.sshTunnelDialer = sshTunnelDialer
+	}
+}
+
+func NewQuerier[T any](conn *sqlx.DB, opts ...Querier_Opts[T]) *StdSqlQuerier[T] {
+	querier := &StdSqlQuerier[T]{conn: conn}
+
+	for _, opt := range opts {
+		opt(querier)
+	}
+
+	return querier
 }
 
 type StdSqlQuerier[T any] struct {
-	conn *sqlx.DB
+	conn            *sqlx.DB
+	sshTunnelDialer *sshtunnel.SshTunnelDialer
 }
 
 func (s StdSqlQuerier[T]) QueryMany(ctx context.Context, sql string, opts ...exec.QueryManyOpt[T]) ([]*T, error) {
 	return QueryMany(ctx, s.conn, sql, opts...)
 }
 
-func (s StdSqlQuerier[T]) QueryAndProcessMany(ctx context.Context, sql string, handler func(ctx context.Context, batch []*T) error, opts ...exec.QueryManyOpt[T]) error {
+func (s StdSqlQuerier[T]) QueryAndProcessMany(
+	ctx context.Context,
+	sql string,
+	handler func(ctx context.Context, batch []*T) error,
+	opts ...exec.QueryManyOpt[T],
+) error {
 	return QueryAndProcessMany(ctx, s.conn, sql, handler, opts...)
 }
 
@@ -35,5 +58,18 @@ func (s StdSqlQuerier[T]) Exec(ctx context.Context, sql string) error {
 }
 
 func (s StdSqlQuerier[T]) Close() error {
-	return s.conn.Close()
+	var errs []error
+	if err := s.conn.Close(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if s.sshTunnelDialer != nil {
+		fmt.Println("closing ssh tunnel")
+		if err := s.sshTunnelDialer.Close(); err != nil {
+			fmt.Println("error closing ssh tunnel", err)
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
# Why
SSH connections are not closed.

Redshift and Postgres are using StdSql querier package not their own. So `Close()` function in their package is actually never called. This PR is fixing closing SSH connections, not refactoring code as I am not sure what package to use (redshift vs stdsql) is expected.

## Before (ssh conn still `ESTABLISHED`, postgres conn is closed -> `TIME_WAIT` .. what is ok and expected)
https://github.com/user-attachments/assets/e30cc583-c988-4b50-8e91-0468582877c8



## After (ssh conn closed and gone, postgres -> `TIME_WAIT`)
https://github.com/user-attachments/assets/9f2678fe-c25c-4c55-b035-cd1646a07973

