### PR TITLE
Missing logic.

### DIFF
--- a/metrics/ApplyMonitorDefArgs/bigquery.snap
+++ b/metrics/ApplyMonitorDefArgs/bigquery.snap
@@ -8,7 +8,6 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-
 group by TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), HOUR), INTERVAL 1 HOUR)
 order by TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), HOUR), INTERVAL 1 HOUR) 
 ---
@@ -21,8 +20,6 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-
-
  
 ---
 
@@ -36,7 +33,6 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-
 group by
   TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), HOUR), INTERVAL 1 HOUR), 
   COALESCE(SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100), '')
@@ -54,7 +50,6 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-
 group by COALESCE(SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100), '')
 order by COALESCE(SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100), '') 
 ---
@@ -133,7 +128,6 @@ select
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
 where (1=1)
-
  
 ---
 
@@ -246,7 +240,6 @@ select
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
 where (run_status > 0) and (run_type > 0)
-
  
 ---
 

--- a/metrics/ApplyMonitorDefArgs/clickhouse.snap
+++ b/metrics/ApplyMonitorDefArgs/clickhouse.snap
@@ -8,7 +8,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by time_segment
 order by time_segment 
 ---
@@ -21,8 +20,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
-
  
 ---
 
@@ -36,7 +33,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by
   time_segment, 
   segment
@@ -54,7 +50,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by segment
 order by segment 
 ---
@@ -133,7 +128,6 @@ select
   max(ingested_at) as max
 from default.runs 
 where (1=1)
-
  
 ---
 
@@ -246,7 +240,6 @@ select
   max(ingested_at) as max
 from default.runs 
 where (run_status > 0) and (run_type > 0)
-
  
 ---
 

--- a/metrics/ApplyMonitorDefArgs/databricks.snap
+++ b/metrics/ApplyMonitorDefArgs/databricks.snap
@@ -8,7 +8,6 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-
 group by `time_segment`
 order by `time_segment` 
 ---
@@ -21,8 +20,6 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-
-
  
 ---
 
@@ -36,7 +33,6 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-
 group by
   `time_segment`, 
   `segment`
@@ -54,7 +50,6 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-
 group by `segment`
 order by `segment` 
 ---
@@ -133,7 +128,6 @@ select
   max(ingested_at) as `max`
 from db.default.runs 
 where (1=1)
-
  
 ---
 
@@ -246,7 +240,6 @@ select
   max(ingested_at) as `max`
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
-
  
 ---
 

--- a/metrics/ApplyMonitorDefArgs/duckdb.snap
+++ b/metrics/ApplyMonitorDefArgs/duckdb.snap
@@ -8,7 +8,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by time_segment
 order by time_segment 
 ---
@@ -21,8 +20,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
-
  
 ---
 
@@ -36,7 +33,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by
   time_segment, 
   segment
@@ -54,7 +50,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by segment
 order by segment 
 ---
@@ -133,7 +128,6 @@ select
   max(ingested_at) as max
 from default.runs 
 where (1=1)
-
  
 ---
 
@@ -246,7 +240,6 @@ select
   max(ingested_at) as max
 from default.runs 
 where (run_status > 0) and (run_type > 0)
-
  
 ---
 

--- a/metrics/ApplyMonitorDefArgs/mysql.snap
+++ b/metrics/ApplyMonitorDefArgs/mysql.snap
@@ -8,7 +8,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by DATEADD(HOUR, 1, STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d %H:00:00'), '%Y-%m-%d %H:%i:%s'))
 order by DATEADD(HOUR, 1, STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d %H:00:00'), '%Y-%m-%d %H:%i:%s')) 
 ---
@@ -21,8 +20,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
-
  
 ---
 
@@ -36,7 +33,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by
   DATEADD(HOUR, 1, STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d %H:00:00'), '%Y-%m-%d %H:%i:%s')), 
   COALESCE(SUBSTRING(CAST(run_type AS CHAR), 1, 100), '')
@@ -54,7 +50,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by COALESCE(SUBSTRING(CAST(run_type AS CHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(run_type AS CHAR), 1, 100), '') 
 ---
@@ -133,7 +128,6 @@ select
   max(ingested_at) as max
 from default.runs 
 where (1=1)
-
  
 ---
 
@@ -246,7 +240,6 @@ select
   max(ingested_at) as max
 from default.runs 
 where (run_status > 0) and (run_type > 0)
-
  
 ---
 

--- a/metrics/ApplyMonitorDefArgs/postgres.snap
+++ b/metrics/ApplyMonitorDefArgs/postgres.snap
@@ -8,7 +8,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by DATE_TRUNC('HOUR', ingested_at) + '1 HOUR'
 order by DATE_TRUNC('HOUR', ingested_at) + '1 HOUR' 
 ---
@@ -21,8 +20,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
-
  
 ---
 
@@ -36,7 +33,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by
   DATE_TRUNC('HOUR', ingested_at) + '1 HOUR', 
   COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
@@ -54,7 +50,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
@@ -133,7 +128,6 @@ select
   max(ingested_at) as max
 from default.runs 
 where (1=1)
-
  
 ---
 
@@ -246,7 +240,6 @@ select
   max(ingested_at) as max
 from default.runs 
 where (run_status > 0) and (run_type > 0)
-
  
 ---
 

--- a/metrics/ApplyMonitorDefArgs/redshift.snap
+++ b/metrics/ApplyMonitorDefArgs/redshift.snap
@@ -8,7 +8,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-
 group by DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at))
 order by DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)) 
 ---
