### PR TITLE
Trino - query table metrics

### DIFF
--- a/scrapper/trino/query_catalog_test.go
+++ b/scrapper/trino/query_catalog_test.go
@@ -26,10 +26,11 @@ func (s *QueryCatalogSuite) TestQueryCatalog() {
 	// docker run --name trino -d -p 8080:8080 trinodb/trino
 	ctx := context.TODO()
 	conf := &trino.TrinoConf{
-		Host:     "localhost",
-		Port:     8080,
-		User:     "trino",
-		Password: "trino",
+		Host:      "localhost",
+		Port:      8080,
+		User:      "trino",
+		Password:  "trino",
+		Plaintext: true,
 	}
 	scr, err := NewTrinoScrapper(ctx, &TrinoScrapperConf{
 		TrinoConf: conf,

--- a/scrapper/trino/query_table_metrics.go
+++ b/scrapper/trino/query_table_metrics.go
@@ -1,0 +1,64 @@
+package trino
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+)
+
+type trinoStatsRow struct {
+	ColumnName         sql.NullString  `db:"column_name"`
+	RowCount           sql.NullFloat64 `db:"row_count"`
+	DataSize           sql.NullFloat64 `db:"data_size"`
+	DistinctValueCount sql.NullFloat64 `db:"distinct_values_count"`
+	NullsFraction      sql.NullFloat64 `db:"nulls_fraction"`
+	LowValue           sql.NullString  `db:"low_value"`
+	HighValue          sql.NullString  `db:"high_value"`
+}
+
+func (e *TrinoScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFetchTime time.Time) ([]*scrapper.TableMetricsRow, error) {
+	tables, err := e.QueryTables(ctx)
+	if err != nil {
+		return nil, err
+	}
+	db := e.executor.GetDb()
+	var out []*scrapper.TableMetricsRow
+
+	for _, t := range tables {
+		fqTable := fmt.Sprintf("%s.%s.%s", t.Database, t.Schema, t.Table)
+		query := fmt.Sprintf("SHOW STATS FOR %s", fqTable)
+		rows, err := db.QueryxContext(ctx, query)
+		if err != nil {
+			// skip tables with errors (e.g. views, permissions)
+			continue
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var stat trinoStatsRow
+			if err := rows.StructScan(&stat); err != nil {
+				continue
+			}
+			if !stat.ColumnName.Valid { // NULL column_name row
+				var rowCount *int64
+				if stat.RowCount.Valid {
+					v := int64(stat.RowCount.Float64)
+					rowCount = &v
+				}
+				out = append(out, &scrapper.TableMetricsRow{
+					Instance:  t.Instance,
+					Database:  t.Database,
+					Schema:    t.Schema,
+					Table:     t.Table,
+					RowCount:  rowCount,
+					UpdatedAt: nil,
+					SizeBytes: nil,
+				})
+				break
+			}
+		}
+	}
+	return out, nil
+}

--- a/scrapper/trino/query_table_metrics.go
+++ b/scrapper/trino/query_table_metrics.go
@@ -32,14 +32,13 @@ func (e *TrinoScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFetchT
 		query := fmt.Sprintf("SHOW STATS FOR %s", fqTable)
 		rows, err := db.QueryxContext(ctx, query)
 		if err != nil {
-			// skip tables with errors (e.g. views, permissions)
-			continue
+			return nil, err
 		}
 		defer rows.Close()
 		for rows.Next() {
 			var stat trinoStatsRow
 			if err := rows.StructScan(&stat); err != nil {
-				continue
+				return nil, err
 			}
 			if !stat.ColumnName.Valid { // NULL column_name row
 				var rowCount *int64

--- a/scrapper/trino/query_table_metrics_test.go
+++ b/scrapper/trino/query_table_metrics_test.go
@@ -4,27 +4,25 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/getsynq/dwhsupport/exec/trino"
 	"github.com/stretchr/testify/suite"
 )
 
-type QuerySqlDefinitionsSuite struct {
+type QueryTableMetricsSuite struct {
 	suite.Suite
 }
 
-func TestQuerySqlDefinitionsSuite(t *testing.T) {
+func TestQueryTableMetricsSuite(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.Skip("skipping Trino test in CI environment")
 	}
-	suite.Run(t, new(QuerySqlDefinitionsSuite))
+	suite.Run(t, new(QueryTableMetricsSuite))
 }
 
-func (s *QuerySqlDefinitionsSuite) TestQuerySqlDefinitions() {
-	// please run locally to make test pass:
-	// docker run --name trino -d -p 8080:8080 trinodb/trino
-	// or run bash or docker compose up in cloud/def-infra/trino repository/directory
+func (s *QueryTableMetricsSuite) TestQueryTableMetrics() {
 	ctx := context.TODO()
 	conf := &trino.TrinoConf{
 		Host:      "localhost",
@@ -41,17 +39,15 @@ func (s *QuerySqlDefinitionsSuite) TestQuerySqlDefinitions() {
 	s.Require().NotNil(scr)
 	defer scr.Close()
 
-	rows, err := scr.QuerySqlDefinitions(ctx)
+	rows, err := scr.QueryTableMetrics(ctx, *new(time.Time))
 	s.Require().NoError(err)
 	s.Require().NotEmpty(rows)
 	spew.Dump(rows)
 
-	// Spot check first row fields
 	row := rows[0]
 	s.Equal("localhost", row.Instance)
 	s.Equal("iceberg", row.Database)
 	s.NotEmpty(row.Schema)
 	s.NotEmpty(row.Table)
-	s.NotEmpty(row.Sql)
-	s.True(row.IsView)
+	s.NotNil(row.RowCount)
 }

--- a/scrapper/trino/query_tables_test.go
+++ b/scrapper/trino/query_tables_test.go
@@ -26,10 +26,11 @@ func (s *QueryTablesSuite) TestQueryTables() {
 	// docker run --name trino -d -p 8080:8080 trinodb/trino
 	ctx := context.TODO()
 	conf := &trino.TrinoConf{
-		Host:     "localhost",
-		Port:     8080,
-		User:     "trino",
-		Password: "trino",
+		Host:      "localhost",
+		Port:      8080,
+		User:      "trino",
+		Password:  "trino",
+		Plaintext: true,
 	}
 	scr, err := NewTrinoScrapper(ctx, &TrinoScrapperConf{
 		TrinoConf: conf,

--- a/scrapper/trino/trino.go
+++ b/scrapper/trino/trino.go
@@ -2,7 +2,6 @@ package trino
 
 import (
 	"context"
-	"time"
 
 	dwhexectrino "github.com/getsynq/dwhsupport/exec/trino"
 	"github.com/getsynq/dwhsupport/scrapper"
@@ -55,10 +54,6 @@ func (e *TrinoScrapper) ValidateConfiguration(ctx context.Context) ([]string, er
 
 func (e *TrinoScrapper) Close() error {
 	return e.executor.Close()
-}
-
-func (e *TrinoScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFetchTime time.Time) ([]*scrapper.TableMetricsRow, error) {
-	return nil, scrapper.ErrUnsupported
 }
 
 func (e *TrinoScrapper) QueryDatabases(ctx context.Context) ([]*scrapper.DatabaseRow, error) {


### PR DESCRIPTION
# Why
Basic logic to query metrics. Right now we are scrapping only row_count logic.