### PR TITLE
Trino - excluded schemas.

### DIFF
--- a/scrapper/trino/query_catalog.sql
+++ b/scrapper/trino/query_catalog.sql
@@ -17,4 +17,4 @@ LEFT JOIN system.metadata.table_comments tc
   ON t.table_catalog = tc.catalog_name
   AND t.table_schema = tc.schema_name
   AND t.table_name = tc.table_name
-WHERE t.table_schema NOT IN ('information_schema', 'sys', 'pg_catalog')
+WHERE t.table_schema NOT IN ('information_schema')

--- a/scrapper/trino/query_sql_definitions.sql
+++ b/scrapper/trino/query_sql_definitions.sql
@@ -5,7 +5,7 @@ with tables as (
         table_name,
         table_type
     from {{catalog}}.information_schema.tables
-    where table_schema not in ('information_schema', 'sys')
+    where table_schema not in ('information_schema')
 )
 select 
     t.database,

--- a/scrapper/trino/query_tables.sql
+++ b/scrapper/trino/query_tables.sql
@@ -11,4 +11,4 @@ LEFT JOIN system.metadata.table_comments c
   ON t.table_catalog = c.catalog_name
   AND t.table_schema = c.schema_name
   AND t.table_name = c.table_name
-WHERE t.table_schema NOT IN ('information_schema', 'sys', 'pg_catalog')
+WHERE t.table_schema NOT IN ('information_schema')


### PR DESCRIPTION
# Why
After discussion we decided to exclude only `information_schema` ... until we will be able to specify catalog type and based on that set other exclusions.