### PR TITLE
chore: apply gofmt formatting across codebase

### DIFF
--- a/exec/bigquery/query.go
+++ b/exec/bigquery/query.go
@@ -88,7 +88,12 @@ func (q *Querier[T]) QueryMany(
 	return results, nil
 }
 
-func (q *Querier[T]) QueryAndProcessMany(ctx context.Context, sql string, handler func(ctx context.Context, batch []*T) error, opts ...exec.QueryManyOpt[T]) error {
+func (q *Querier[T]) QueryAndProcessMany(
+	ctx context.Context,
+	sql string,
+	handler func(ctx context.Context, batch []*T) error,
+	opts ...exec.QueryManyOpt[T],
+) error {
 	qq := exec.NewQueryMany[T](sql)
 	for _, opt := range opts {
 		opt(qq)

--- a/exec/clickhouse/clickhouse_test.go
+++ b/exec/clickhouse/clickhouse_test.go
@@ -42,7 +42,11 @@ func (s *ClickhouseSuite) TestSomething() {
 	defer execer.Close()
 
 	q := NewQuerier[res](execer)
-	res, err := q.QueryMany(ctx, "SELECT table_catalog, table_schema, table_name, table_type FROM information_schema.tables WHERE table_catalog = ?", exec.WithArgs[res]("system"))
+	res, err := q.QueryMany(
+		ctx,
+		"SELECT table_catalog, table_schema, table_name, table_type FROM information_schema.tables WHERE table_catalog = ?",
+		exec.WithArgs[res]("system"),
+	)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(res)
 

--- a/exec/stdsql/helpers.go
+++ b/exec/stdsql/helpers.go
@@ -7,7 +7,13 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-func QueryAndProcessMany[T any](ctx context.Context, conn *sqlx.DB, sql string, handler func(ctx context.Context, rows []*T) error, opts ...exec.QueryManyOpt[T]) error {
+func QueryAndProcessMany[T any](
+	ctx context.Context,
+	conn *sqlx.DB,
+	sql string,
+	handler func(ctx context.Context, rows []*T) error,
+	opts ...exec.QueryManyOpt[T],
+) error {
 
 	queryMany := exec.NewQueryMany[T](sql)
 	for _, opt := range opts {

--- a/metrics/extractor_test.go
+++ b/metrics/extractor_test.go
@@ -70,7 +70,13 @@ func (s *MetricExtractorSuite) TestExtractGrowthsFromMetricSeries() {
 	})
 }
 
-func createMetrics(val int64, lastLoaded time.Time, at time.Time, valSeries []*MetricVal[int64], loadSeries []*MetricVal[time.Time]) ([]*MetricVal[int64], []*MetricVal[time.Time]) {
+func createMetrics(
+	val int64,
+	lastLoaded time.Time,
+	at time.Time,
+	valSeries []*MetricVal[int64],
+	loadSeries []*MetricVal[time.Time],
+) ([]*MetricVal[int64], []*MetricVal[time.Time]) {
 	valSeries = append(valSeries, &MetricVal[int64]{Value: val, At: at})
 	loadSeries = append(loadSeries, &MetricVal[time.Time]{Value: lastLoaded, At: at})
 

--- a/scrapper/bigquery/bigquery.go
+++ b/scrapper/bigquery/bigquery.go
@@ -103,7 +103,11 @@ func (e *BigQueryScrapper) queryRows(ctx context.Context, q string, args ...inte
 }
 
 func (e *BigQueryScrapper) ValidateConfiguration(ctx context.Context) ([]string, error) {
-	crm, err := cloudresourcemanager.NewService(ctx, option.WithCredentialsJSON([]byte(e.conf.CredentialsJson)), option.WithUserAgent("synq-bq-client-v1.0.0"))
+	crm, err := cloudresourcemanager.NewService(
+		ctx,
+		option.WithCredentialsJSON([]byte(e.conf.CredentialsJson)),
+		option.WithUserAgent("synq-bq-client-v1.0.0"),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +125,13 @@ func (e *BigQueryScrapper) ValidateConfiguration(ctx context.Context) ([]string,
 		missingPermissions, _ := lo.Difference(expectedPermissions, gotPermissions)
 		if len(missingPermissions) > 0 {
 			logging.GetLogger(ctx).WithField("missing_permissions", missingPermissions).Info("missing BigQuery permissions")
-			warnings = append(warnings, fmt.Sprintf("Some permissions are missing, this might cause not all features to work properly: %s", strings.Join(missingPermissions, ", ")))
+			warnings = append(
+				warnings,
+				fmt.Sprintf(
+					"Some permissions are missing, this might cause not all features to work properly: %s",
+					strings.Join(missingPermissions, ", "),
+				),
+			)
 		}
 	} else {
 		logging.GetLogger(ctx).WithError(err).Error("failed to test BigQuery permissions")

--- a/scrapper/bigquery/query.go
+++ b/scrapper/bigquery/query.go
@@ -38,7 +38,13 @@ func QueryMany[T any](ctx context.Context, conn Executor, sql string, opts ...dw
 	return results, nil
 }
 
-func QueryAndProcessMany[T any](ctx context.Context, conn Executor, sql string, handler func(ctx context.Context, rows []*T) error, opts ...dwhexec.QueryManyOpt[T]) error {
+func QueryAndProcessMany[T any](
+	ctx context.Context,
+	conn Executor,
+	sql string,
+	handler func(ctx context.Context, rows []*T) error,
+	opts ...dwhexec.QueryManyOpt[T],
+) error {
 	q := dwhexec.NewQueryMany[T](sql)
 	for _, opt := range opts {
 		opt(q)

--- a/scrapper/bigquery/query_segments.go
+++ b/scrapper/bigquery/query_segments.go
@@ -12,7 +12,7 @@ import (
 
 type dwhBigquerySegmentResponse struct {
 	Segment bigquery.NullString `ch:"segment" bigquery:"segment" db:"segment"`
-	Count   bigquery.NullInt64  `ch:"count" bigquery:"count" db:"count"`
+	Count   bigquery.NullInt64  `ch:"count"   bigquery:"count"   db:"count"`
 }
 
 func (r *dwhBigquerySegmentResponse) GetSegment() string {

--- a/scrapper/databricks/query_catalog.go
+++ b/scrapper/databricks/query_catalog.go
@@ -15,11 +15,11 @@ import (
 
 type Tags struct {
 	CatalogName string `db:"catalog_name" json:"catalog_name"`
-	SchemaName  string `db:"schema_name" json:"schema_name"`
-	TableName   string `db:"table_name" json:"table_name"`
-	ColumnName  string `db:"column_name" json:"column_name"`
-	TagName     string `db:"tag_name" json:"tag_name"`
-	TagValue    string `db:"tag_value" json:"tag_value"`
+	SchemaName  string `db:"schema_name"  json:"schema_name"`
+	TableName   string `db:"table_name"   json:"table_name"`
+	ColumnName  string `db:"column_name"  json:"column_name"`
+	TagName     string `db:"tag_name"     json:"tag_name"`
+	TagValue    string `db:"tag_value"    json:"tag_value"`
 }
 
 func (e *DatabricksScrapper) QueryCatalog(ctx context.Context) ([]*scrapper.CatalogColumnRow, error) {
@@ -56,7 +56,10 @@ func (e *DatabricksScrapper) QueryCatalog(ctx context.Context) ([]*scrapper.Cata
 				continue
 			}
 
-			tables, err := e.client.Tables.ListAll(ctx, servicecatalog.ListTablesRequest{CatalogName: catalogInfo.Name, SchemaName: schemaInfo.Name, OmitProperties: true})
+			tables, err := e.client.Tables.ListAll(
+				ctx,
+				servicecatalog.ListTablesRequest{CatalogName: catalogInfo.Name, SchemaName: schemaInfo.Name, OmitProperties: true},
+			)
 			if err != nil {
 				return nil, err
 			}
@@ -72,11 +75,12 @@ func (e *DatabricksScrapper) QueryCatalog(ctx context.Context) ([]*scrapper.Cata
 				tableTags := getTableTags(tagsLookup, tableInfo.CatalogName, tableInfo.SchemaName, tableInfo.Name)
 				for _, columnInfo := range tableInfo.Columns {
 					catalogRow := &scrapper.CatalogColumnRow{
-						Instance:     e.conf.WorkspaceUrl,
-						Database:     tableInfo.CatalogName,
-						Schema:       tableInfo.SchemaName,
-						Table:        tableInfo.Name,
-						IsView:       tableInfo.TableType == servicecatalog.TableTypeMaterializedView || tableInfo.TableType == servicecatalog.TableTypeView,
+						Instance: e.conf.WorkspaceUrl,
+						Database: tableInfo.CatalogName,
+						Schema:   tableInfo.SchemaName,
+						Table:    tableInfo.Name,
+						IsView: tableInfo.TableType == servicecatalog.TableTypeMaterializedView ||
+							tableInfo.TableType == servicecatalog.TableTypeView,
 						Column:       columnInfo.Name,
 						Type:         columnInfo.TypeText,
 						Position:     int32(columnInfo.Position + 1),

--- a/scrapper/databricks/query_sql_definitions.go
+++ b/scrapper/databricks/query_sql_definitions.go
@@ -44,7 +44,10 @@ func (e *DatabricksScrapper) QuerySqlDefinitions(ctx context.Context) ([]*scrapp
 				continue
 			}
 
-			tables, err := e.client.Tables.ListAll(ctx, servicecatalog.ListTablesRequest{CatalogName: catalogInfo.Name, SchemaName: schemaInfo.Name, OmitColumns: true, OmitProperties: true})
+			tables, err := e.client.Tables.ListAll(
+				ctx,
+				servicecatalog.ListTablesRequest{CatalogName: catalogInfo.Name, SchemaName: schemaInfo.Name, OmitColumns: true, OmitProperties: true},
+			)
 			if err != nil {
 				return nil, err
 			}
@@ -100,7 +103,13 @@ func (e *DatabricksScrapper) QuerySqlDefinitions(ctx context.Context) ([]*scrapp
 	return sqlDefs, nil
 }
 
-func (e *DatabricksScrapper) showCreateTable(ctx context.Context, sqlClient *dwhexecdatabricks.DatabricksExecutor, catalog string, schema string, table string) (string, error) {
+func (e *DatabricksScrapper) showCreateTable(
+	ctx context.Context,
+	sqlClient *dwhexecdatabricks.DatabricksExecutor,
+	catalog string,
+	schema string,
+	table string,
+) (string, error) {
 	var res []string
 	sql := fmt.Sprintf("SHOW CREATE TABLE `%s`.`%s`.`%s`", catalog, schema, table)
 	var err = sqlClient.GetDb().SelectContext(ctx, &res, sql)

--- a/scrapper/databricks/query_table_metrics.go
+++ b/scrapper/databricks/query_table_metrics.go
@@ -56,7 +56,15 @@ func (e *DatabricksScrapper) QueryTableMetrics(ctx context.Context, lastMetricsF
 				continue
 			}
 
-			tables, err := e.client.Tables.ListAll(ctx, servicecatalog.ListTablesRequest{CatalogName: catalogInfo.Name, SchemaName: schemaInfo.Name, OmitColumns: true, IncludeDeltaMetadata: true})
+			tables, err := e.client.Tables.ListAll(
+				ctx,
+				servicecatalog.ListTablesRequest{
+					CatalogName:          catalogInfo.Name,
+					SchemaName:           schemaInfo.Name,
+					OmitColumns:          true,
+					IncludeDeltaMetadata: true,
+				},
+			)
 			if err != nil {
 				return nil, err
 			}

--- a/scrapper/models.go
+++ b/scrapper/models.go
@@ -122,7 +122,7 @@ type TableRow struct {
 	IsView      bool                   `db:"is_view"     json:"is_view"     ch:"is_view"`
 	IsTable     bool                   `db:"is_table"    json:"is_table"    ch:"is_table"`
 	Options     map[string]interface{} `db:"options"     json:"options"`
-	Annotations []*Annotation          `db:"annotations"  json:"annotations"`
+	Annotations []*Annotation          `db:"annotations" json:"annotations"`
 }
 
 func (r TableRow) TableFqn() DwhFqn {

--- a/scrapper/mysql/query_metrics.go
+++ b/scrapper/mysql/query_metrics.go
@@ -14,7 +14,9 @@ import (
 var tableMetricsSql string
 
 func (e *MySQLScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFetchTime time.Time) ([]*scrapper.TableMetricsRow, error) {
-	return dwhexecmysql.NewQuerier[scrapper.TableMetricsRow](e.executor).QueryMany(ctx, tableMetricsSql, dwhexec.WithPostProcessors(func(row *scrapper.TableMetricsRow) (*scrapper.TableMetricsRow, error) {
+	return dwhexecmysql.NewQuerier[scrapper.TableMetricsRow](
+		e.executor,
+	).QueryMany(ctx, tableMetricsSql, dwhexec.WithPostProcessors(func(row *scrapper.TableMetricsRow) (*scrapper.TableMetricsRow, error) {
 		row.Database = e.conf.Host
 		return row, nil
 	}))

--- a/scrapper/snowflake/query_catalog.go
+++ b/scrapper/snowflake/query_catalog.go
@@ -137,7 +137,9 @@ func (e *SnowflakeScrapper) QueryCatalog(origCtx context.Context) ([]*scrapper.C
 									Column:   "METADATA$ISUPDATE",
 									Type:     "BOOLEAN",
 									Position: int32(len(sourceTableColumns) + 2),
-									Comment:  lo.ToPtr("Specifies whether the action recorded (INSERT or DELETE) is part of an UPDATE applied to the rows in the source table or view."),
+									Comment: lo.ToPtr(
+										"Specifies whether the action recorded (INSERT or DELETE) is part of an UPDATE applied to the rows in the source table or view.",
+									),
 								},
 							)
 							tmpResults = append(
@@ -149,7 +151,9 @@ func (e *SnowflakeScrapper) QueryCatalog(origCtx context.Context) ([]*scrapper.C
 									Column:   "METADATA$ROW_ID",
 									Type:     "ROWID",
 									Position: int32(len(sourceTableColumns) + 3),
-									Comment:  lo.ToPtr("Specifies the unique and immutable ID for the row, which can be used to track changes to specific rows over time."),
+									Comment: lo.ToPtr(
+										"Specifies the unique and immutable ID for the row, which can be used to track changes to specific rows over time.",
+									),
 								},
 							)
 						} else {

--- a/scrapper/snowflake/query_tables.go
+++ b/scrapper/snowflake/query_tables.go
@@ -247,21 +247,21 @@ func (e *SnowflakeScrapper) showShares(ctx context.Context) ([]*ShareDesc, error
 }
 
 type ShareObject struct {
-	Kind     string    `db:"kind" json:"kind"`
-	Name     string    `db:"name" json:"name"`
+	Kind     string    `db:"kind"      json:"kind"`
+	Name     string    `db:"name"      json:"name"`
 	SharedOn time.Time `db:"shared_on" json:"shared_on"`
 }
 
 type ShareDesc struct {
-	Name              string         `db:"name" json:"name"`
-	Kind              string         `db:"kind" json:"kind"`
-	OwnerAccount      string         `db:"owner_account" json:"owner_account"`
-	DatabaseName      string         `db:"database_name" json:"database_name"`
-	To                string         `db:"to" json:"to"`
-	Owner             string         `db:"owner" json:"owner"`
-	Comment           string         `db:"comment" json:"comment"`
+	Name              string         `db:"name"                json:"name"`
+	Kind              string         `db:"kind"                json:"kind"`
+	OwnerAccount      string         `db:"owner_account"       json:"owner_account"`
+	DatabaseName      string         `db:"database_name"       json:"database_name"`
+	To                string         `db:"to"                  json:"to"`
+	Owner             string         `db:"owner"               json:"owner"`
+	Comment           string         `db:"comment"             json:"comment"`
 	ListingGlobalName string         `db:"listing_global_name" json:"listing_global_name"`
-	Objects           []*ShareObject `json:"objects"`
+	Objects           []*ShareObject `                         json:"objects"`
 }
 
 func (d *ShareDesc) String() string {

--- a/scrapper/snowflake/snowflake.go
+++ b/scrapper/snowflake/snowflake.go
@@ -153,11 +153,11 @@ func (e *SnowflakeScrapper) Close() error {
 }
 
 type DbDesc struct {
-	Name    string `db:"name" json:"name"`
-	Origin  string `db:"origin" json:"origin"`
-	Owner   string `db:"owner" json:"owner"`
+	Name    string `db:"name"    json:"name"`
+	Origin  string `db:"origin"  json:"origin"`
+	Owner   string `db:"owner"   json:"owner"`
 	Comment string `db:"comment" json:"comment"`
-	Kind    string `db:"kind" json:"kind"`
+	Kind    string `db:"kind"    json:"kind"`
 }
 
 func (d *DbDesc) String() string {

--- a/scrapper/trino/query_building_test.go
+++ b/scrapper/trino/query_building_test.go
@@ -14,8 +14,12 @@ func (e *TrinoScrapper) buildTablesQuery(catalogName string) string {
 
 	// Conditionally add table comments JOIN based on feature flag
 	if e.conf.FetchTableComments {
-		catalogQuery = strings.Replace(catalogQuery, "{{table_comments_join}}",
-			"LEFT JOIN system.metadata.table_comments c\n  ON t.table_catalog = c.catalog_name\n  AND t.table_schema = c.schema_name\n  AND t.table_name = c.table_name", -1)
+		catalogQuery = strings.Replace(
+			catalogQuery,
+			"{{table_comments_join}}",
+			"LEFT JOIN system.metadata.table_comments c\n  ON t.table_catalog = c.catalog_name\n  AND t.table_schema = c.schema_name\n  AND t.table_name = c.table_name",
+			-1,
+		)
 		catalogQuery = strings.Replace(catalogQuery, "{{table_comment_expression}}", "c.comment", -1)
 	} else {
 		catalogQuery = strings.Replace(catalogQuery, "{{table_comments_join}}", "", -1)
@@ -24,8 +28,12 @@ func (e *TrinoScrapper) buildTablesQuery(catalogName string) string {
 
 	// Conditionally add materialized views JOIN based on feature flag
 	if e.conf.FetchMaterializedViews {
-		catalogQuery = strings.Replace(catalogQuery, "{{materialized_views_join}}",
-			"LEFT JOIN system.metadata.materialized_views mv\n  ON t.table_catalog = mv.catalog_name\n    AND t.table_schema = mv.schema_name\n    AND t.table_name = mv.name", -1)
+		catalogQuery = strings.Replace(
+			catalogQuery,
+			"{{materialized_views_join}}",
+			"LEFT JOIN system.metadata.materialized_views mv\n  ON t.table_catalog = mv.catalog_name\n    AND t.table_schema = mv.schema_name\n    AND t.table_name = mv.name",
+			-1,
+		)
 		catalogQuery = strings.Replace(catalogQuery, "{{table_type_expression}}",
 			"(CASE WHEN mv.name IS NOT NULL THEN 'MATERIALIZED VIEW'\n    ELSE t.table_type END)", -1)
 		catalogQuery = strings.Replace(catalogQuery, "{{is_table_expression}}",
@@ -49,8 +57,12 @@ func (e *TrinoScrapper) buildSqlDefinitionsQuery(catalogName string) string {
 
 	// Conditionally add materialized views JOIN based on feature flag
 	if e.conf.FetchMaterializedViews {
-		catalogQuery = strings.Replace(catalogQuery, "{{materialized_views_join}}",
-			"LEFT JOIN system.metadata.materialized_views mv ON t.database = mv.catalog_name AND t.schema = mv.schema_name AND t.table_name = mv.name", -1)
+		catalogQuery = strings.Replace(
+			catalogQuery,
+			"{{materialized_views_join}}",
+			"LEFT JOIN system.metadata.materialized_views mv ON t.database = mv.catalog_name AND t.schema = mv.schema_name AND t.table_name = mv.name",
+			-1,
+		)
 		catalogQuery = strings.Replace(catalogQuery, "{{is_materialized_view_expression}}",
 			"(mv.name IS NOT NULL)", -1)
 		catalogQuery = strings.Replace(catalogQuery, "{{sql_expression}}",

--- a/scrapper/trino/query_catalog.go
+++ b/scrapper/trino/query_catalog.go
@@ -30,8 +30,12 @@ func (e *TrinoScrapper) QueryCatalog(ctx context.Context) ([]*scrapper.CatalogCo
 
 		// Conditionally add table comments JOIN based on feature flag
 		if e.conf.FetchTableComments {
-			query = strings.Replace(query, "{{table_comments_join}}",
-				"LEFT JOIN system.metadata.table_comments tc ON t.table_catalog = tc.catalog_name AND t.table_schema = tc.schema_name AND t.table_name = tc.table_name", -1)
+			query = strings.Replace(
+				query,
+				"{{table_comments_join}}",
+				"LEFT JOIN system.metadata.table_comments tc ON t.table_catalog = tc.catalog_name AND t.table_schema = tc.schema_name AND t.table_name = tc.table_name",
+				-1,
+			)
 			query = strings.Replace(query, "{{table_comment_expression}}",
 				"coalesce(tc.comment, '')", -1)
 		} else {

--- a/scrapper/trino/query_sql_definitions.go
+++ b/scrapper/trino/query_sql_definitions.go
@@ -108,8 +108,12 @@ func (e *TrinoScrapper) getBasicSqlDefinitions(ctx context.Context) ([]*scrapper
 
 		// Conditionally add materialized views JOIN based on feature flag
 		if e.conf.FetchMaterializedViews {
-			catalogQuery = strings.Replace(catalogQuery, "{{materialized_views_join}}",
-				"LEFT JOIN system.metadata.materialized_views mv ON t.database = mv.catalog_name AND t.schema = mv.schema_name AND t.table_name = mv.name", -1)
+			catalogQuery = strings.Replace(
+				catalogQuery,
+				"{{materialized_views_join}}",
+				"LEFT JOIN system.metadata.materialized_views mv ON t.database = mv.catalog_name AND t.schema = mv.schema_name AND t.table_name = mv.name",
+				-1,
+			)
 			catalogQuery = strings.Replace(catalogQuery, "{{is_materialized_view_expression}}",
 				"(mv.name IS NOT NULL)", -1)
 			catalogQuery = strings.Replace(catalogQuery, "{{sql_expression}}",

--- a/scrapper/trino/query_table_metrics.go
+++ b/scrapper/trino/query_table_metrics.go
@@ -113,7 +113,12 @@ type trinoShowStatsRow struct {
 	HighValue          sql.NullString  `db:"high_value"`
 }
 
-func (e *TrinoScrapper) showStatsMetricsStrategy(ctx context.Context, db *sqlx.DB, tableRow *scrapper.TableRow, tableMetricsRow *scrapper.TableMetricsRow) error {
+func (e *TrinoScrapper) showStatsMetricsStrategy(
+	ctx context.Context,
+	db *sqlx.DB,
+	tableRow *scrapper.TableRow,
+	tableMetricsRow *scrapper.TableMetricsRow,
+) error {
 	if tableRow.TableType == "VIEW" {
 		return nil
 	}
@@ -164,7 +169,12 @@ type trinoIcebergSnapshotsRow struct {
 	Summary      trino.NullMap  `db:"summary"`
 }
 
-func (e *TrinoScrapper) icebergMetricsStrategy(ctx context.Context, db *sqlx.DB, tableRow *scrapper.TableRow, tableMetricsRow *scrapper.TableMetricsRow) error {
+func (e *TrinoScrapper) icebergMetricsStrategy(
+	ctx context.Context,
+	db *sqlx.DB,
+	tableRow *scrapper.TableRow,
+	tableMetricsRow *scrapper.TableMetricsRow,
+) error {
 
 	// Let's reuse SHOW STATS
 	if err := e.showStatsMetricsStrategy(ctx, db, tableRow, tableMetricsRow); err != nil {

--- a/scrapper/trino/query_tables.go
+++ b/scrapper/trino/query_tables.go
@@ -42,8 +42,12 @@ func (e *TrinoScrapper) queryTables(ctx context.Context, catalogName string) ([]
 
 	// Conditionally add table comments JOIN based on feature flag
 	if e.conf.FetchTableComments {
-		catalogQuery = strings.Replace(catalogQuery, "{{table_comments_join}}",
-			"LEFT JOIN system.metadata.table_comments c\n  ON t.table_catalog = c.catalog_name\n  AND t.table_schema = c.schema_name\n  AND t.table_name = c.table_name", -1)
+		catalogQuery = strings.Replace(
+			catalogQuery,
+			"{{table_comments_join}}",
+			"LEFT JOIN system.metadata.table_comments c\n  ON t.table_catalog = c.catalog_name\n  AND t.table_schema = c.schema_name\n  AND t.table_name = c.table_name",
+			-1,
+		)
 		catalogQuery = strings.Replace(catalogQuery, "{{table_comment_expression}}", "c.comment", -1)
 	} else {
 		catalogQuery = strings.Replace(catalogQuery, "{{table_comments_join}}", "", -1)
@@ -52,8 +56,12 @@ func (e *TrinoScrapper) queryTables(ctx context.Context, catalogName string) ([]
 
 	// Conditionally add materialized views JOIN based on feature flag
 	if e.conf.FetchMaterializedViews {
-		catalogQuery = strings.Replace(catalogQuery, "{{materialized_views_join}}",
-			"LEFT JOIN system.metadata.materialized_views mv\n  ON t.table_catalog = mv.catalog_name\n    AND t.table_schema = mv.schema_name\n    AND t.table_name = mv.name", -1)
+		catalogQuery = strings.Replace(
+			catalogQuery,
+			"{{materialized_views_join}}",
+			"LEFT JOIN system.metadata.materialized_views mv\n  ON t.table_catalog = mv.catalog_name\n    AND t.table_schema = mv.schema_name\n    AND t.table_name = mv.name",
+			-1,
+		)
 		catalogQuery = strings.Replace(catalogQuery, "{{table_type_expression}}",
 			"(CASE WHEN mv.name IS NOT NULL THEN 'MATERIALIZED VIEW'\n    ELSE t.table_type END)", -1)
 		catalogQuery = strings.Replace(catalogQuery, "{{is_table_expression}}",

--- a/scrapper/trino/table_comments_feature_test.go
+++ b/scrapper/trino/table_comments_feature_test.go
@@ -111,8 +111,12 @@ func (e *TrinoScrapper) buildCatalogQuery(catalogName string) string {
 
 	// Conditionally add table comments JOIN based on feature flag
 	if e.conf.FetchTableComments {
-		catalogQuery = strings.Replace(catalogQuery, "{{table_comments_join}}",
-			"LEFT JOIN system.metadata.table_comments tc ON t.table_catalog = tc.catalog_name AND t.table_schema = tc.schema_name AND t.table_name = tc.table_name", -1)
+		catalogQuery = strings.Replace(
+			catalogQuery,
+			"{{table_comments_join}}",
+			"LEFT JOIN system.metadata.table_comments tc ON t.table_catalog = tc.catalog_name AND t.table_schema = tc.schema_name AND t.table_name = tc.table_name",
+			-1,
+		)
 		catalogQuery = strings.Replace(catalogQuery, "{{table_comment_expression}}",
 			"coalesce(tc.comment, '')", -1)
 	} else {

--- a/scrapper/trino/trino.go
+++ b/scrapper/trino/trino.go
@@ -33,10 +33,10 @@ type TrinoScrapper struct {
 }
 
 type TrinoCatalog struct {
-	CatalogName   string `db:"catalog_name" json:"catalog_name"`
-	ConnectorId   string `db:"connector_id" json:"connector_id"`
+	CatalogName   string `db:"catalog_name"   json:"catalog_name"`
+	ConnectorId   string `db:"connector_id"   json:"connector_id"`
 	ConnectorName string `db:"connector_name" json:"connector_name"`
-	IsAccepted    bool   `db:"-" json:"is_accepted"`
+	IsAccepted    bool   `db:"-"              json:"is_accepted"`
 }
 
 func (c *TrinoCatalog) String() string {


### PR DESCRIPTION
## Summary

Applied `gofmt` formatting across the entire codebase to ensure consistent Go code style. This is a non-functional change that only affects code formatting, primarily improving multi-line string literals and composite literal formatting.

Changes include:
- Improved formatting of multi-line string literals (SQL queries, etc.)
- Better alignment of composite literals
- Consistent indentation across all Go files

All changes are purely cosmetic with no functional impact.