### PR TITLE
bq scrapper: INFORMATION_SCHEMA metrics, explicit datasets, access-denied handling

### DIFF
--- a/scrapper/bigquery/query_table_metrics.go
+++ b/scrapper/bigquery/query_table_metrics.go
@@ -73,6 +73,10 @@ func (e *BigQueryScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFet
 			q := fmt.Sprintf(tableMetricsSql, quoteTable(dataset.ProjectID), quoteTable(dataset.DatasetID))
 			rows, err := e.queryRows(groupCtx, q)
 			if err != nil {
+				if errIsAccessDenied(err) || errIsNotFound(err) {
+					log.Warnf("skipping dataset %s for metrics: %v", dataset.DatasetID, err)
+					return nil
+				}
 				return err
 			}
 


### PR DESCRIPTION
## Summary

- Handle access-denied per-dataset in QueryTableMetrics (aligns with catalog/tables/sql_definitions)
- Add `UseInformationSchema` flag to switch table metrics from `__TABLES__` (requires `bigquery.tables.getData`) to `INFORMATION_SCHEMA.TABLES+PARTITIONS` (requires only metadata permissions)
- Add `Datasets` field for explicit dataset names — enables customers with dataset-level IAM who lack project-level `bigquery.datasets.list`
- Extract shared `listDatasets()` helper, replacing duplicated dataset iteration in all 4 scrapper methods
- Skip misleading project-level permission check in `ValidateConfiguration` when `Datasets` is set
- Expose `QueryTableMetricsV2` for side-by-side comparison testing

Related: [PR-7039](https://linear.app/synq/issue/PR-7039), [PR-6954](https://linear.app/synq/issue/PR-6954)