@@ -21,8 +20,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-
-
  
 ---
 
@@ -36,7 +33,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-
 group by
   DATEADD(HOUR, 1, DATE_TRUNC('HOUR', ingested_at)), 
   COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
@@ -54,7 +50,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-
 group by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
@@ -133,7 +128,6 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where (1=1)
-
  
 ---
 
@@ -246,7 +240,6 @@ select
   max(ingested_at) as max
 from "db"."default"."runs" 
 where (run_status > 0) and (run_type > 0)
-
  
 ---
 

--- a/metrics/ApplyMonitorDefArgs/snowflake.snap
+++ b/metrics/ApplyMonitorDefArgs/snowflake.snap
@@ -8,7 +8,6 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-
 group by "time_segment"
 order by "time_segment" 
 ---
@@ -21,8 +20,6 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-
-
  
 ---
 
@@ -36,7 +33,6 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-
 group by
   "time_segment", 
   "segment"
@@ -54,7 +50,6 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-
 group by "segment"
 order by "segment" 
 ---
@@ -133,7 +128,6 @@ select
   max(ingested_at) as "max"
 from db.default.runs 
 where (1=1)
-
  
 ---
 
@@ -246,7 +240,6 @@ select
   max(ingested_at) as "max"
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
-
  
 ---
 

--- a/metrics/ApplyMonitorDefArgs/trino.snap
+++ b/metrics/ApplyMonitorDefArgs/trino.snap
@@ -8,7 +8,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-
 group by DATE_ADD('HOUR', 1, DATE_TRUNC('HOUR', ingested_at))
 order by DATE_ADD('HOUR', 1, DATE_TRUNC('HOUR', ingested_at)) 
 ---
@@ -21,8 +20,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-
-
  
 ---
 
@@ -36,7 +33,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-
 group by
   DATE_ADD('HOUR', 1, DATE_TRUNC('HOUR', ingested_at)), 
   COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
@@ -54,7 +50,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-
 group by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(run_type AS VARCHAR), 1, 100), '') 
 ---
@@ -133,7 +128,6 @@ select
   max(ingested_at) as max
 from db.default.runs 
 where (1=1)
-
  
 ---
 
@@ -246,7 +240,6 @@ select
   max(ingested_at) as max
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
-
  
 ---
 

--- a/metrics/Filters/bigquery.snap
+++ b/metrics/Filters/bigquery.snap
@@ -3,6 +3,5 @@
 select *
 from `db.default.runs` 
 where (workspace = 'synq-demo') and ((status in ('success', 'failed') or skip = 'true'))
-
  
 ---

--- a/metrics/Filters/clickhouse.snap
+++ b/metrics/Filters/clickhouse.snap
@@ -3,6 +3,5 @@
 select *
 from default.runs 
 where (workspace = 'synq-demo') and ((status in ('success', 'failed') or skip = 'true'))
-
  
 ---

--- a/metrics/Filters/databricks.snap
+++ b/metrics/Filters/databricks.snap
@@ -3,6 +3,5 @@
 select *
 from db.default.runs 
 where (`workspace` = 'synq-demo') and ((`status` in ('success', 'failed') or `skip` = 'true'))
-
  
 ---

--- a/metrics/Filters/duckdb.snap
+++ b/metrics/Filters/duckdb.snap
@@ -3,6 +3,5 @@
 select *
 from default.runs 
 where (workspace = 'synq-demo') and ((status in ('success', 'failed') or skip = 'true'))
