### PR TITLE
Disable Trino table comment retrieval and Trino MV support for now

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getsynq/dwhsupport
 
-go 1.23
+go 1.24.5
 
 require (
 	buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.6-20250516112206-28f4ae7297f9.1

--- a/scrapper/trino/query_catalog.sql
+++ b/scrapper/trino/query_catalog.sql
@@ -6,14 +6,10 @@ SELECT
     c.ordinal_position as position,
     c.data_type as type,
     c.comment as comment,
-    tc.comment as table_comment
+    '' as table_comment
 FROM {{catalog}}.information_schema.tables t
 JOIN {{catalog}}.information_schema.columns c
   ON t.table_catalog = c.table_catalog
   AND t.table_schema = c.table_schema
   AND t.table_name = c.table_name
-LEFT JOIN system.metadata.table_comments tc
-  ON t.table_catalog = tc.catalog_name
-  AND t.table_schema = tc.schema_name
-  AND t.table_name = tc.table_name
 WHERE t.table_schema NOT IN ('information_schema')

--- a/scrapper/trino/query_sql_definitions.sql
+++ b/scrapper/trino/query_sql_definitions.sql
@@ -12,13 +12,8 @@ select
     t.schema,
     t.table_name as "table",
     (t.table_type = 'VIEW' AND v.view_definition IS NOT NULL) as is_view,
-    mv.name is not null as is_materialized_view,
-    coalesce(mv.definition, v.view_definition, '') as sql
+    coalesce(v.view_definition, '') as sql
 from tables t
 left join {{catalog}}.information_schema.views v
     on t.schema = v.table_schema and t.table_name = v.table_name
-LEFT JOIN system.metadata.materialized_views mv
-    ON t.database = mv.catalog_name
-    AND t.schema = mv.schema_name
-    AND t.table_name = mv.name
 order by t.database, t.schema, t.table_name 

--- a/scrapper/trino/query_table_metrics.go
+++ b/scrapper/trino/query_table_metrics.go
@@ -56,6 +56,12 @@ func (e *TrinoScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFetchT
 				continue
 			}
 
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+
 			tableMetricsRow := &scrapper.TableMetricsRow{
 				Instance: t.Instance,
 				Database: t.Database,

--- a/scrapper/trino/query_tables.sql
+++ b/scrapper/trino/query_tables.sql
@@ -2,18 +2,9 @@ SELECT
     t.table_catalog as database,
     t.table_schema as schema,
     t.table_name as "table",
-    (case WHEN mv.name IS NOT NULL THEN 'MATERIALIZED VIEW'
-    ELSE t.table_type END) AS "table_type",
-    c.comment as description,
-    mv.name is null AND t.table_type = 'BASE TABLE' as is_table,
-    mv.name is not null OR t.table_type = 'VIEW'  as is_view
+    t.table_type AS "table_type",
+    '' as description,
+    t.table_type = 'BASE TABLE' as is_table,
+    t.table_type = 'VIEW'  as is_view
 FROM {{catalog}}.information_schema.tables t
-LEFT JOIN system.metadata.table_comments c
-  ON t.table_catalog = c.catalog_name
-  AND t.table_schema = c.schema_name
-  AND t.table_name = c.table_name
-LEFT JOIN system.metadata.materialized_views mv
-  ON t.table_catalog = mv.catalog_name
-    AND t.table_schema = mv.schema_name
-    AND t.table_name = mv.name
 WHERE t.table_schema NOT IN ('information_schema')


### PR DESCRIPTION
In some environments, it causes crashes when in a loop as it tries to verify row-level permissions to system tables.