### PR TITLE
Zdenko/dialect base safe filter

### DIFF
--- a/metrics/ApplyMonitorDefArgs/bigquery.snap
+++ b/metrics/ApplyMonitorDefArgs/bigquery.snap
@@ -119,7 +119,7 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-where 1=1
+where (1=1)
 group by TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), HOUR), INTERVAL 1 HOUR)
 order by TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), HOUR), INTERVAL 1 HOUR) 
 ---
@@ -132,7 +132,7 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-where 1=1
+where (1=1)
 
  
 ---
@@ -147,7 +147,7 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-where 1=1
+where (1=1)
 group by
   TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), HOUR), INTERVAL 1 HOUR), 
   COALESCE(SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100), '')
@@ -165,7 +165,7 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-where 1=1
+where (1=1)
 group by COALESCE(SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100), '')
 order by COALESCE(SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100), '') 
 ---
@@ -185,7 +185,7 @@ from `db.default.runs`
 where
   COALESCE(SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTR(SAFE_CAST(run_status AS STRING), 1, 100), '') in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), HOUR), INTERVAL 1 HOUR), 
   COALESCE(SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), ''), 
@@ -212,7 +212,7 @@ from `db.default.runs`
 where
   COALESCE(SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTR(SAFE_CAST(run_status AS STRING), 1, 100), '') in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   COALESCE(SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), ''), 
   COALESCE(SUBSTR(SAFE_CAST(run_status AS STRING), 1, 100), ''), 
@@ -232,9 +232,7 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), HOUR), INTERVAL 1 HOUR)
 order by TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), HOUR), INTERVAL 1 HOUR) 
 ---
@@ -247,9 +245,7 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
  
 ---
@@ -264,9 +260,7 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), HOUR), INTERVAL 1 HOUR), 
   COALESCE(SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100), '')
@@ -284,9 +278,7 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by COALESCE(SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100), '')
 order by COALESCE(SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100), '') 
 ---
@@ -306,8 +298,7 @@ from `db.default.runs`
 where
   COALESCE(SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTR(SAFE_CAST(run_status AS STRING), 1, 100), '') in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), HOUR), INTERVAL 1 HOUR), 
   COALESCE(SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), ''), 
@@ -334,8 +325,7 @@ from `db.default.runs`
 where
   COALESCE(SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTR(SAFE_CAST(run_status AS STRING), 1, 100), '') in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   COALESCE(SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), ''), 
   COALESCE(SUBSTR(SAFE_CAST(run_status AS STRING), 1, 100), ''), 

--- a/metrics/ApplyMonitorDefArgs/clickhouse.snap
+++ b/metrics/ApplyMonitorDefArgs/clickhouse.snap
@@ -119,7 +119,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 group by time_segment
 order by time_segment 
 ---
@@ -132,7 +132,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 
  
 ---
@@ -147,7 +147,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 group by
   time_segment, 
   segment
@@ -165,7 +165,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 group by segment
 order by segment 
 ---
@@ -185,7 +185,7 @@ from default.runs
 where
   segment not in ('synq-demo') and 
   segment_2 in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   time_segment, 
   segment, 
@@ -212,7 +212,7 @@ from default.runs
 where
   segment not in ('synq-demo') and 
   segment_2 in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   segment, 
   segment_2, 
@@ -232,9 +232,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by time_segment
 order by time_segment 
 ---
@@ -247,9 +245,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
  
 ---
@@ -264,9 +260,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   time_segment, 
   segment
@@ -284,9 +278,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by segment
 order by segment 
 ---
@@ -306,8 +298,7 @@ from default.runs
 where
   segment not in ('synq-demo') and 
   segment_2 in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   time_segment, 
   segment, 
@@ -334,8 +325,7 @@ from default.runs
 where
   segment not in ('synq-demo') and 
   segment_2 in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   segment, 
   segment_2, 

--- a/metrics/ApplyMonitorDefArgs/databricks.snap
+++ b/metrics/ApplyMonitorDefArgs/databricks.snap
@@ -119,7 +119,7 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-where 1=1
+where (1=1)
 group by `time_segment`
 order by `time_segment` 
 ---
@@ -132,7 +132,7 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-where 1=1
+where (1=1)
 
  
 ---
@@ -147,7 +147,7 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-where 1=1
+where (1=1)
 group by
   `time_segment`, 
   `segment`
@@ -165,7 +165,7 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-where 1=1
+where (1=1)
 group by `segment`
 order by `segment` 
 ---
@@ -185,7 +185,7 @@ from db.default.runs
 where
   `segment` not in ('synq-demo') and 
   `segment_2` in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   `time_segment`, 
   `segment`, 
@@ -212,7 +212,7 @@ from db.default.runs
 where
   `segment` not in ('synq-demo') and 
   `segment_2` in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   `segment`, 
   `segment_2`, 
@@ -232,9 +232,7 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by `time_segment`
 order by `time_segment` 
 ---
@@ -247,9 +245,7 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
  
 ---
@@ -264,9 +260,7 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   `time_segment`, 
   `segment`
@@ -284,9 +278,7 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by `segment`
 order by `segment` 
 ---
@@ -306,8 +298,7 @@ from db.default.runs
 where
   `segment` not in ('synq-demo') and 
   `segment_2` in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   `time_segment`, 
   `segment`, 
@@ -334,8 +325,7 @@ from db.default.runs
 where
   `segment` not in ('synq-demo') and 
   `segment_2` in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   `segment`, 
   `segment_2`, 

--- a/metrics/ApplyMonitorDefArgs/duckdb.snap
+++ b/metrics/ApplyMonitorDefArgs/duckdb.snap
@@ -119,7 +119,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 group by time_segment
 order by time_segment 
 ---
@@ -132,7 +132,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 
  
 ---
@@ -147,7 +147,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 group by
   time_segment, 
   segment
@@ -165,7 +165,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 group by segment
 order by segment 
 ---
@@ -185,7 +185,7 @@ from default.runs
 where
   segment not in ('synq-demo') and 
   segment_2 in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   time_segment, 
   segment, 
@@ -212,7 +212,7 @@ from default.runs
 where
   segment not in ('synq-demo') and 
   segment_2 in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   segment, 
   segment_2, 
@@ -232,9 +232,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by time_segment
 order by time_segment 
 ---
@@ -247,9 +245,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
  
 ---
@@ -264,9 +260,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   time_segment, 
   segment
@@ -284,9 +278,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by segment
 order by segment 
 ---
@@ -306,8 +298,7 @@ from default.runs
 where
   segment not in ('synq-demo') and 
   segment_2 in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   time_segment, 
   segment, 
@@ -334,8 +325,7 @@ from default.runs
 where
   segment not in ('synq-demo') and 
   segment_2 in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   segment, 
   segment_2, 