-
  
 ---

--- a/metrics/Filters/mysql.snap
+++ b/metrics/Filters/mysql.snap
@@ -3,6 +3,5 @@
 select *
 from default.runs 
 where (workspace = 'synq-demo') and ((status in ('success', 'failed') or skip = 'true'))
-
  
 ---

--- a/metrics/Filters/postgres.snap
+++ b/metrics/Filters/postgres.snap
@@ -3,6 +3,5 @@
 select *
 from default.runs 
 where (workspace = 'synq-demo') and ((status in ('success', 'failed') or skip = 'true'))
-
  
 ---

--- a/metrics/Filters/redshift.snap
+++ b/metrics/Filters/redshift.snap
@@ -3,6 +3,5 @@
 select *
 from "db"."default"."runs" 
 where (workspace = 'synq-demo') and ((status in ('success', 'failed') or skip = 'true'))
-
  
 ---

--- a/metrics/Filters/snowflake.snap
+++ b/metrics/Filters/snowflake.snap
@@ -3,6 +3,5 @@
 select *
 from db.default.runs 
 where ("workspace" = 'synq-demo') and (("status" in ('success', 'failed') or "skip" = 'true'))
-
  
 ---

--- a/metrics/Filters/trino.snap
+++ b/metrics/Filters/trino.snap
@@ -3,6 +3,5 @@
 select *
 from db.default.runs 
 where (workspace = 'synq-demo') and ((status in ('success', 'failed') or skip = 'true'))
-
  
 ---

--- a/metrics/MultiMetricValues/bigquery.snap
+++ b/metrics/MultiMetricValues/bigquery.snap
@@ -15,7 +15,6 @@ select
   CAST(approx_quantiles(run_type, 2)[offset(1)] AS FLOAT64) as run_type$median, 
   CAST(stddev_samp(run_type) AS FLOAT64) as run_type$stddev
 from `db.default.runs` 
-
 group by
   COALESCE(workspace, ''), 
   COALESCE(run_type, '')

--- a/metrics/MultiMetricValues/clickhouse.snap
+++ b/metrics/MultiMetricValues/clickhouse.snap
@@ -15,7 +15,6 @@ select
   toFloat64(median(run_type)) as run_type$median, 
   toFloat64(stddevSamp(run_type)) as run_type$stddev
 from default.runs 
-
 group by
   segment, 
   segment_2

--- a/metrics/MultiMetricValues/databricks.snap
+++ b/metrics/MultiMetricValues/databricks.snap
@@ -15,7 +15,6 @@ select
   CAST(median(run_type) AS FLOAT) as `run_type$median`, 
   CAST(stddev(run_type) AS FLOAT) as `run_type$stddev`
 from db.default.runs 
-
 group by
   `segment`, 
   `segment_2`

--- a/metrics/MultiMetricValues/duckdb.snap
+++ b/metrics/MultiMetricValues/duckdb.snap
@@ -15,7 +15,6 @@ select
   CAST(MEDIAN(run_type) AS FLOAT) as run_type$median, 
   CAST(STDDEV(run_type) AS FLOAT) as run_type$stddev
 from default.runs 
-
 group by
   segment, 
   segment_2

--- a/metrics/MultiMetricValues/mysql.snap
+++ b/metrics/MultiMetricValues/mysql.snap
@@ -15,7 +15,6 @@ select
   CAST(MEDIAN(run_type) AS FLOAT) as run_type$median, 
   CAST(STDDEV(run_type) AS FLOAT) as run_type$stddev
 from default.runs 
-
 group by
   COALESCE(workspace, ''), 
   COALESCE(run_type, '')

--- a/metrics/MultiMetricValues/postgres.snap
+++ b/metrics/MultiMetricValues/postgres.snap
@@ -15,7 +15,6 @@ select
   CAST(MEDIAN(run_type) AS FLOAT) as run_type$median, 
   CAST(STDDEV(run_type) AS FLOAT) as run_type$stddev
 from default.runs 
-
 group by
   COALESCE(workspace, ''), 
   COALESCE(run_type, '')

--- a/metrics/MultiMetricValues/redshift.snap
+++ b/metrics/MultiMetricValues/redshift.snap
@@ -14,7 +14,6 @@ select
   CAST(MEDIAN(run_type) AS FLOAT) as run_type$median, 
   CAST(STDDEV(run_type) AS FLOAT) as run_type$stddev
 from "db"."default"."runs" 
