### PR TITLE
Redshift - aggr column ref as expression.

### DIFF
--- a/metrics/ApplyMonitorDefArgs/redshift.snap
+++ b/metrics/ApplyMonitorDefArgs/redshift.snap
@@ -9,8 +9,8 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 
-group by time_segment
-order by time_segment 
+group by DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at))
+order by DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)) 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_no_conditions_no_segmentation/no_partitioning - 1]
@@ -38,11 +38,11 @@ select
 from "db"."default"."runs" 
 
 group by
-  time_segment, 
-  segment
+  DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by
-  time_segment, 
-  segment 
+  DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_no_conditions_single_segmentation_all/no_partitioning - 1]
@@ -55,8 +55,8 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 
-group by segment
-order by segment 
+group by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
+order by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_no_conditions_multi_segmentation/partitioning - 1]
@@ -72,18 +72,18 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where
-  segment not in ('synq-demo') and 
-  segment_2 in ('1', '2', '3', '4')
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4')
 group by
-  time_segment, 
-  segment, 
-  segment_2, 
-  segment_3
+  DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by
-  time_segment, 
-  segment, 
-  segment_2, 
-  segment_3 
+  DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_no_conditions_multi_segmentation/no_partitioning - 1]
@@ -98,16 +98,16 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where
-  segment not in ('synq-demo') and 
-  segment_2 in ('1', '2', '3', '4')
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4')
 group by
-  segment, 
-  segment_2, 
-  segment_3
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by
-  segment, 
-  segment_2, 
-  segment_3 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_single_condition_no_segmentation/partitioning - 1]
@@ -120,8 +120,8 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where (1=1)
-group by time_segment
-order by time_segment 
+group by DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at))
+order by DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)) 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_single_condition_no_segmentation/no_partitioning - 1]
@@ -149,11 +149,11 @@ select
 from "db"."default"."runs" 
 where (1=1)
 group by
-  time_segment, 
-  segment
+  DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by
-  time_segment, 
-  segment 
+  DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_single_condition_single_segmentation_all/no_partitioning - 1]
@@ -166,8 +166,8 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where (1=1)
-group by segment
-order by segment 
+group by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
+order by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_single_condition_multi_segmentation/partitioning - 1]
@@ -183,19 +183,19 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where
-  segment not in ('synq-demo') and 
-  segment_2 in ('1', '2', '3', '4') and 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4') and 
   (1=1)
 group by
-  time_segment, 
-  segment, 
-  segment_2, 
-  segment_3
+  DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by
-  time_segment, 
-  segment, 
-  segment_2, 
-  segment_3 
+  DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_single_condition_multi_segmentation/no_partitioning - 1]
@@ -210,17 +210,17 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where
-  segment not in ('synq-demo') and 
-  segment_2 in ('1', '2', '3', '4') and 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4') and 
   (1=1)
 group by
-  segment, 
-  segment_2, 
-  segment_3
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by
-  segment, 
-  segment_2, 
-  segment_3 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_multi_condition_no_segmentation/partitioning - 1]
@@ -233,8 +233,8 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where (run_status > 0) and (run_type > 0)
-group by time_segment
-order by time_segment 
+group by DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at))
+order by DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)) 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_multi_condition_no_segmentation/no_partitioning - 1]
@@ -262,11 +262,11 @@ select
 from "db"."default"."runs" 
 where (run_status > 0) and (run_type > 0)
 group by
-  time_segment, 
-  segment
+  DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by
-  time_segment, 
-  segment 
+  DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_multi_condition_single_segmentation_all/no_partitioning - 1]
@@ -279,8 +279,8 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where (run_status > 0) and (run_type > 0)
-group by segment
-order by segment 
+group by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
+order by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_multi_condition_multi_segmentation/partitioning - 1]
@@ -296,19 +296,19 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where
-  segment not in ('synq-demo') and 
-  segment_2 in ('1', '2', '3', '4') and 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4') and 
   (run_status > 0) and (run_type > 0)
 group by
-  time_segment, 
-  segment, 
-  segment_2, 
-  segment_3
+  DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by
-  time_segment, 
-  segment, 
-  segment_2, 
-  segment_3 
+  DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestApplyMonitorDefArgs/redshift_multi_condition_multi_segmentation/no_partitioning - 1]
@@ -323,15 +323,15 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where
-  segment not in ('synq-demo') and 
-  segment_2 in ('1', '2', '3', '4') and 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') not in ('synq-demo') and 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), '') in ('1', '2', '3', '4') and 
   (run_status > 0) and (run_type > 0)
 group by
-  segment, 
-  segment_2, 
-  segment_3
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by
-  segment, 
-  segment_2, 
-  segment_3 
+  COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), ''), 
+  COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---

--- a/metrics/MultiMetricValues/redshift.snap
+++ b/metrics/MultiMetricValues/redshift.snap
@@ -16,9 +16,9 @@ select
 from "db"."default"."runs" 
 
 group by
-  segment, 
-  segment_2
+  COALESCE(workspace, ''), 
+  COALESCE(run_type, '')
 order by
-  segment, 
-  segment_2 
+  COALESCE(workspace, ''), 
+  COALESCE(run_type, '') 
 ---

