### PR TITLE
Trino - trim right semicolons.

### DIFF
--- a/exec/trino/query.go
+++ b/exec/trino/query.go
@@ -1,10 +1,44 @@
 package trino
 
 import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/exec"
 	"github.com/getsynq/dwhsupport/exec/querier"
 	"github.com/getsynq/dwhsupport/exec/stdsql"
 )
 
+type Querier[T any] struct {
+	std *stdsql.StdSqlQuerier[T]
+}
+
+var _ querier.Querier[any] = &Querier[any]{}
+
 func NewQuerier[T any](conn *TrinoExecutor) querier.Querier[T] {
-	return stdsql.NewQuerier[T](conn.db)
+	return &Querier[T]{std: stdsql.NewQuerier[T](conn.db)}
+}
+
+func (q *Querier[T]) Close() error {
+	return q.std.Close()
+}
+
+func (q *Querier[T]) QueryMany(ctx context.Context, sql string, opts ...exec.QueryManyOpt[T]) ([]*T, error) {
+	return q.std.QueryMany(ctx, trimRightSemicolons(sql), opts...)
+}
+
+func (q *Querier[T]) QueryAndProcessMany(
+	ctx context.Context,
+	sql string,
+	handler func(ctx context.Context, batch []*T) error,
+	opts ...exec.QueryManyOpt[T],
+) error {
+	return q.std.QueryAndProcessMany(ctx, trimRightSemicolons(sql), handler, opts...)
+}
+
+func (q *Querier[T]) QueryMaps(ctx context.Context, sql string) ([]exec.QueryMapResult, error) {
+	return q.std.QueryMaps(ctx, trimRightSemicolons(sql))
+}
+
+func (q *Querier[T]) Exec(ctx context.Context, sql string) error {
+	return q.std.Exec(ctx, trimRightSemicolons(sql))
 }

--- a/exec/trino/trino.go
+++ b/exec/trino/trino.go
@@ -65,11 +65,11 @@ func NewTrinoExecutor(ctx context.Context, conf *TrinoConf) (*TrinoExecutor, err
 }
 
 func (e *TrinoExecutor) QueryRows(ctx context.Context, sql string, args ...interface{}) (*sqlx.Rows, error) {
-	return e.db.QueryxContext(ctx, sql, args...)
+	return e.db.QueryxContext(ctx, trimRightSemicolons(sql), args...)
 }
 
 func (e *TrinoExecutor) Exec(ctx context.Context, q string) error {
-	_, err := e.db.Exec(q)
+	_, err := e.db.Exec(trimRightSemicolons(q))
 	return err
 }
 

--- a/exec/trino/trino_test.go
+++ b/exec/trino/trino_test.go
@@ -31,17 +31,18 @@ func (s *TrinoSuite) TestBasicQuery() {
 	// docker run --name trino -d -p 8080:8080 trinodb/trino
 	ctx := context.TODO()
 	execer, err := NewTrinoExecutor(ctx, &TrinoConf{
-		Host:     "localhost",
-		Port:     8080,
-		User:     "trino",
-		Password: "trino",
+		Host:      "localhost",
+		Port:      8080,
+		User:      "trino",
+		Password:  "trino",
+		Plaintext: true,
 	})
 	s.NoError(err)
 	s.NotNil(execer)
 	defer execer.Close()
 
 	q := NewQuerier[res](execer)
-	results, err := q.QueryMany(ctx, "SELECT table_catalog, table_schema, table_name, table_type FROM tpch.information_schema.tables LIMIT 1")
+	results, err := q.QueryMany(ctx, "SELECT table_catalog, table_schema, table_name, table_type FROM tpch.information_schema.tables LIMIT 1;")
 	s.Require().NoError(err)
 	s.Require().NotEmpty(results)
 	s.Equal("tpch", results[0].TableCatalog)

--- a/exec/trino/utils.go
+++ b/exec/trino/utils.go
@@ -1,0 +1,7 @@
+package trino
+
+import "strings"
+
+func trimRightSemicolons(sql string) string {
+	return strings.TrimRight(sql, ";")
+}

--- a/exec/trino/utils_test.go
+++ b/exec/trino/utils_test.go
@@ -1,0 +1,23 @@
+package trino
+
+import "testing"
+
+func TestRemoveTrailingSemicolon(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"SELECT 1;", "SELECT 1"},
+		{"SELECT 1", "SELECT 1"},
+		{";", ""},
+		{"", ""},
+		{"SELECT 1;;", "SELECT 1"},
+	}
+
+	for _, tt := range tests {
+		got := trimRightSemicolons(tt.input)
+		if got != tt.expected {
+			t.Errorf("removeTrailingSemicolon(%q) = %q; want %q", tt.input, got, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
# Why
Trino driver is not expecting `;` in the end of statement and reporting error: `mismatched input ';'. Expecting: <EOF>`

We want to have executor supporting queries with `;` in the end. This PR is trimming right semicolons from sql statement and then executing it for Trino logic.