-
 group by
   COALESCE(workspace, ''), 
   COALESCE(run_type, '')

--- a/metrics/MultiMetricValues/snowflake.snap
+++ b/metrics/MultiMetricValues/snowflake.snap
@@ -15,7 +15,6 @@ select
   CAST(median(run_type) AS FLOAT) as "run_type$median", 
   CAST(stddev(run_type) AS FLOAT) as "run_type$stddev"
 from db.default.runs 
-
 group by
   "segment", 
   "segment_2"

--- a/metrics/MultiMetricValues/trino.snap
+++ b/metrics/MultiMetricValues/trino.snap
@@ -15,7 +15,6 @@ select
   CAST(approx_percentile(run_type, 0.5) AS DOUBLE) as run_type$median, 
   CAST(STDDEV(run_type) AS DOUBLE) as run_type$stddev
 from db.default.runs 
-
 group by
   COALESCE(workspace, ''), 
   COALESCE(run_type, '')

--- a/metrics/Partition/bigquery.snap
+++ b/metrics/Partition/bigquery.snap
@@ -10,6 +10,5 @@ from `db.default.runs`
 where
   timestamp(ingested_at) >= timestamp '2025-01-01T00:00:00Z' and 
   timestamp(ingested_at) < timestamp '2025-02-01T00:00:00Z'
-
  
 ---

--- a/metrics/Partition/clickhouse.snap
+++ b/metrics/Partition/clickhouse.snap
@@ -10,6 +10,5 @@ from default.runs
 where
   ingested_at >= parseDateTimeBestEffort('2025-01-01 00:00:00') and 
   ingested_at < parseDateTimeBestEffort('2025-02-01 00:00:00')
-
  
 ---

--- a/metrics/Partition/databricks.snap
+++ b/metrics/Partition/databricks.snap
@@ -10,6 +10,5 @@ from db.default.runs
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z'
-
  
 ---

--- a/metrics/Partition/duckdb.snap
+++ b/metrics/Partition/duckdb.snap
@@ -10,6 +10,5 @@ from default.runs
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z'
-
  
 ---

--- a/metrics/Partition/mysql.snap
+++ b/metrics/Partition/mysql.snap
@@ -10,6 +10,5 @@ from default.runs
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z'
-
  
 ---

--- a/metrics/Partition/postgres.snap
+++ b/metrics/Partition/postgres.snap
@@ -10,6 +10,5 @@ from default.runs
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z'
-
  
 ---

--- a/metrics/Partition/redshift.snap
+++ b/metrics/Partition/redshift.snap
@@ -10,6 +10,5 @@ from "db"."default"."runs"
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z'
-
  
 ---

--- a/metrics/Partition/snowflake.snap
+++ b/metrics/Partition/snowflake.snap
@@ -10,6 +10,5 @@ from db.default.runs
 where
   ingested_at >= '2025-01-01T00:00:00Z' and 
   ingested_at < '2025-02-01T00:00:00Z'
-
  
 ---

--- a/metrics/Partition/trino.snap
+++ b/metrics/Partition/trino.snap
@@ -10,6 +10,5 @@ from db.default.runs
 where
   ingested_at >= from_iso8601_timestamp('2025-01-01T00:00:00Z') and 
   ingested_at < from_iso8601_timestamp('2025-02-01T00:00:00Z')
-
  
 ---

--- a/metrics/ProfileColumns/bigquery.snap
+++ b/metrics/ProfileColumns/bigquery.snap
@@ -26,8 +26,6 @@ select
   min(timestamp(created_at)) as created_at$min, 
   max(timestamp(created_at)) as created_at$max
 from `db.default.runs` 
-
-
 order by num_rows desc limit 1000
 ---
 
@@ -59,7 +57,6 @@ select
   min(timestamp(created_at)) as created_at$min, 
   max(timestamp(created_at)) as created_at$max
 from `db.default.runs` 
-
 group by SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -94,7 +91,6 @@ select
   min(timestamp(created_at)) as created_at$min, 
   max(timestamp(created_at)) as created_at$max
 from `db.default.runs` 
-
 group by
   SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100) as segment, 
   SUBSTR(SAFE_CAST(run_status AS STRING), 1, 100) as segment2, 
@@ -130,7 +126,6 @@ select
   max(timestamp(created_at)) as created_at$max
 from `db.default.runs` 
 where (1=1)
-
 order by num_rows desc limit 1000
 ---
 
@@ -233,7 +228,6 @@ select
   max(timestamp(created_at)) as created_at$max
 from `db.default.runs` 
 where (run_status > 0) and (run_type > 0)
