### PR TITLE
Scrapper - query sql definitions.

### DIFF
--- a/scrapper/trino/query_sql_definitions.go
+++ b/scrapper/trino/query_sql_definitions.go
@@ -1,0 +1,37 @@
+package trino
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"strings"
+
+	dwhexec "github.com/getsynq/dwhsupport/exec"
+	"github.com/getsynq/dwhsupport/exec/stdsql"
+	"github.com/getsynq/dwhsupport/scrapper"
+)
+
+//go:embed query_sql_definitions.sql
+var querySqlDefinitionsSQL string
+
+func (e *TrinoScrapper) QuerySqlDefinitions(ctx context.Context) ([]*scrapper.SqlDefinitionRow, error) {
+	query := querySqlDefinitionsSQL
+	db := e.executor.GetDb()
+	var out []*scrapper.SqlDefinitionRow
+
+	for _, catalog := range e.conf.Catalogs {
+		catalogQuery := strings.Replace(query, "{{catalog}}", catalog, -1)
+		fmt.Println(catalogQuery)
+		res, err := stdsql.QueryMany(ctx, db, catalogQuery,
+			dwhexec.WithPostProcessors(func(row *scrapper.SqlDefinitionRow) (*scrapper.SqlDefinitionRow, error) {
+				row.Instance = e.conf.Host
+				return row, nil
+			}),
+		)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res...)
+	}
+	return out, nil
+}

--- a/scrapper/trino/query_sql_definitions.go
+++ b/scrapper/trino/query_sql_definitions.go
@@ -3,7 +3,6 @@ package trino
 import (
 	"context"
 	_ "embed"
-	"fmt"
 	"strings"
 
 	dwhexec "github.com/getsynq/dwhsupport/exec"
@@ -21,7 +20,6 @@ func (e *TrinoScrapper) QuerySqlDefinitions(ctx context.Context) ([]*scrapper.Sq
 
 	for _, catalog := range e.conf.Catalogs {
 		catalogQuery := strings.Replace(query, "{{catalog}}", catalog, -1)
-		fmt.Println(catalogQuery)
 		res, err := stdsql.QueryMany(ctx, db, catalogQuery,
 			dwhexec.WithPostProcessors(func(row *scrapper.SqlDefinitionRow) (*scrapper.SqlDefinitionRow, error) {
 				row.Instance = e.conf.Host

--- a/scrapper/trino/query_sql_definitions.sql
+++ b/scrapper/trino/query_sql_definitions.sql
@@ -1,0 +1,20 @@
+with tables as (
+    select 
+        table_catalog as database,
+        table_schema as schema,
+        table_name,
+        table_type
+    from {{catalog}}.information_schema.tables
+    where table_schema not in ('information_schema', 'sys')
+)
+select 
+    t.database,
+    t.schema,
+    t.table_name as "table",
+    t.table_type = 'VIEW' as is_view,
+    v.view_definition as sql
+from tables t
+left join {{catalog}}.information_schema.views v
+    on t.schema = v.table_schema and t.table_name = v.table_name
+where t.table_type = 'VIEW' or v.view_definition is not null
+order by t.database, t.schema, t.table_name 

--- a/scrapper/trino/query_sql_definitions_test.go
+++ b/scrapper/trino/query_sql_definitions_test.go
@@ -1,0 +1,54 @@
+package trino
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/getsynq/dwhsupport/exec/trino"
+	"github.com/stretchr/testify/suite"
+)
+
+type QuerySqlDefinitionsSuite struct {
+	suite.Suite
+}
+
+func TestQuerySqlDefinitionsSuite(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping Trino test in CI environment")
+	}
+	suite.Run(t, new(QuerySqlDefinitionsSuite))
+}
+
+func (s *QuerySqlDefinitionsSuite) TestQuerySqlDefinitions() {
+	// please run locally to make test pass:
+	// docker run --name trino -d -p 8080:8080 trinodb/trino
+	// or run bash or docker compose up in cloud/def-infra/trino repository/directory
+	ctx := context.TODO()
+	conf := &trino.TrinoConf{
+		Host:     "localhost",
+		Port:     8080,
+		User:     "trino",
+		Password: "trino",
+		Catalogs: []string{"iceberg"},
+	}
+	scr, err := NewTrinoScrapper(ctx, conf)
+	s.Require().NoError(err)
+	s.Require().NotNil(scr)
+	defer scr.Close()
+
+	rows, err := scr.QuerySqlDefinitions(ctx)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(rows)
+	spew.Dump(rows)
+
+	// Spot check first row fields
+	row := rows[0]
+	s.Equal("localhost", row.Instance)
+	s.Equal("iceberg", row.Database)
+	s.NotEmpty(row.Schema)
+	s.NotEmpty(row.Table)
+	s.NotEmpty(row.Sql)
+	s.True(row.IsView)
+}

--- a/scrapper/trino/trino.go
+++ b/scrapper/trino/trino.go
@@ -56,10 +56,6 @@ func (e *TrinoScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFetchT
 	return nil, scrapper.ErrUnsupported
 }
 
-func (e *TrinoScrapper) QuerySqlDefinitions(ctx context.Context) ([]*scrapper.SqlDefinitionRow, error) {
-	return nil, scrapper.ErrUnsupported
-}
-
 func (e *TrinoScrapper) QueryCatalog(ctx context.Context) ([]*scrapper.CatalogColumnRow, error) {
 	return nil, scrapper.ErrUnsupported
 }


### PR DESCRIPTION
# Why
Trino scrapper logic to query sql definitions. Now we are getting definitions only for views similarly to postgres logic (discussed w/ Lukasz) and task created for later optimisation https://linear.app/synq/issue/PR-5079/ddl-for-tablesviews