### PR TITLE
Metrics with snapshotted_at.

### DIFF
--- a/metrics/types.go
+++ b/metrics/types.go
@@ -16,6 +16,7 @@ type MetricVal[T MetricType] struct {
 	MetricId             MetricId
 	At                   time.Time
 	IngestedAt           time.Time
+	SnapshottedAt        time.Time
 	Value                T
 	MetricsVersion       int32
 	IsAnomaly            bool


### PR DESCRIPTION
# Why
Lets add `snapsthottedAt` information on metric. It is different from `At (metric timestamp)` and `IngestedAt (when saved)` as this is when it was loaded from DWH. We want to be able to work also with this information (display to client, propagate to prediction, ...)