-
 order by num_rows desc limit 1000
 ---
 

--- a/metrics/ProfileColumns/clickhouse.snap
+++ b/metrics/ProfileColumns/clickhouse.snap
@@ -26,8 +26,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-
-
 order by num_rows desc limit 1000
 ---
 
@@ -59,7 +57,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-
 group by segment
 order by num_rows desc limit 1000
 ---
@@ -94,7 +91,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-
 group by
   segment, 
   segment2, 
@@ -130,7 +126,6 @@ select
   max(created_at) as created_at$max
 from default.runs 
 where (1=1)
-
 order by num_rows desc limit 1000
 ---
 
@@ -233,7 +228,6 @@ select
   max(created_at) as created_at$max
 from default.runs 
 where (run_status > 0) and (run_type > 0)
-
 order by num_rows desc limit 1000
 ---
 

--- a/metrics/ProfileColumns/databricks.snap
+++ b/metrics/ProfileColumns/databricks.snap
@@ -26,8 +26,6 @@ select
   min(created_at) as `created_at$min`, 
   max(created_at) as `created_at$max`
 from db.default.runs 
-
-
 order by `num_rows` desc limit 1000
 ---
 
@@ -59,7 +57,6 @@ select
   min(created_at) as `created_at$min`, 
   max(created_at) as `created_at$max`
 from db.default.runs 
-
 group by `segment`
 order by `num_rows` desc limit 1000
 ---
@@ -94,7 +91,6 @@ select
   min(created_at) as `created_at$min`, 
   max(created_at) as `created_at$max`
 from db.default.runs 
-
 group by
   `segment`, 
   `segment2`, 
@@ -130,7 +126,6 @@ select
   max(created_at) as `created_at$max`
 from db.default.runs 
 where (1=1)
-
 order by `num_rows` desc limit 1000
 ---
 
@@ -233,7 +228,6 @@ select
   max(created_at) as `created_at$max`
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
-
 order by `num_rows` desc limit 1000
 ---
 

--- a/metrics/ProfileColumns/duckdb.snap
+++ b/metrics/ProfileColumns/duckdb.snap
@@ -26,8 +26,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-
-
 order by num_rows desc limit 1000
 ---
 
@@ -59,7 +57,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-
 group by segment
 order by num_rows desc limit 1000
 ---
@@ -94,7 +91,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-
 group by
   segment, 
   segment2, 
@@ -130,7 +126,6 @@ select
   max(created_at) as created_at$max
 from default.runs 
 where (1=1)
-
 order by num_rows desc limit 1000
 ---
 
@@ -233,7 +228,6 @@ select
   max(created_at) as created_at$max
 from default.runs 
 where (run_status > 0) and (run_type > 0)
-
 order by num_rows desc limit 1000
 ---
 

--- a/metrics/ProfileColumns/mysql.snap
+++ b/metrics/ProfileColumns/mysql.snap
@@ -26,8 +26,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-
-
 order by num_rows desc limit 1000
 ---
 
