### PR TITLE
Handle timeout errors.

### DIFF
--- a/exec/stdsql/helpers.go
+++ b/exec/stdsql/helpers.go
@@ -132,6 +132,10 @@ func QueryMaps(ctx context.Context, conn *sqlx.DB, sql string) ([]exec.QueryMapR
 		results = append(results, result)
 	}
 
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
 	return results, nil
 }
 


### PR DESCRIPTION
# Why
We didn't check error after calling `rows.Next() -> bool` function. If there is some error during iteration eg. timeout we want to return this dwh error and NOT empty result with no error.

### NOTE
`QueryAndProcessMany` have this error handling already implemented. These 2 places are just missed.