--- a/metrics/PartitionWithTimeRange/redshift.snap
+++ b/metrics/PartitionWithTimeRange/redshift.snap
@@ -15,6 +15,6 @@ from "db"."default"."runs"
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z'
-group by time_segment
-order by time_segment 
+group by DATEADD(DAY, 1, DATE_TRUNC('DAY', ingested_at))
+order by DATEADD(DAY, 1, DATE_TRUNC('DAY', ingested_at)) 
 ---

--- a/metrics/ProfileColumns/redshift.snap
+++ b/metrics/ProfileColumns/redshift.snap
@@ -58,7 +58,7 @@ select
   max(created_at) as created_at$max
 from "db"."default"."runs" 
 
-group by segment
+group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
 
@@ -93,9 +93,9 @@ select
 from "db"."default"."runs" 
 
 group by
-  segment, 
-  segment2, 
-  segment3
+  SUBSTRING(CAST(workspace AS VARCHAR), 1, 100) as segment, 
+  SUBSTRING(CAST(run_status AS VARCHAR), 1, 100) as segment2, 
+  SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment3
 order by num_rows desc limit 1000
 ---
 
@@ -158,7 +158,7 @@ select
   max(created_at) as created_at$max
 from "db"."default"."runs" 
 where (1=1)
-group by segment
+group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
 
@@ -193,9 +193,9 @@ select
 from "db"."default"."runs" 
 where (1=1)
 group by
-  segment, 
-  segment2, 
-  segment3
+  SUBSTRING(CAST(workspace AS VARCHAR), 1, 100) as segment, 
+  SUBSTRING(CAST(run_status AS VARCHAR), 1, 100) as segment2, 
+  SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment3
 order by num_rows desc limit 1000
 ---
 
@@ -258,7 +258,7 @@ select
   max(created_at) as created_at$max
 from "db"."default"."runs" 
 where (run_status > 0) and (run_type > 0)
-group by segment
+group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
 
@@ -293,8 +293,8 @@ select
 from "db"."default"."runs" 
 where (run_status > 0) and (run_type > 0)
 group by
-  segment, 
-  segment2, 
-  segment3
+  SUBSTRING(CAST(workspace AS VARCHAR), 1, 100) as segment, 
+  SUBSTRING(CAST(run_status AS VARCHAR), 1, 100) as segment2, 
+  SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment3
 order by num_rows desc limit 1000
 ---

--- a/metrics/SegmentWithTimeRange/redshift.snap
+++ b/metrics/SegmentWithTimeRange/redshift.snap
@@ -15,6 +15,6 @@ where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z' and 
   (workspace = 'synq-demo' OR 1=1)
-group by segment
-order by segment 
+group by COALESCE(CAST(workspace AS VARCHAR), '')
+order by COALESCE(CAST(workspace AS VARCHAR), '') 
 ---

--- a/metrics/SegmentationRules/redshift.snap
+++ b/metrics/SegmentationRules/redshift.snap
@@ -7,8 +7,8 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 
-group by segment
-order by segment 
+group by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '')
+order by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestSegmentationRules/redshift_empty_include - 1]
@@ -19,8 +19,8 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where (1=2)
-group by segment
-order by segment 
+group by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '')
+order by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') 
 ---
 
 [TestMetricsSuite/TestSegmentationRules/redshift_allowed_segments - 1]
@@ -30,7 +30,7 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-where segment in ('synq-demo', 'synq-demo-2')
-group by segment
-order by segment 
+where COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') in ('synq-demo', 'synq-demo-2')
+group by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '')
+order by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') 
 ---

--- a/metrics/SegmentsListQuery/redshift.snap
+++ b/metrics/SegmentsListQuery/redshift.snap
@@ -11,8 +11,8 @@ where
   created_at < '2025-03-16T00:00:00Z' and 
   (1=1)
 group by
-  segment, 
-  segment2, 
-  segment3
-order by num_rows desc limit 10
+  SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), 
+  SUBSTRING(CAST(run_status AS VARCHAR), 1, 100), 
+  SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)
+order by count(*) desc limit 10
 ---

--- a/sqldialect/dialect_redshift.go
+++ b/sqldialect/dialect_redshift.go
@@ -84,7 +84,7 @@ func (d *RedshiftDialect) Coalesce(exprs ...Expr) Expr {
 }
 
 func (d *RedshiftDialect) AggregationColumnReference(expression Expr, alias string) Expr {
-	return Identifier(alias)
+	return expression
 }
 
 func (d *RedshiftDialect) SubString(expr Expr, start int64, length int64) Expr {


### PR DESCRIPTION
# Why
For redshift in sql like:
```
select 
  COALESCE(SUBSTRING(CAST(country AS VARCHAR), 1, 150), '') as segment,
  sum(price)
from table
where created_at between 'xxxxx' and 'yyyyy'
group by segment
```
is in some cases is result returned in some it returns `column "table.country" must appear in the GROUP BY clause or be used in an aggregate function`.I have even investigated case when changing `where` time limit expression was either return result or this error. Sometime it works because Redshift doesn’t catch this as an issue in all cases — possibly due to query planning differences, table size, or implicit assumptions (sometimes, Redshift is inconsistent here — it’s picky in some contexts and lenient in others).

To make it works for every case we are using in `group_by` and `order_by` parts the expressions again instead of aliases.