@@ -59,7 +57,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-
 group by SUBSTRING(CAST(run_type AS CHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -94,7 +91,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-
 group by
   SUBSTRING(CAST(workspace AS CHAR), 1, 100) as segment, 
   SUBSTRING(CAST(run_status AS CHAR), 1, 100) as segment2, 
@@ -130,7 +126,6 @@ select
   max(created_at) as created_at$max
 from default.runs 
 where (1=1)
-
 order by num_rows desc limit 1000
 ---
 
@@ -233,7 +228,6 @@ select
   max(created_at) as created_at$max
 from default.runs 
 where (run_status > 0) and (run_type > 0)
-
 order by num_rows desc limit 1000
 ---
 

--- a/metrics/ProfileColumns/postgres.snap
+++ b/metrics/ProfileColumns/postgres.snap
@@ -26,8 +26,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-
-
 order by num_rows desc limit 1000
 ---
 
@@ -59,7 +57,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -94,7 +91,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from default.runs 
-
 group by
   SUBSTRING(CAST(workspace AS VARCHAR), 1, 100) as segment, 
   SUBSTRING(CAST(run_status AS VARCHAR), 1, 100) as segment2, 
@@ -130,7 +126,6 @@ select
   max(created_at) as created_at$max
 from default.runs 
 where (1=1)
-
 order by num_rows desc limit 1000
 ---
 
@@ -233,7 +228,6 @@ select
   max(created_at) as created_at$max
 from default.runs 
 where (run_status > 0) and (run_type > 0)
-
 order by num_rows desc limit 1000
 ---
 

--- a/metrics/ProfileColumns/redshift.snap
+++ b/metrics/ProfileColumns/redshift.snap
@@ -25,8 +25,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from "db"."default"."runs" 
-
-
 order by num_rows desc limit 1000
 ---
 
@@ -57,7 +55,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from "db"."default"."runs" 
-
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -91,7 +88,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from "db"."default"."runs" 
-
 group by
   SUBSTRING(CAST(workspace AS VARCHAR), 1, 100) as segment, 
   SUBSTRING(CAST(run_status AS VARCHAR), 1, 100) as segment2, 
@@ -126,7 +122,6 @@ select
   max(created_at) as created_at$max
 from "db"."default"."runs" 
 where (1=1)
-
 order by num_rows desc limit 1000
 ---
 
@@ -226,7 +221,6 @@ select
   max(created_at) as created_at$max
 from "db"."default"."runs" 
 where (run_status > 0) and (run_type > 0)
-
 order by num_rows desc limit 1000
 ---
 

--- a/metrics/ProfileColumns/snowflake.snap
+++ b/metrics/ProfileColumns/snowflake.snap
@@ -26,8 +26,6 @@ select
   min(created_at) as "created_at$min", 
   max(created_at) as "created_at$max"
 from db.default.runs 
-
-
 order by "num_rows" desc limit 1000
 ---
 
@@ -59,7 +57,6 @@ select
   min(created_at) as "created_at$min", 
   max(created_at) as "created_at$max"
 from db.default.runs 
-
 group by "segment"
 order by "num_rows" desc limit 1000
 ---
@@ -94,7 +91,6 @@ select
   min(created_at) as "created_at$min", 
   max(created_at) as "created_at$max"
 from db.default.runs 
-
 group by
   "segment", 
   "segment2", 
@@ -130,7 +126,6 @@ select
   max(created_at) as "created_at$max"
 from db.default.runs 
 where (1=1)
-
 order by "num_rows" desc limit 1000
 ---
 
@@ -233,7 +228,6 @@ select
   max(created_at) as "created_at$max"
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
-
 order by "num_rows" desc limit 1000
 ---
 

--- a/metrics/ProfileColumns/trino.snap
+++ b/metrics/ProfileColumns/trino.snap
@@ -26,8 +26,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from db.default.runs 
-
-
 order by num_rows desc limit 1000
 ---
 
@@ -59,7 +57,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from db.default.runs 
-
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100) as segment
 order by num_rows desc limit 1000
 ---
@@ -94,7 +91,6 @@ select
   min(created_at) as created_at$min, 
   max(created_at) as created_at$max
 from db.default.runs 
-
 group by
   SUBSTRING(CAST(workspace AS VARCHAR), 1, 100) as segment, 
   SUBSTRING(CAST(run_status AS VARCHAR), 1, 100) as segment2, 
@@ -130,7 +126,6 @@ select
   max(created_at) as created_at$max
 from db.default.runs 
 where (1=1)
-
 order by num_rows desc limit 1000
 ---
 
@@ -233,7 +228,6 @@ select
   max(created_at) as created_at$max
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
-
 order by num_rows desc limit 1000
 ---
 

--- a/metrics/SegmentationRules/bigquery.snap
+++ b/metrics/SegmentationRules/bigquery.snap
@@ -6,7 +6,6 @@ select
   min(timestamp(ingested_at)) as min, 
   max(timestamp(ingested_at)) as max
 from `db.default.runs` 
-
 group by COALESCE(SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), '')
 order by COALESCE(SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), '') 
 ---

--- a/metrics/SegmentationRules/clickhouse.snap
+++ b/metrics/SegmentationRules/clickhouse.snap
@@ -6,7 +6,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by segment
 order by segment 
 ---

--- a/metrics/SegmentationRules/databricks.snap
+++ b/metrics/SegmentationRules/databricks.snap
@@ -6,7 +6,6 @@ select
   min(ingested_at) as `min`, 
   max(ingested_at) as `max`
 from db.default.runs 
-
 group by `segment`
 order by `segment` 
 ---

--- a/metrics/SegmentationRules/duckdb.snap
+++ b/metrics/SegmentationRules/duckdb.snap
@@ -6,7 +6,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by segment
 order by segment 
 ---