--- a/metrics/ApplyMonitorDefArgs/mysql.snap
+++ b/metrics/ApplyMonitorDefArgs/mysql.snap
@@ -119,7 +119,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 group by DATEADD(HOUR, 1, STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d %H:00:00'), '%Y-%m-%d %H:%i:%s'))
 order by DATEADD(HOUR, 1, STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d %H:00:00'), '%Y-%m-%d %H:%i:%s')) 
 ---
@@ -132,7 +132,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 
  
 ---
@@ -147,7 +147,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 group by
   DATEADD(HOUR, 1, STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d %H:00:00'), '%Y-%m-%d %H:%i:%s')), 
   COALESCE(SUBSTRING(CAST(run_type AS CHAR), 1, 100), '')
@@ -165,7 +165,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 group by COALESCE(SUBSTRING(CAST(run_type AS CHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(run_type AS CHAR), 1, 100), '') 
 ---
@@ -185,7 +185,7 @@ from default.runs
 where
   COALESCE(SUBSTRING(CAST(workspace AS CHAR), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTRING(CAST(run_status AS CHAR), 1, 100), '') in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   DATEADD(HOUR, 1, STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d %H:00:00'), '%Y-%m-%d %H:%i:%s')), 
   COALESCE(SUBSTRING(CAST(workspace AS CHAR), 1, 100), ''), 
@@ -212,7 +212,7 @@ from default.runs
 where
   COALESCE(SUBSTRING(CAST(workspace AS CHAR), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTRING(CAST(run_status AS CHAR), 1, 100), '') in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   COALESCE(SUBSTRING(CAST(workspace AS CHAR), 1, 100), ''), 
   COALESCE(SUBSTRING(CAST(run_status AS CHAR), 1, 100), ''), 
@@ -232,9 +232,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by DATEADD(HOUR, 1, STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d %H:00:00'), '%Y-%m-%d %H:%i:%s'))
 order by DATEADD(HOUR, 1, STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d %H:00:00'), '%Y-%m-%d %H:%i:%s')) 
 ---
@@ -247,9 +245,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
  
 ---
@@ -264,9 +260,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   DATEADD(HOUR, 1, STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d %H:00:00'), '%Y-%m-%d %H:%i:%s')), 
   COALESCE(SUBSTRING(CAST(run_type AS CHAR), 1, 100), '')
@@ -284,9 +278,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by COALESCE(SUBSTRING(CAST(run_type AS CHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(run_type AS CHAR), 1, 100), '') 
 ---
@@ -306,8 +298,7 @@ from default.runs
 where
   COALESCE(SUBSTRING(CAST(workspace AS CHAR), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTRING(CAST(run_status AS CHAR), 1, 100), '') in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   DATEADD(HOUR, 1, STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d %H:00:00'), '%Y-%m-%d %H:%i:%s')), 
   COALESCE(SUBSTRING(CAST(workspace AS CHAR), 1, 100), ''), 
@@ -334,8 +325,7 @@ from default.runs
 where
   COALESCE(SUBSTRING(CAST(workspace AS CHAR), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTRING(CAST(run_status AS CHAR), 1, 100), '') in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   COALESCE(SUBSTRING(CAST(workspace AS CHAR), 1, 100), ''), 
   COALESCE(SUBSTRING(CAST(run_status AS CHAR), 1, 100), ''), 

--- a/metrics/ApplyMonitorDefArgs/postgres.snap
+++ b/metrics/ApplyMonitorDefArgs/postgres.snap
@@ -119,7 +119,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 group by DATE_TRUNC('HOUR', ingested_at) + '1 HOUR'
 order by DATE_TRUNC('HOUR', ingested_at) + '1 HOUR' 
 ---
@@ -132,7 +132,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 
  
 ---
@@ -147,7 +147,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 group by
   DATE_TRUNC('HOUR', ingested_at) + '1 HOUR', 
   COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
@@ -165,7 +165,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=1
+where (1=1)
 group by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
@@ -185,7 +185,7 @@ from default.runs
 where
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   DATE_TRUNC('HOUR', ingested_at) + '1 HOUR', 
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
@@ -212,7 +212,7 @@ from default.runs
 where
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
   COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
@@ -232,9 +232,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by DATE_TRUNC('HOUR', ingested_at) + '1 HOUR'
 order by DATE_TRUNC('HOUR', ingested_at) + '1 HOUR' 
 ---
@@ -247,9 +245,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
  
 ---
@@ -264,9 +260,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   DATE_TRUNC('HOUR', ingested_at) + '1 HOUR', 
   COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
@@ -284,9 +278,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
@@ -306,8 +298,7 @@ from default.runs
 where
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   DATE_TRUNC('HOUR', ingested_at) + '1 HOUR', 
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
@@ -334,8 +325,7 @@ from default.runs
 where
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
   COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 

--- a/metrics/ApplyMonitorDefArgs/redshift.snap
+++ b/metrics/ApplyMonitorDefArgs/redshift.snap
@@ -119,7 +119,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-where 1=1
+where (1=1)
 group by time_segment
 order by time_segment 
 ---
@@ -132,7 +132,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-where 1=1
+where (1=1)
 
  
 ---
@@ -147,7 +147,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-where 1=1
+where (1=1)
 group by
   time_segment, 
   segment
@@ -165,7 +165,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-where 1=1
+where (1=1)
 group by segment
 order by segment 
 ---
@@ -185,7 +185,7 @@ from "db"."default"."runs"
 where
   segment not in ('synq-demo') and 
   segment_2 in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   time_segment, 
   segment, 
@@ -212,7 +212,7 @@ from "db"."default"."runs"
 where
   segment not in ('synq-demo') and 
   segment_2 in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   segment, 
   segment_2, 
@@ -232,9 +232,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by time_segment
 order by time_segment 
 ---
@@ -247,9 +245,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
  
 ---
@@ -264,9 +260,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   time_segment, 
   segment
@@ -284,9 +278,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by segment
 order by segment 
 ---
@@ -306,8 +298,7 @@ from "db"."default"."runs"
 where
   segment not in ('synq-demo') and 
   segment_2 in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   time_segment, 
   segment, 
@@ -334,8 +325,7 @@ from "db"."default"."runs"
 where
   segment not in ('synq-demo') and 
   segment_2 in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   segment, 
   segment_2, 

--- a/metrics/ApplyMonitorDefArgs/snowflake.snap
+++ b/metrics/ApplyMonitorDefArgs/snowflake.snap
@@ -119,7 +119,7 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-where 1=1
+where (1=1)
 group by "time_segment"
 order by "time_segment" 
 ---
@@ -132,7 +132,7 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-where 1=1
+where (1=1)
 
  
 ---
@@ -147,7 +147,7 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-where 1=1
+where (1=1)
 group by
   "time_segment", 
   "segment"
@@ -165,7 +165,7 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-where 1=1
+where (1=1)
 group by "segment"
 order by "segment" 
 ---
@@ -185,7 +185,7 @@ from db.default.runs
 where
   "segment" not in ('synq-demo') and 
   "segment_2" in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   "time_segment", 
   "segment", 
@@ -212,7 +212,7 @@ from db.default.runs
 where
   "segment" not in ('synq-demo') and 
   "segment_2" in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   "segment", 
   "segment_2", 
@@ -232,9 +232,7 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by "time_segment"
 order by "time_segment" 
 ---
@@ -247,9 +245,7 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
  
 ---
@@ -264,9 +260,7 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   "time_segment", 
   "segment"
@@ -284,9 +278,7 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by "segment"
 order by "segment" 
 ---
@@ -306,8 +298,7 @@ from db.default.runs
 where
   "segment" not in ('synq-demo') and 
   "segment_2" in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   "time_segment", 
   "segment", 
@@ -334,8 +325,7 @@ from db.default.runs
 where
   "segment" not in ('synq-demo') and 
   "segment_2" in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   "segment", 
   "segment_2", 

--- a/metrics/ApplyMonitorDefArgs/trino.snap
+++ b/metrics/ApplyMonitorDefArgs/trino.snap
@@ -119,7 +119,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-where 1=1
+where (1=1)
 group by DATE_ADD('HOUR', 1, DATE_TRUNC('HOUR', ingested_at))
 order by DATE_ADD('HOUR', 1, DATE_TRUNC('HOUR', ingested_at)) 
 ---
@@ -132,7 +132,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-where 1=1
+where (1=1)
 
  
 ---
@@ -147,7 +147,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-where 1=1
+where (1=1)
 group by
   DATE_ADD('HOUR', 1, DATE_TRUNC('HOUR', ingested_at)), 
   COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
@@ -165,7 +165,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-where 1=1
+where (1=1)
 group by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
@@ -185,7 +185,7 @@ from db.default.runs
 where
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   DATE_ADD('HOUR', 1, DATE_TRUNC('HOUR', ingested_at)), 
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
@@ -212,7 +212,7 @@ from db.default.runs
 where
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4') and 
-  1=1
+  (1=1)
 group by
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
   COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
@@ -232,9 +232,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by DATE_ADD('HOUR', 1, DATE_TRUNC('HOUR', ingested_at))
 order by DATE_ADD('HOUR', 1, DATE_TRUNC('HOUR', ingested_at)) 
 ---
@@ -247,9 +245,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
  
 ---
@@ -264,9 +260,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   DATE_ADD('HOUR', 1, DATE_TRUNC('HOUR', ingested_at)), 
   COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
@@ -284,9 +278,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
@@ -306,8 +298,7 @@ from db.default.runs
 where
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   DATE_ADD('HOUR', 1, DATE_TRUNC('HOUR', ingested_at)), 
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
@@ -334,8 +325,7 @@ from db.default.runs
 where
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
   COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4') and 
-  run_status > 0 and 
-  run_type > 0
+  (run_status > 0) and (run_type > 0)
 group by
   COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
   COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 

--- a/metrics/ProfileColumns/bigquery.snap
+++ b/metrics/ProfileColumns/bigquery.snap
@@ -129,7 +129,7 @@ select
   min(timestamp(created_at)) as created_at$min, 
   max(timestamp(created_at)) as created_at$max
 from `db.default.runs` 
-where 1=1
+where (1=1)
 
 order by num_rows desc limit 1000
 ---
@@ -162,7 +162,7 @@ select
   min(timestamp(created_at)) as created_at$min, 
   max(timestamp(created_at)) as created_at$max
 from `db.default.runs` 
-where 1=1
+where (1=1)
 group by SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -197,7 +197,7 @@ select
   min(timestamp(created_at)) as created_at$min, 
   max(timestamp(created_at)) as created_at$max
 from `db.default.runs` 
-where 1=1
+where (1=1)
 group by
   SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100) as segment, 
   SUBSTR(SAFE_CAST(run_status AS STRING), 1, 100) as segment2, 
@@ -232,9 +232,7 @@ select
   min(timestamp(created_at)) as created_at$min, 
   max(timestamp(created_at)) as created_at$max
 from `db.default.runs` 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
 order by num_rows desc limit 1000
 ---
@@ -267,9 +265,7 @@ select
   min(timestamp(created_at)) as created_at$min, 
   max(timestamp(created_at)) as created_at$max
 from `db.default.runs` 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -304,9 +300,7 @@ select
   min(timestamp(created_at)) as created_at$min, 
   max(timestamp(created_at)) as created_at$max
 from `db.default.runs` 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100) as segment, 
   SUBSTR(SAFE_CAST(run_status AS STRING), 1, 100) as segment2, 

--- a/metrics/ProfileColumns/clickhouse.snap
+++ b/metrics/ProfileColumns/clickhouse.snap
@@ -129,7 +129,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where 1=1
+where (1=1)
 
 order by num_rows desc limit 1000
 ---
@@ -162,7 +162,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where 1=1
+where (1=1)
 group by segment
 order by num_rows desc limit 1000
 ---
@@ -197,7 +197,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where 1=1
+where (1=1)
 group by
   segment, 
   segment2, 
@@ -232,9 +232,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
 order by num_rows desc limit 1000
 ---
@@ -267,9 +265,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by segment
 order by num_rows desc limit 1000
 ---
@@ -304,9 +300,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   segment, 
   segment2, 

--- a/metrics/ProfileColumns/databricks.snap
+++ b/metrics/ProfileColumns/databricks.snap
@@ -129,7 +129,7 @@ select
   min(created_at) as `created_at$min`, 
   max(created_at) as `created_at$max`
 from db.default.runs 
-where 1=1
+where (1=1)
 
 order by `num_rows` desc limit 1000
 ---
@@ -162,7 +162,7 @@ select
   min(created_at) as `created_at$min`, 
   max(created_at) as `created_at$max`
 from db.default.runs 
-where 1=1
+where (1=1)
 group by `segment`
 order by `num_rows` desc limit 1000
 ---
@@ -197,7 +197,7 @@ select
   min(created_at) as `created_at$min`, 
   max(created_at) as `created_at$max`
 from db.default.runs 
-where 1=1
+where (1=1)
 group by
   `segment`, 
   `segment2`, 
@@ -232,9 +232,7 @@ select
   min(created_at) as `created_at$min`, 
   max(created_at) as `created_at$max`
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
 order by `num_rows` desc limit 1000
 ---
@@ -267,9 +265,7 @@ select
   min(created_at) as `created_at$min`, 
   max(created_at) as `created_at$max`
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by `segment`
 order by `num_rows` desc limit 1000
 ---
@@ -304,9 +300,7 @@ select
   min(created_at) as `created_at$min`, 
   max(created_at) as `created_at$max`
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   `segment`, 
   `segment2`, 

--- a/metrics/ProfileColumns/duckdb.snap
+++ b/metrics/ProfileColumns/duckdb.snap
@@ -129,7 +129,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where 1=1
+where (1=1)
 
 order by num_rows desc limit 1000
 ---
@@ -162,7 +162,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where 1=1
+where (1=1)
 group by segment
 order by num_rows desc limit 1000
 ---
@@ -197,7 +197,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where 1=1
+where (1=1)
 group by
   segment, 
   segment2, 
@@ -232,9 +232,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
 order by num_rows desc limit 1000
 ---
@@ -267,9 +265,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by segment
 order by num_rows desc limit 1000
 ---
@@ -304,9 +300,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   segment, 
   segment2, 

--- a/metrics/ProfileColumns/mysql.snap
+++ b/metrics/ProfileColumns/mysql.snap
@@ -129,7 +129,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where 1=1
+where (1=1)
 
 order by num_rows desc limit 1000
 ---
@@ -162,7 +162,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where 1=1
+where (1=1)
 group by SUBSTRING(CAST(run_type AS CHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -197,7 +197,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where 1=1
+where (1=1)
 group by
   SUBSTRING(CAST(workspace AS CHAR), 1, 100) as segment, 
   SUBSTRING(CAST(run_status AS CHAR), 1, 100) as segment2, 
@@ -232,9 +232,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
 order by num_rows desc limit 1000
 ---
@@ -267,9 +265,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by SUBSTRING(CAST(run_type AS CHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -304,9 +300,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   SUBSTRING(CAST(workspace AS CHAR), 1, 100) as segment, 
   SUBSTRING(CAST(run_status AS CHAR), 1, 100) as segment2, 

--- a/metrics/ProfileColumns/postgres.snap
+++ b/metrics/ProfileColumns/postgres.snap
@@ -129,7 +129,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where 1=1
+where (1=1)
 
 order by num_rows desc limit 1000
 ---
@@ -162,7 +162,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where 1=1
+where (1=1)
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -197,7 +197,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where 1=1
+where (1=1)
 group by
   SUBSTRING(CAST(workspace AS VARCHAR), 1, 100) as segment, 
   SUBSTRING(CAST(run_status AS VARCHAR), 1, 100) as segment2, 
@@ -232,9 +232,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
 order by num_rows desc limit 1000
 ---
@@ -267,9 +265,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -304,9 +300,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   SUBSTRING(CAST(workspace AS VARCHAR), 1, 100) as segment, 
   SUBSTRING(CAST(run_status AS VARCHAR), 1, 100) as segment2, 

--- a/metrics/ProfileColumns/redshift.snap
+++ b/metrics/ProfileColumns/redshift.snap
@@ -125,7 +125,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from "db"."default"."runs" 
-where 1=1
+where (1=1)
 
 order by num_rows desc limit 1000
 ---
@@ -157,7 +157,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from "db"."default"."runs" 
-where 1=1
+where (1=1)
 group by segment
 order by num_rows desc limit 1000
 ---
@@ -191,7 +191,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from "db"."default"."runs" 
-where 1=1
+where (1=1)
 group by
   segment, 
   segment2, 
@@ -225,9 +225,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from "db"."default"."runs" 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
 order by num_rows desc limit 1000
 ---
@@ -259,9 +257,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from "db"."default"."runs" 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by segment
 order by num_rows desc limit 1000
 ---
@@ -295,9 +291,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from "db"."default"."runs" 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   segment, 
   segment2, 

--- a/metrics/ProfileColumns/snowflake.snap
+++ b/metrics/ProfileColumns/snowflake.snap
@@ -129,7 +129,7 @@ select
   min(created_at) as "created_at$min", 
   max(created_at) as "created_at$max"
 from db.default.runs 
-where 1=1
+where (1=1)
 
 order by "num_rows" desc limit 1000
 ---
@@ -162,7 +162,7 @@ select
   min(created_at) as "created_at$min", 
   max(created_at) as "created_at$max"
 from db.default.runs 
-where 1=1
+where (1=1)
 group by "segment"
 order by "num_rows" desc limit 1000
 ---
@@ -197,7 +197,7 @@ select
   min(created_at) as "created_at$min", 
   max(created_at) as "created_at$max"
 from db.default.runs 
-where 1=1
+where (1=1)
 group by
   "segment", 
   "segment2", 
@@ -232,9 +232,7 @@ select
   min(created_at) as "created_at$min", 
   max(created_at) as "created_at$max"
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
 order by "num_rows" desc limit 1000
 ---
@@ -267,9 +265,7 @@ select
   min(created_at) as "created_at$min", 
   max(created_at) as "created_at$max"
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by "segment"
 order by "num_rows" desc limit 1000
 ---
@@ -304,9 +300,7 @@ select
   min(created_at) as "created_at$min", 
   max(created_at) as "created_at$max"
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   "segment", 
   "segment2", 

--- a/metrics/ProfileColumns/trino.snap
+++ b/metrics/ProfileColumns/trino.snap
@@ -129,7 +129,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from db.default.runs 
-where 1=1
+where (1=1)
 
 order by num_rows desc limit 1000
 ---
@@ -162,7 +162,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from db.default.runs 
-where 1=1
+where (1=1)
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -197,7 +197,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from db.default.runs 
-where 1=1
+where (1=1)
 group by
   SUBSTRING(CAST(workspace AS VARCHAR), 1, 100) as segment, 
   SUBSTRING(CAST(run_status AS VARCHAR), 1, 100) as segment2, 
@@ -232,9 +232,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 
 order by num_rows desc limit 1000
 ---
@@ -267,9 +265,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -304,9 +300,7 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from db.default.runs 
-where
-  run_status > 0 and 
-  run_type > 0
+where (run_status > 0) and (run_type > 0)
 group by
   SUBSTRING(CAST(workspace AS VARCHAR), 1, 100) as segment, 
   SUBSTRING(CAST(run_status AS VARCHAR), 1, 100) as segment2, 

--- a/metrics/SegmentWithTimeRange/bigquery.snap
+++ b/metrics/SegmentWithTimeRange/bigquery.snap
@@ -37,7 +37,7 @@ from `db.default.runs`
 where
   timestamp(ingested_at) >= timestamp '2025-01-01T00:00:00Z' and 
   timestamp(ingested_at) < timestamp '2025-02-01T00:00:00Z' and 
-  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+  (workspace = 'synq-demo' OR 1=1)
 group by COALESCE(SAFE_CAST(workspace AS STRING), '')
 order by COALESCE(SAFE_CAST(workspace AS STRING), '') 
 ---

--- a/metrics/SegmentWithTimeRange/bigquery.snap
+++ b/metrics/SegmentWithTimeRange/bigquery.snap
@@ -19,3 +19,25 @@ where
 group by COALESCE(SAFE_CAST(workspace AS STRING), '')
 order by COALESCE(SAFE_CAST(workspace AS STRING), '') 
 ---
+
+[TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
+select
+  COALESCE(SAFE_CAST(workspace AS STRING), '') as segment, 
+  'run_type' as field, 
+  count(*) as num_rows, 
+  count(run_type) as num_not_null, 
+  count(distinct run_type) as num_unique, 
+  countif(run_type = 0) as num_empty, 
+  CAST(avg(run_type) AS FLOAT64) as mean, 
+  CAST(min(run_type) AS FLOAT64) as min, 
+  CAST(max(run_type) AS FLOAT64) as max, 
+  CAST(approx_quantiles(run_type, 2)[offset(1)] AS FLOAT64) as median, 
+  CAST(stddev_samp(run_type) AS FLOAT64) as stddev
+from `db.default.runs` 
+where
+  timestamp(ingested_at) >= timestamp '2025-01-01T00:00:00Z' and 
+  timestamp(ingested_at) < timestamp '2025-02-01T00:00:00Z' and 
+  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+group by COALESCE(SAFE_CAST(workspace AS STRING), '')
+order by COALESCE(SAFE_CAST(workspace AS STRING), '') 
+---

--- a/metrics/SegmentWithTimeRange/bigquery.snap
+++ b/metrics/SegmentWithTimeRange/bigquery.snap
@@ -1,25 +1,3 @@
-
-[TestMetricsSuite/TestSegmentWithTimeRange - 1]
-select
-  COALESCE(SAFE_CAST(workspace AS STRING), '') as segment, 
-  'run_type' as field, 
-  count(*) as num_rows, 
-  count(run_type) as num_not_null, 
-  count(distinct run_type) as num_unique, 
-  countif(run_type = 0) as num_empty, 
-  CAST(avg(run_type) AS FLOAT64) as mean, 
-  CAST(min(run_type) AS FLOAT64) as min, 
-  CAST(max(run_type) AS FLOAT64) as max, 
-  CAST(approx_quantiles(run_type, 2)[offset(1)] AS FLOAT64) as median, 
-  CAST(stddev_samp(run_type) AS FLOAT64) as stddev
-from `db.default.runs` 
-where
-  timestamp(ingested_at) >= timestamp '2025-01-01T00:00:00Z' and 
-  timestamp(ingested_at) < timestamp '2025-02-01T00:00:00Z'
-group by COALESCE(SAFE_CAST(workspace AS STRING), '')
-order by COALESCE(SAFE_CAST(workspace AS STRING), '') 
----
-
 [TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
 select
   COALESCE(SAFE_CAST(workspace AS STRING), '') as segment, 

--- a/metrics/SegmentWithTimeRange/clickhouse.snap
+++ b/metrics/SegmentWithTimeRange/clickhouse.snap
@@ -19,3 +19,25 @@ where
 group by segment
 order by segment 
 ---
+
+[TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
+select
+  coalesce(toString(workspace), '') as segment, 
+  'run_type' as field, 
+  toInt64(count(*)) as num_rows, 
+  toInt64(count(run_type)) as num_not_null, 
+  toInt64(count(distinct run_type)) as num_unique, 
+  toInt64(countIf(run_type = 0)) as num_empty, 
+  toFloat64(avg(run_type)) as mean, 
+  toFloat64(min(run_type)) as min, 
+  toFloat64(max(run_type)) as max, 
+  toFloat64(median(run_type)) as median, 
+  toFloat64(stddevSamp(run_type)) as stddev
+from default.runs 
+where
+  ingested_at >= parseDateTimeBestEffort('2025-01-01 00:00:00') and 
+  ingested_at < parseDateTimeBestEffort('2025-02-01 00:00:00') and 
+  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+group by segment
+order by segment 
+---

--- a/metrics/SegmentWithTimeRange/clickhouse.snap
+++ b/metrics/SegmentWithTimeRange/clickhouse.snap
@@ -37,7 +37,7 @@ from default.runs
 where
   ingested_at >= parseDateTimeBestEffort('2025-01-01 00:00:00') and 
   ingested_at < parseDateTimeBestEffort('2025-02-01 00:00:00') and 
-  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+  (workspace = 'synq-demo' OR 1=1)
 group by segment
 order by segment 
 ---

--- a/metrics/SegmentWithTimeRange/clickhouse.snap
+++ b/metrics/SegmentWithTimeRange/clickhouse.snap
@@ -1,25 +1,3 @@
-
-[TestMetricsSuite/TestSegmentWithTimeRange - 1]
-select
-  coalesce(toString(workspace), '') as segment, 
-  'run_type' as field, 
-  toInt64(count(*)) as num_rows, 
-  toInt64(count(run_type)) as num_not_null, 
-  toInt64(count(distinct run_type)) as num_unique, 
-  toInt64(countIf(run_type = 0)) as num_empty, 
-  toFloat64(avg(run_type)) as mean, 
-  toFloat64(min(run_type)) as min, 
-  toFloat64(max(run_type)) as max, 
-  toFloat64(median(run_type)) as median, 
-  toFloat64(stddevSamp(run_type)) as stddev
-from default.runs 
-where
-  ingested_at >= parseDateTimeBestEffort('2025-01-01 00:00:00') and 
-  ingested_at < parseDateTimeBestEffort('2025-02-01 00:00:00')
-group by segment
-order by segment 
----
-
 [TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
 select
   coalesce(toString(workspace), '') as segment, 

--- a/metrics/SegmentWithTimeRange/databricks.snap
+++ b/metrics/SegmentWithTimeRange/databricks.snap
@@ -19,3 +19,25 @@ where
 group by `segment`
 order by `segment` 
 ---
+
+[TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
+select
+  COALESCE(CAST(`workspace` AS STRING), '') as `segment`, 
+  'run_type' as `field`, 
+  count(*) as `num_rows`, 
+  count(run_type) as `num_not_null`, 
+  count(distinct run_type) as `num_unique`, 
+  count_if(run_type = 0) as `num_empty`, 
+  CAST(avg(run_type) AS FLOAT) as `mean`, 
+  CAST(min(run_type) AS FLOAT) as `min`, 
+  CAST(max(run_type) AS FLOAT) as `max`, 
+  CAST(median(run_type) AS FLOAT) as `median`, 
+  CAST(stddev(run_type) AS FLOAT) as `stddev`
+from db.default.runs 
+where
+  ingested_at >= '2025-01-01T00:00:00Z' and 
+  ingested_at < '2025-02-01T00:00:00Z' and 
+  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+group by `segment`
+order by `segment` 
+---

--- a/metrics/SegmentWithTimeRange/databricks.snap
+++ b/metrics/SegmentWithTimeRange/databricks.snap
@@ -1,25 +1,3 @@
-
-[TestMetricsSuite/TestSegmentWithTimeRange - 1]
-select
-  COALESCE(CAST(`workspace` AS STRING), '') as `segment`, 
-  'run_type' as `field`, 
-  count(*) as `num_rows`, 
-  count(run_type) as `num_not_null`, 
-  count(distinct run_type) as `num_unique`, 
-  count_if(run_type = 0) as `num_empty`, 
-  CAST(avg(run_type) AS FLOAT) as `mean`, 
-  CAST(min(run_type) AS FLOAT) as `min`, 
-  CAST(max(run_type) AS FLOAT) as `max`, 
-  CAST(median(run_type) AS FLOAT) as `median`, 
-  CAST(stddev(run_type) AS FLOAT) as `stddev`
-from db.default.runs 
-where
-  ingested_at >= '2025-01-01T00:00:00Z' and 
-  ingested_at < '2025-02-01T00:00:00Z'
-group by `segment`
-order by `segment` 
----
-
 [TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
 select
   COALESCE(CAST(`workspace` AS STRING), '') as `segment`, 

--- a/metrics/SegmentWithTimeRange/databricks.snap
+++ b/metrics/SegmentWithTimeRange/databricks.snap
@@ -37,7 +37,7 @@ from db.default.runs
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z' and 
-  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+  (workspace = 'synq-demo' OR 1=1)
 group by `segment`
 order by `segment` 
 ---

--- a/metrics/SegmentWithTimeRange/duckdb.snap
+++ b/metrics/SegmentWithTimeRange/duckdb.snap
@@ -19,3 +19,25 @@ where
 group by segment
 order by segment 
 ---
+
+[TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
+select
+  COALESCE(CAST(workspace AS VARCHAR), '') as segment, 
+  'run_type' as field, 
+  count(*) as num_rows, 
+  count(run_type) as num_not_null, 
+  count(distinct run_type) as num_unique, 
+  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as num_empty, 
+  CAST(avg(run_type) AS FLOAT) as mean, 
+  CAST(min(run_type) AS FLOAT) as min, 
+  CAST(max(run_type) AS FLOAT) as max, 
+  CAST(MEDIAN(run_type) AS FLOAT) as median, 
+  CAST(STDDEV(run_type) AS FLOAT) as stddev
+from default.runs 
+where
+  ingested_at >= '2025-01-01T00:00:00Z' and 
+  ingested_at < '2025-02-01T00:00:00Z' and 
+  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+group by segment
+order by segment 
+---

--- a/metrics/SegmentWithTimeRange/duckdb.snap
+++ b/metrics/SegmentWithTimeRange/duckdb.snap
@@ -37,7 +37,7 @@ from default.runs
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z' and 
-  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+  (workspace = 'synq-demo' OR 1=1)
 group by segment
 order by segment 
 ---

--- a/metrics/SegmentWithTimeRange/duckdb.snap
+++ b/metrics/SegmentWithTimeRange/duckdb.snap
@@ -1,25 +1,3 @@
-
-[TestMetricsSuite/TestSegmentWithTimeRange - 1]
-select
-  COALESCE(CAST(workspace AS VARCHAR), '') as segment, 
-  'run_type' as field, 
-  count(*) as num_rows, 
-  count(run_type) as num_not_null, 
-  count(distinct run_type) as num_unique, 
-  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as num_empty, 
-  CAST(avg(run_type) AS FLOAT) as mean, 
-  CAST(min(run_type) AS FLOAT) as min, 
-  CAST(max(run_type) AS FLOAT) as max, 
-  CAST(MEDIAN(run_type) AS FLOAT) as median, 
-  CAST(STDDEV(run_type) AS FLOAT) as stddev
-from default.runs 
-where
-  ingested_at >= '2025-01-01T00:00:00Z' and 
-  ingested_at < '2025-02-01T00:00:00Z'
-group by segment
-order by segment 
----
-
 [TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
 select
   COALESCE(CAST(workspace AS VARCHAR), '') as segment, 

--- a/metrics/SegmentWithTimeRange/mysql.snap
+++ b/metrics/SegmentWithTimeRange/mysql.snap
@@ -37,7 +37,7 @@ from default.runs
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z' and 
-  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+  (workspace = 'synq-demo' OR 1=1)
 group by COALESCE(CAST(workspace AS CHAR), '')
 order by COALESCE(CAST(workspace AS CHAR), '') 
 ---

--- a/metrics/SegmentWithTimeRange/mysql.snap
+++ b/metrics/SegmentWithTimeRange/mysql.snap
@@ -19,3 +19,25 @@ where
 group by COALESCE(CAST(workspace AS CHAR), '')
 order by COALESCE(CAST(workspace AS CHAR), '') 
 ---
+
+[TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
+select
+  COALESCE(CAST(workspace AS CHAR), '') as segment, 
+  'run_type' as field, 
+  count(*) as num_rows, 
+  count(run_type) as num_not_null, 
+  count(distinct run_type) as num_unique, 
+  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as num_empty, 
+  CAST(avg(run_type) AS FLOAT) as mean, 
+  CAST(min(run_type) AS FLOAT) as min, 
+  CAST(max(run_type) AS FLOAT) as max, 
+  CAST(MEDIAN(run_type) AS FLOAT) as median, 
+  CAST(STDDEV(run_type) AS FLOAT) as stddev
+from default.runs 
+where
+  ingested_at >= '2025-01-01T00:00:00Z' and 
+  ingested_at < '2025-02-01T00:00:00Z' and 
+  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+group by COALESCE(CAST(workspace AS CHAR), '')
+order by COALESCE(CAST(workspace AS CHAR), '') 
+---

--- a/metrics/SegmentWithTimeRange/mysql.snap
+++ b/metrics/SegmentWithTimeRange/mysql.snap
@@ -1,25 +1,3 @@
-
-[TestMetricsSuite/TestSegmentWithTimeRange - 1]
-select
-  COALESCE(CAST(workspace AS CHAR), '') as segment, 
-  'run_type' as field, 
-  count(*) as num_rows, 
-  count(run_type) as num_not_null, 
-  count(distinct run_type) as num_unique, 
-  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as num_empty, 
-  CAST(avg(run_type) AS FLOAT) as mean, 
-  CAST(min(run_type) AS FLOAT) as min, 
-  CAST(max(run_type) AS FLOAT) as max, 
-  CAST(MEDIAN(run_type) AS FLOAT) as median, 
-  CAST(STDDEV(run_type) AS FLOAT) as stddev
-from default.runs 
-where
-  ingested_at >= '2025-01-01T00:00:00Z' and 
-  ingested_at < '2025-02-01T00:00:00Z'
-group by COALESCE(CAST(workspace AS CHAR), '')
-order by COALESCE(CAST(workspace AS CHAR), '') 
----
-
 [TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
 select
   COALESCE(CAST(workspace AS CHAR), '') as segment, 

--- a/metrics/SegmentWithTimeRange/postgres.snap
+++ b/metrics/SegmentWithTimeRange/postgres.snap
@@ -37,7 +37,7 @@ from default.runs
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z' and 
-  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+  (workspace = 'synq-demo' OR 1=1)
 group by COALESCE(CAST(workspace AS VARCHAR), '')
 order by COALESCE(CAST(workspace AS VARCHAR), '') 
 ---

--- a/metrics/SegmentWithTimeRange/postgres.snap
+++ b/metrics/SegmentWithTimeRange/postgres.snap
@@ -19,3 +19,25 @@ where
 group by COALESCE(CAST(workspace AS VARCHAR), '')
 order by COALESCE(CAST(workspace AS VARCHAR), '') 
 ---
+
+[TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
+select
+  COALESCE(CAST(workspace AS VARCHAR), '') as segment, 
+  'run_type' as field, 
+  count(*) as num_rows, 
+  count(run_type) as num_not_null, 
+  count(distinct run_type) as num_unique, 
+  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as num_empty, 
+  CAST(avg(run_type) AS FLOAT) as mean, 
+  CAST(min(run_type) AS FLOAT) as min, 
+  CAST(max(run_type) AS FLOAT) as max, 
+  CAST(MEDIAN(run_type) AS FLOAT) as median, 
+  CAST(STDDEV(run_type) AS FLOAT) as stddev
+from default.runs 
+where
+  ingested_at >= '2025-01-01T00:00:00Z' and 
+  ingested_at < '2025-02-01T00:00:00Z' and 
+  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+group by COALESCE(CAST(workspace AS VARCHAR), '')
+order by COALESCE(CAST(workspace AS VARCHAR), '') 
+---

--- a/metrics/SegmentWithTimeRange/postgres.snap
+++ b/metrics/SegmentWithTimeRange/postgres.snap
@@ -1,25 +1,3 @@
-
-[TestMetricsSuite/TestSegmentWithTimeRange - 1]
-select
-  COALESCE(CAST(workspace AS VARCHAR), '') as segment, 
-  'run_type' as field, 
-  count(*) as num_rows, 
-  count(run_type) as num_not_null, 
-  count(distinct run_type) as num_unique, 
-  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as num_empty, 
-  CAST(avg(run_type) AS FLOAT) as mean, 
-  CAST(min(run_type) AS FLOAT) as min, 
-  CAST(max(run_type) AS FLOAT) as max, 
-  CAST(MEDIAN(run_type) AS FLOAT) as median, 
-  CAST(STDDEV(run_type) AS FLOAT) as stddev
-from default.runs 
-where
-  ingested_at >= '2025-01-01T00:00:00Z' and 
-  ingested_at < '2025-02-01T00:00:00Z'
-group by COALESCE(CAST(workspace AS VARCHAR), '')
-order by COALESCE(CAST(workspace AS VARCHAR), '') 
----
-
 [TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
 select
   COALESCE(CAST(workspace AS VARCHAR), '') as segment, 

--- a/metrics/SegmentWithTimeRange/redshift.snap
+++ b/metrics/SegmentWithTimeRange/redshift.snap
@@ -35,7 +35,7 @@ from "db"."default"."runs"
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z' and 
-  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+  (workspace = 'synq-demo' OR 1=1)
 group by segment
 order by segment 
 ---

--- a/metrics/SegmentWithTimeRange/redshift.snap
+++ b/metrics/SegmentWithTimeRange/redshift.snap
@@ -1,24 +1,3 @@
-
-[TestMetricsSuite/TestSegmentWithTimeRange - 1]
-select
-  COALESCE(CAST(workspace AS VARCHAR), '') as segment, 
-  'run_type' as field, 
-  count(*) as num_rows, 
-  count(run_type) as num_not_null, 
-  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as num_empty, 
-  CAST(avg(run_type) AS FLOAT) as mean, 
-  CAST(min(run_type) AS FLOAT) as min, 
-  CAST(max(run_type) AS FLOAT) as max, 
-  CAST(MEDIAN(run_type) AS FLOAT) as median, 
-  CAST(STDDEV(run_type) AS FLOAT) as stddev
-from "db"."default"."runs" 
-where
-  ingested_at >= '2025-01-01T00:00:00Z' and 
-  ingested_at < '2025-02-01T00:00:00Z'
-group by segment
-order by segment 
----
-
 [TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
 select
   COALESCE(CAST(workspace AS VARCHAR), '') as segment, 

--- a/metrics/SegmentWithTimeRange/redshift.snap
+++ b/metrics/SegmentWithTimeRange/redshift.snap
@@ -18,3 +18,24 @@ where
 group by segment
 order by segment 
 ---
+
+[TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
+select
+  COALESCE(CAST(workspace AS VARCHAR), '') as segment, 
+  'run_type' as field, 
+  count(*) as num_rows, 
+  count(run_type) as num_not_null, 
+  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as num_empty, 
+  CAST(avg(run_type) AS FLOAT) as mean, 
+  CAST(min(run_type) AS FLOAT) as min, 
+  CAST(max(run_type) AS FLOAT) as max, 
+  CAST(MEDIAN(run_type) AS FLOAT) as median, 
+  CAST(STDDEV(run_type) AS FLOAT) as stddev
+from "db"."default"."runs" 
+where
+  ingested_at >= '2025-01-01T00:00:00Z' and 
+  ingested_at < '2025-02-01T00:00:00Z' and 
+  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+group by segment
+order by segment 
+---

--- a/metrics/SegmentWithTimeRange/snowflake.snap
+++ b/metrics/SegmentWithTimeRange/snowflake.snap
@@ -1,25 +1,3 @@
-
-[TestMetricsSuite/TestSegmentWithTimeRange - 1]
-select
-  COALESCE(to_varchar("workspace"), '') as "segment", 
-  'run_type' as "field", 
-  count(*) as "num_rows", 
-  count(run_type) as "num_not_null", 
-  count(distinct run_type) as "num_unique", 
-  count_if(run_type = 0) as "num_empty", 
-  CAST(avg(run_type) AS FLOAT) as "mean", 
-  CAST(min(run_type) AS FLOAT) as "min", 
-  CAST(max(run_type) AS FLOAT) as "max", 
-  CAST(median(run_type) AS FLOAT) as "median", 
-  CAST(stddev(run_type) AS FLOAT) as "stddev"
-from db.default.runs 
-where
-  ingested_at >= '2025-01-01T00:00:00Z' and 
-  ingested_at < '2025-02-01T00:00:00Z'
-group by "segment"
-order by "segment" 
----
-
 [TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
 select
   COALESCE(to_varchar("workspace"), '') as "segment", 

--- a/metrics/SegmentWithTimeRange/snowflake.snap
+++ b/metrics/SegmentWithTimeRange/snowflake.snap
@@ -19,3 +19,25 @@ where
 group by "segment"
 order by "segment" 
 ---
+
+[TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
+select
+  COALESCE(to_varchar("workspace"), '') as "segment", 
+  'run_type' as "field", 
+  count(*) as "num_rows", 
+  count(run_type) as "num_not_null", 
+  count(distinct run_type) as "num_unique", 
+  count_if(run_type = 0) as "num_empty", 
+  CAST(avg(run_type) AS FLOAT) as "mean", 
+  CAST(min(run_type) AS FLOAT) as "min", 
+  CAST(max(run_type) AS FLOAT) as "max", 
+  CAST(median(run_type) AS FLOAT) as "median", 
+  CAST(stddev(run_type) AS FLOAT) as "stddev"
+from db.default.runs 
+where
+  ingested_at >= '2025-01-01T00:00:00Z' and 
+  ingested_at < '2025-02-01T00:00:00Z' and 
+  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+group by "segment"
+order by "segment" 
+---

--- a/metrics/SegmentWithTimeRange/snowflake.snap
+++ b/metrics/SegmentWithTimeRange/snowflake.snap
@@ -37,7 +37,7 @@ from db.default.runs
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z' and 
-  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+  (workspace = 'synq-demo' OR 1=1)
 group by "segment"
 order by "segment" 
 ---

--- a/metrics/SegmentWithTimeRange/trino.snap
+++ b/metrics/SegmentWithTimeRange/trino.snap
@@ -19,3 +19,25 @@ where
 group by COALESCE(CAST(workspace AS VARCHAR), '')
 order by COALESCE(CAST(workspace AS VARCHAR), '') 
 ---
+
+[TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
+select
+  COALESCE(CAST(workspace AS VARCHAR), '') as segment, 
+  'run_type' as field, 
+  count(*) as num_rows, 
+  count(run_type) as num_not_null, 
+  count(distinct run_type) as num_unique, 
+  count_if(run_type = 0) as num_empty, 
+  CAST(avg(run_type) AS DOUBLE) as mean, 
+  CAST(min(run_type) AS DOUBLE) as min, 
+  CAST(max(run_type) AS DOUBLE) as max, 
+  CAST(approx_percentile(run_type, 0.5) AS DOUBLE) as median, 
+  CAST(STDDEV(run_type) AS DOUBLE) as stddev
+from db.default.runs 
+where
+  ingested_at >= from_iso8601_timestamp('2025-01-01T00:00:00Z') and 
+  ingested_at < from_iso8601_timestamp('2025-02-01T00:00:00Z') and 
+  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+group by COALESCE(CAST(workspace AS VARCHAR), '')
+order by COALESCE(CAST(workspace AS VARCHAR), '') 
+---

--- a/metrics/SegmentWithTimeRange/trino.snap
+++ b/metrics/SegmentWithTimeRange/trino.snap
@@ -37,7 +37,7 @@ from db.default.runs
 where
   ingested_at >= from_iso8601_timestamp('2025-01-01T00:00:00Z') and 
   ingested_at < from_iso8601_timestamp('2025-02-01T00:00:00Z') and 
-  (workspace = 'synq-demo' OR workspace = 'synq-demo-2')
+  (workspace = 'synq-demo' OR 1=1)
 group by COALESCE(CAST(workspace AS VARCHAR), '')
 order by COALESCE(CAST(workspace AS VARCHAR), '') 
 ---

--- a/metrics/SegmentWithTimeRange/trino.snap
+++ b/metrics/SegmentWithTimeRange/trino.snap
@@ -1,25 +1,3 @@
-
-[TestMetricsSuite/TestSegmentWithTimeRange - 1]
-select
-  COALESCE(CAST(workspace AS VARCHAR), '') as segment, 
-  'run_type' as field, 
-  count(*) as num_rows, 
-  count(run_type) as num_not_null, 
-  count(distinct run_type) as num_unique, 
-  count_if(run_type = 0) as num_empty, 
-  CAST(avg(run_type) AS DOUBLE) as mean, 
-  CAST(min(run_type) AS DOUBLE) as min, 
-  CAST(max(run_type) AS DOUBLE) as max, 
-  CAST(approx_percentile(run_type, 0.5) AS DOUBLE) as median, 
-  CAST(STDDEV(run_type) AS DOUBLE) as stddev
-from db.default.runs 
-where
-  ingested_at >= from_iso8601_timestamp('2025-01-01T00:00:00Z') and 
-  ingested_at < from_iso8601_timestamp('2025-02-01T00:00:00Z')
-group by COALESCE(CAST(workspace AS VARCHAR), '')
-order by COALESCE(CAST(workspace AS VARCHAR), '') 
----
-
 [TestMetricsSuite/TestSegmentWithTimeRangeWithFilter - 1]
 select
   COALESCE(CAST(workspace AS VARCHAR), '') as segment, 

--- a/metrics/SegmentationRules/bigquery.snap
+++ b/metrics/SegmentationRules/bigquery.snap
@@ -18,7 +18,7 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-where 1=2
+where (1=2)
 group by COALESCE(SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), '')
 order by COALESCE(SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), '') 
 ---

--- a/metrics/SegmentationRules/clickhouse.snap
+++ b/metrics/SegmentationRules/clickhouse.snap
@@ -18,7 +18,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=2
+where (1=2)
 group by segment
 order by segment 
 ---

--- a/metrics/SegmentationRules/databricks.snap
+++ b/metrics/SegmentationRules/databricks.snap
@@ -18,7 +18,7 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-where 1=2
+where (1=2)
 group by `segment`
 order by `segment` 
 ---

--- a/metrics/SegmentationRules/duckdb.snap
+++ b/metrics/SegmentationRules/duckdb.snap
@@ -18,7 +18,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=2
+where (1=2)
 group by segment
 order by segment 
 ---

--- a/metrics/SegmentationRules/mysql.snap
+++ b/metrics/SegmentationRules/mysql.snap
@@ -18,7 +18,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=2
+where (1=2)
 group by COALESCE(SUBSTRING(CAST(workspace AS CHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(workspace AS CHAR), 1, 100), '') 
 ---

--- a/metrics/SegmentationRules/postgres.snap
+++ b/metrics/SegmentationRules/postgres.snap
@@ -18,7 +18,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-where 1=2
+where (1=2)
 group by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') 
 ---

--- a/metrics/SegmentationRules/redshift.snap
+++ b/metrics/SegmentationRules/redshift.snap
@@ -18,7 +18,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-where 1=2
+where (1=2)
 group by segment
 order by segment 
 ---

--- a/metrics/SegmentationRules/snowflake.snap
+++ b/metrics/SegmentationRules/snowflake.snap
@@ -18,7 +18,7 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-where 1=2
+where (1=2)
 group by "segment"
 order by "segment" 
 ---

--- a/metrics/SegmentationRules/trino.snap
+++ b/metrics/SegmentationRules/trino.snap
@@ -18,7 +18,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-where 1=2
+where (1=2)
 group by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') 
 ---

--- a/metrics/SegmentsListQuery/bigquery.snap
+++ b/metrics/SegmentsListQuery/bigquery.snap
@@ -9,7 +9,7 @@ from `db.default.runs`
 where
   timestamp(created_at) >= timestamp '1985-07-16T00:00:00Z' and 
   timestamp(created_at) < timestamp '2025-03-16T00:00:00Z' and 
-  1=1
+  (1=1)
 group by
   SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), 
   SUBSTR(SAFE_CAST(run_status AS STRING), 1, 100), 

--- a/metrics/SegmentsListQuery/clickhouse.snap
+++ b/metrics/SegmentsListQuery/clickhouse.snap
@@ -9,7 +9,7 @@ from default.runs
 where
   created_at >= parseDateTimeBestEffort('1985-07-16 00:00:00') and 
   created_at < parseDateTimeBestEffort('2025-03-16 00:00:00') and 
-  1=1
+  (1=1)
 group by
   segment, 
   segment2, 

--- a/metrics/SegmentsListQuery/databricks.snap
+++ b/metrics/SegmentsListQuery/databricks.snap
@@ -9,7 +9,7 @@ from db.default.runs
 where
   created_at >= '1985-07-16T00:00:00Z' and 
   created_at < '2025-03-16T00:00:00Z' and 
-  1=1
+  (1=1)
 group by
   `segment`, 
   `segment2`, 

--- a/metrics/SegmentsListQuery/duckdb.snap
+++ b/metrics/SegmentsListQuery/duckdb.snap
@@ -9,7 +9,7 @@ from default.runs
 where
   created_at >= '1985-07-16T00:00:00Z' and 
   created_at < '2025-03-16T00:00:00Z' and 
-  1=1
+  (1=1)
 group by
   segment, 
   segment2, 

--- a/metrics/SegmentsListQuery/mysql.snap
+++ b/metrics/SegmentsListQuery/mysql.snap
@@ -9,7 +9,7 @@ from default.runs
 where
   created_at >= '1985-07-16T00:00:00Z' and 
   created_at < '2025-03-16T00:00:00Z' and 
-  1=1
+  (1=1)
 group by
   SUBSTRING(CAST(workspace AS CHAR), 1, 100), 
   SUBSTRING(CAST(run_status AS CHAR), 1, 100), 

--- a/metrics/SegmentsListQuery/postgres.snap
+++ b/metrics/SegmentsListQuery/postgres.snap
@@ -9,7 +9,7 @@ from default.runs
 where
   created_at >= '1985-07-16T00:00:00Z' and 
   created_at < '2025-03-16T00:00:00Z' and 
-  1=1
+  (1=1)
 group by
   SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), 
   SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), 

--- a/metrics/SegmentsListQuery/redshift.snap
+++ b/metrics/SegmentsListQuery/redshift.snap
@@ -9,7 +9,7 @@ from "db"."default"."runs"
 where
   created_at >= '1985-07-16T00:00:00Z' and 
   created_at < '2025-03-16T00:00:00Z' and 
-  1=1
+  (1=1)
 group by
   segment, 
   segment2, 

--- a/metrics/SegmentsListQuery/snowflake.snap
+++ b/metrics/SegmentsListQuery/snowflake.snap
@@ -9,7 +9,7 @@ from db.default.runs
 where
   created_at >= '1985-07-16T00:00:00Z' and 
   created_at < '2025-03-16T00:00:00Z' and 
-  1=1
+  (1=1)
 group by
   "segment", 
   "segment2", 

--- a/metrics/queries_test.go
+++ b/metrics/queries_test.go
@@ -267,7 +267,7 @@ func (s *MetricsSuite) TestPartitionWithTimeRange() {
 	}
 }
 
-func (s *MetricsSuite) TestSegmentWithTimeRange() {
+func (s *MetricsSuite) TestSegmentWithTimeRangeWithFilter() {
 
 	tableFqnExpr := dwhsql.TableFqn("db", "default", "runs")
 
@@ -284,6 +284,7 @@ func (s *MetricsSuite) TestSegmentWithTimeRange() {
 		queryBuilder := querybuilder.NewQueryBuilder(tableFqnExpr, expressions)
 		queryBuilder = queryBuilder.WithSegment(dwhsql.ToString(dwhsql.Identifier("workspace")))
 		queryBuilder = queryBuilder.WithFieldTimeRange(dwhsql.TimeCol(partition.Field), partition.From, partition.To)
+		queryBuilder = queryBuilder.WithFilter(dwhsql.Sql("workspace = 'synq-demo' OR workspace = 'synq-demo-2'"))
 		sql, err := queryBuilder.ToSql(dialect.Dialect)
 		s.Require().NoError(err)
 		s.Require().NotEmpty(sql)

--- a/metrics/queries_test.go
+++ b/metrics/queries_test.go
@@ -284,7 +284,7 @@ func (s *MetricsSuite) TestSegmentWithTimeRangeWithFilter() {
 		queryBuilder := querybuilder.NewQueryBuilder(tableFqnExpr, expressions)
 		queryBuilder = queryBuilder.WithSegment(dwhsql.ToString(dwhsql.Identifier("workspace")))
 		queryBuilder = queryBuilder.WithFieldTimeRange(dwhsql.TimeCol(partition.Field), partition.From, partition.To)
-		queryBuilder = queryBuilder.WithFilter(dwhsql.Sql("workspace = 'synq-demo' OR workspace = 'synq-demo-2'"))
+		queryBuilder = queryBuilder.WithFilter(dwhsql.Sql("workspace = 'synq-demo' OR 1=1"))
 		sql, err := queryBuilder.ToSql(dialect.Dialect)
 		s.Require().NoError(err)
 		s.Require().NotEmpty(sql)

--- a/querybuilder/query_builder.go
+++ b/querybuilder/query_builder.go
@@ -222,7 +222,7 @@ func (b *QueryBuilder) ToSql(dialect Dialect) (string, error) {
 
 	// Apply custom filters
 	if len(b.filters) > 0 {
-		q = q.Where(b.filters...)
+		q = q.Where(AndGroups(b.filters...))
 	}
 
 	return q.ToSql(dialect)

--- a/sqldialect/base.go
+++ b/sqldialect/base.go
@@ -793,3 +793,26 @@ func ToExprSlice[T Expr](expr []T) []Expr {
 func ToExpr[T Expr](expr T) Expr {
 	return expr
 }
+
+// Add after other CondExpr types
+
+type AndGroupsExpr struct {
+	conds []CondExpr
+}
+
+func AndGroups(conds ...CondExpr) *AndGroupsExpr {
+	return &AndGroupsExpr{conds: conds}
+}
+
+func (e *AndGroupsExpr) ToSql(dialect Dialect) (string, error) {
+	if len(e.conds) == 0 {
+		return "", nil
+	}
+	sqls, err := exprsToSql(e.conds, dialect)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("(%s)", strings.Join(sqls, ") and (")), nil
+}
+
+func (e *AndGroupsExpr) IsCondExpr() {}


### PR DESCRIPTION
# Why
The possibility to add to filter code as `dwhsql.Sql("workspace = 'synq-demo' OR 1=1")` can expose unexpected data into result. We want to prevent these situations to surround filters with brackets before join them by `and`.