### PR TITLE
Trino - better semicolon trimming.

### DIFF
--- a/exec/trino/utils.go
+++ b/exec/trino/utils.go
@@ -3,5 +3,6 @@ package trino
 import "strings"
 
 func trimRightSemicolons(sql string) string {
+	sql = strings.TrimSpace(sql)
 	return strings.TrimRight(sql, ";")
 }

--- a/exec/trino/utils_test.go
+++ b/exec/trino/utils_test.go
@@ -12,6 +12,7 @@ func TestRemoveTrailingSemicolon(t *testing.T) {
 		{";", ""},
 		{"", ""},
 		{"SELECT 1;;", "SELECT 1"},
+		{"SELECT 1;\nSELECT 2;\n", "SELECT 1;\nSELECT 2"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Why
Removing end semicolon in sql statement didn't work if there were whitespace in the end (eg. new line). This PR is correcting it.