--- a/metrics/SegmentationRules/mysql.snap
+++ b/metrics/SegmentationRules/mysql.snap
@@ -6,7 +6,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by COALESCE(SUBSTRING(CAST(workspace AS CHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(workspace AS CHAR), 1, 100), '') 
 ---

--- a/metrics/SegmentationRules/postgres.snap
+++ b/metrics/SegmentationRules/postgres.snap
@@ -6,7 +6,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from default.runs 
-
 group by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') 
 ---

--- a/metrics/SegmentationRules/redshift.snap
+++ b/metrics/SegmentationRules/redshift.snap
@@ -6,7 +6,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from "db"."default"."runs" 
-
 group by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') 
 ---

--- a/metrics/SegmentationRules/snowflake.snap
+++ b/metrics/SegmentationRules/snowflake.snap
@@ -6,7 +6,6 @@ select
   min(ingested_at) as "min", 
   max(ingested_at) as "max"
 from db.default.runs 
-
 group by "segment"
 order by "segment" 
 ---

--- a/metrics/SegmentationRules/trino.snap
+++ b/metrics/SegmentationRules/trino.snap
@@ -6,7 +6,6 @@ select
   min(ingested_at) as min, 
   max(ingested_at) as max
 from db.default.runs 
-
 group by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '')
 order by COALESCE(SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), '') 
 ---

--- a/metrics/SimpleQueryBuilder/bigquery.snap
+++ b/metrics/SimpleQueryBuilder/bigquery.snap
@@ -7,7 +7,5 @@ select
   count(distinct workspace) as num_unique, 
   countif(workspace = '') as num_empty
 from `db.default.runs` 
-
-
  
 ---

--- a/metrics/SimpleQueryBuilder/clickhouse.snap
+++ b/metrics/SimpleQueryBuilder/clickhouse.snap
@@ -7,7 +7,5 @@ select
   toInt64(count(distinct workspace)) as num_unique, 
   toInt64(countIf(workspace = '')) as num_empty
 from default.runs 
-
-
  
 ---

--- a/metrics/SimpleQueryBuilder/databricks.snap
+++ b/metrics/SimpleQueryBuilder/databricks.snap
@@ -7,7 +7,5 @@ select
   count(distinct workspace) as `num_unique`, 
   count_if(workspace = '') as `num_empty`
 from db.default.runs 
-
-
  
 ---

--- a/metrics/SimpleQueryBuilder/duckdb.snap
+++ b/metrics/SimpleQueryBuilder/duckdb.snap
@@ -7,7 +7,5 @@ select
   count(distinct workspace) as num_unique, 
   SUM(CASE WHEN workspace = '' THEN 1 ELSE 0 END) as num_empty
 from default.runs 
-
-
  
 ---

--- a/metrics/SimpleQueryBuilder/mysql.snap
+++ b/metrics/SimpleQueryBuilder/mysql.snap
@@ -7,7 +7,5 @@ select
   count(distinct workspace) as num_unique, 
   SUM(CASE WHEN workspace = '' THEN 1 ELSE 0 END) as num_empty
 from default.runs 
-
-
  
 ---

--- a/metrics/SimpleQueryBuilder/postgres.snap
+++ b/metrics/SimpleQueryBuilder/postgres.snap
@@ -7,7 +7,5 @@ select
   count(distinct workspace) as num_unique, 
   SUM(CASE WHEN workspace = '' THEN 1 ELSE 0 END) as num_empty
 from default.runs 
-
-
  
 ---

--- a/metrics/SimpleQueryBuilder/redshift.snap
+++ b/metrics/SimpleQueryBuilder/redshift.snap
@@ -7,7 +7,5 @@ select
   count(distinct workspace) as num_unique, 
   SUM(CASE WHEN workspace = '' THEN 1 ELSE 0 END) as num_empty
 from "db"."default"."runs" 
-
-
  
 ---

--- a/metrics/SimpleQueryBuilder/snowflake.snap
+++ b/metrics/SimpleQueryBuilder/snowflake.snap
@@ -7,7 +7,5 @@ select
   count(distinct workspace) as "num_unique", 
   count_if(workspace = '') as "num_empty"
 from db.default.runs 
-
-
  
 ---

--- a/metrics/SimpleQueryBuilder/trino.snap
+++ b/metrics/SimpleQueryBuilder/trino.snap
@@ -7,7 +7,5 @@ select
   count(distinct workspace) as num_unique, 
   count_if(workspace = '') as num_empty
 from db.default.runs 
-
-
  
 ---

--- a/sqldialect/__snapshots__/base_test.snap
+++ b/sqldialect/__snapshots__/base_test.snap
@@ -1,0 +1,9 @@
+
+[TestBaseSuite/TestCte - 1]
+with cte AS (select *
+from default.users 
+order by created_at desc limit 10)
+select *
+from cte 
+ 
+---

--- a/sqldialect/base.go
+++ b/sqldialect/base.go
@@ -725,31 +725,22 @@ func (e *DistinctExpr) ToSql(dialect Dialect) (string, error) {
 
 // var _ Expr = (*TrimExpr)(nil)
 
-type TrimType string
-
-const (
-	TrimTypeBoth  TrimType = "BOTH"
-	TrimTypeLeft  TrimType = "LEADING"
-	TrimTypeRight TrimType = "TRAILING"
-)
-
 type TrimExpr struct {
-	from     Expr
-	chars    *StringLitExpr
-	trimType TrimType
+	expr Expr
 }
 
-func Trim(from Expr, chars string, trimType TrimType) *TrimExpr {
-	expr := &TrimExpr{from: from, trimType: trimType}
-	if chars != "" {
-		expr.chars = String(chars)
+func Trim(expr Expr) *TrimExpr {
+	return &TrimExpr{expr: expr}
+}
+
+func (e *TrimExpr) ToSql(dialect Dialect) (string, error) {
+	exprSql, err := e.expr.ToSql(dialect)
+	if err != nil {
+		return "", err
 	}
-	return expr
-}
 
-// func (e *TrimExpr) ToSql(dialect Dialect) (string, error) {
-// 	return dialect.Trim(e.from, e.chars, e.trimType).ToSql(dialect)
-// }
+	return fmt.Sprintf("trim(%s)", exprSql), nil
+}
 
 //
 // CoalesceExpr

--- a/sqldialect/base_test.go
+++ b/sqldialect/base_test.go
@@ -1,0 +1,30 @@
+package sqldialect
+
+import (
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/suite"
+)
+
+type BaseSuite struct {
+	suite.Suite
+}
+
+func TestBaseSuite(t *testing.T) {
+	suite.Run(t, new(BaseSuite))
+}
+
+func (s *BaseSuite) TestCte() {
+	dialect := NewPostgresDialect()
+	cteSelect := NewSelect().Cols(Star()).
+		From(TableFqn("proj", "default", "users")).
+		OrderBy(Desc(Identifier("created_at"))).
+		WithLimit(Limit(Int64(10)))
+	cteFqn := CteFqn("cte")
+
+	cte := NewSelect().Cte(cteFqn, cteSelect).From(cteFqn).Cols(Star())
+	sql, err := cte.ToSql(dialect)
+	s.Require().NoError(err)
+	snaps.MatchSnapshot(s.T(), sql)
+}

--- a/sqldialect/cond.go
+++ b/sqldialect/cond.go
@@ -12,11 +12,13 @@ import (
 type CompareFn string
 
 const (
-	COMPARE_EQ  CompareFn = "="
-	COMPARE_LT  CompareFn = "<"
-	COMPARE_GT  CompareFn = ">"
-	COMPARE_LTE CompareFn = "<="
-	COMPARE_GTE CompareFn = ">="
+	COMPARE_EQ     CompareFn = "="
+	COMPARE_LT     CompareFn = "<"
+	COMPARE_GT     CompareFn = ">"
+	COMPARE_LTE    CompareFn = "<="
+	COMPARE_GTE    CompareFn = ">="
+	COMPARE_IS     CompareFn = "is"
+	COMPARE_IS_NOT CompareFn = "is not"
 )
 
 type CompareExpr struct {
@@ -170,6 +172,14 @@ func Gte(a, b Expr) *CompareExpr {
 
 func Lte(a, b Expr) *CompareExpr {
 	return compare(a, COMPARE_LTE, b)
+}
+
+func IsNull(a Expr) *CompareExpr {
+	return compare(a, COMPARE_IS, Null())
+}
+
+func IsNotNull(a Expr) *CompareExpr {
+	return compare(a, COMPARE_IS_NOT, Null())
 }
 
 type OrExpr struct {


### PR DESCRIPTION
# Why
Implement some missing logic for base sql dialect. These are:
- having
- CTE
- basic TRIM (remove empty spaces on both sides) w/o support of left,right and specified chars. Once it will be required we implement it and delegate to specific dialect as it is then different based on dialect.
- is null, is not null
- allow distinct to get more than one expr (cols)

**This PR is also removing empty lines from final sql expression string.**