### PR TITLE
bq scrapper: add INFORMATION_SCHEMA metrics, explicit datasets, and listDatasets

### DIFF
--- a/exec/bigquery/bigquery.go
+++ b/exec/bigquery/bigquery.go
@@ -17,10 +17,16 @@ import (
 	"google.golang.org/api/option"
 )
 
+// BigQueryConf configures the BigQuery executor connection.
+// Authentication precedence: AccessToken > CredentialsJson > CredentialsFile.
 type BigQueryConf struct {
-	ProjectId       string
-	Region          string
+	// ProjectId is the GCP project containing BigQuery datasets.
+	ProjectId string
+	// Region restricts queries to a specific BQ region (e.g. "EU", "us-central1").
+	Region string
+	// CredentialsJson is a GCP service account key in JSON format.
 	CredentialsJson string
+	// CredentialsFile is a path to a GCP service account key file.
 	CredentialsFile string
 	// AccessToken is an OAuth access token for user-level authentication.
 	// When set, it takes precedence over CredentialsJson and CredentialsFile.

--- a/scrapper/bigquery/bigquery.go
+++ b/scrapper/bigquery/bigquery.go
@@ -31,10 +31,6 @@ type BigQueryScrapperConf struct {
 	Blocklist string
 	// RateLimitCfg overrides the default rate limit configuration for BQ API calls.
 	RateLimitCfg *RateLimitConfig
-	// UseInformationSchema switches table metrics from __TABLES__ (legacy, requires
-	// bigquery.tables.getData) to INFORMATION_SCHEMA.TABLES+PARTITIONS (requires only
-	// bigquery.tables.get + bigquery.tables.list, covered by metadataViewer role).
-	UseInformationSchema bool
 	// Datasets is an explicit list of dataset names to scrape. When set, only these
 	// datasets are queried instead of listing all datasets in the project via API.
 	// This is required for customers who grant permissions at the dataset level and
@@ -83,13 +79,8 @@ var BaseExpectedPermissions = []string{
 	"bigquery.routines.get",
 	"bigquery.routines.list",
 	"bigquery.tables.get",
-	"bigquery.tables.getData",
 	"bigquery.tables.list",
 	"resourcemanager.projects.get",
-	//"storage.buckets.get",
-	//"storage.buckets.list",
-	//"storage.objects.get",
-	//"storage.objects.list",
 }
 
 func NewBigQueryScrapper(ctx context.Context, conf *BigQueryScrapperConf) (*BigQueryScrapper, error) {
@@ -184,22 +175,13 @@ func (e *BigQueryScrapper) ValidateConfiguration(ctx context.Context) ([]string,
 
 	var warnings []string
 
-	expectedPermissions := make([]string, len(BaseExpectedPermissions))
-	copy(expectedPermissions, BaseExpectedPermissions)
-
-	// bigquery.tables.getData is only needed for __TABLES__ queries;
-	// INFORMATION_SCHEMA requires only bigquery.tables.get + bigquery.tables.list.
-	if e.conf.UseInformationSchema {
-		expectedPermissions = lo.Without(expectedPermissions, "bigquery.tables.getData")
-	}
-
 	if permissions, err := crm.Projects.TestIamPermissions(e.conf.ProjectId, &cloudresourcemanager.TestIamPermissionsRequest{
-		Permissions: expectedPermissions,
+		Permissions: BaseExpectedPermissions,
 	}).Context(ctx).Do(); err == nil {
 		gotPermissions := permissions.Permissions
 		sort.Strings(gotPermissions)
 
-		missingPermissions, _ := lo.Difference(expectedPermissions, gotPermissions)
+		missingPermissions, _ := lo.Difference(BaseExpectedPermissions, gotPermissions)
 		if len(missingPermissions) > 0 {
 			logging.GetLogger(ctx).WithField("missing_permissions", missingPermissions).Info("missing BigQuery permissions")
 			warnings = append(

--- a/scrapper/bigquery/bigquery.go
+++ b/scrapper/bigquery/bigquery.go
@@ -113,8 +113,13 @@ func (e *BigQueryScrapper) Executor() *dwhexecbigquery.BigQueryExecutor {
 func (e *BigQueryScrapper) listDatasets(ctx context.Context) ([]*bigquery.Dataset, error) {
 	if len(e.conf.Datasets) > 0 {
 		client := e.executor.GetBigQueryClient()
+		seen := make(map[string]bool)
 		var result []*bigquery.Dataset
 		for _, name := range e.conf.Datasets {
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
 			result = append(result, client.Dataset(name))
 		}
 		return result, nil

--- a/scrapper/bigquery/bigquery.go
+++ b/scrapper/bigquery/bigquery.go
@@ -20,13 +20,26 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/getsynq/dwhsupport/scrapper"
+	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
 
+// BigQueryScrapperConf configures BigQuery metadata scrapping.
 type BigQueryScrapperConf struct {
 	dwhexecbigquery.BigQueryConf
-	Blocklist    string
+	// Blocklist is a comma-separated list of dataset name patterns to exclude.
+	Blocklist string
+	// RateLimitCfg overrides the default rate limit configuration for BQ API calls.
 	RateLimitCfg *RateLimitConfig
+	// UseInformationSchema switches table metrics from __TABLES__ (legacy, requires
+	// bigquery.tables.getData) to INFORMATION_SCHEMA.TABLES+PARTITIONS (requires only
+	// bigquery.tables.get + bigquery.tables.list, covered by metadataViewer role).
+	UseInformationSchema bool
+	// Datasets is an explicit list of dataset names to scrape. When set, only these
+	// datasets are queried instead of listing all datasets in the project via API.
+	// This is required for customers who grant permissions at the dataset level and
+	// lack project-level bigquery.datasets.list permission.
+	Datasets []string
 }
 
 type Executor interface {
@@ -104,6 +117,39 @@ func (e *BigQueryScrapper) Executor() *dwhexecbigquery.BigQueryExecutor {
 	return e.executor
 }
 
+// listDatasets returns the datasets to scrape. When conf.Datasets is set,
+// returns those explicitly; otherwise lists all visible datasets via the API.
+func (e *BigQueryScrapper) listDatasets(ctx context.Context) ([]*bigquery.Dataset, error) {
+	if len(e.conf.Datasets) > 0 {
+		client := e.executor.GetBigQueryClient()
+		var result []*bigquery.Dataset
+		for _, name := range e.conf.Datasets {
+			result = append(result, client.Dataset(name))
+		}
+		return result, nil
+	}
+
+	client := e.executor.GetBigQueryClient()
+	it := client.Datasets(ctx)
+	it.ListHidden = true
+
+	var result []*bigquery.Dataset
+	for {
+		ds, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			if errIsNotFound(err) || errIsAccessDenied(err) {
+				continue
+			}
+			return nil, err
+		}
+		result = append(result, ds)
+	}
+	return result, nil
+}
+
 func (e *BigQueryScrapper) queryRows(ctx context.Context, q string, args ...interface{}) (*bigquery.RowIterator, error) {
 	query := e.executor.GetBigQueryClient().Query(q)
 	job, err := query.Run(ctx)
@@ -120,6 +166,13 @@ func (e *BigQueryScrapper) queryRows(ctx context.Context, q string, args ...inte
 }
 
 func (e *BigQueryScrapper) ValidateConfiguration(ctx context.Context) ([]string, error) {
+	// When explicit datasets are configured, permissions are granted at dataset level
+	// and project-level TestIamPermissions would report false negatives.
+	if len(e.conf.Datasets) > 0 {
+		logging.GetLogger(ctx).Info("skipping project-level permission check: explicit datasets configured")
+		return nil, nil
+	}
+
 	crm, err := cloudresourcemanager.NewService(
 		ctx,
 		option.WithCredentialsJSON([]byte(e.conf.CredentialsJson)),
@@ -131,7 +184,14 @@ func (e *BigQueryScrapper) ValidateConfiguration(ctx context.Context) ([]string,
 
 	var warnings []string
 
-	expectedPermissions := BaseExpectedPermissions
+	expectedPermissions := make([]string, len(BaseExpectedPermissions))
+	copy(expectedPermissions, BaseExpectedPermissions)
+
+	// bigquery.tables.getData is only needed for __TABLES__ queries;
+	// INFORMATION_SCHEMA requires only bigquery.tables.get + bigquery.tables.list.
+	if e.conf.UseInformationSchema {
+		expectedPermissions = lo.Without(expectedPermissions, "bigquery.tables.getData")
+	}
 
 	if permissions, err := crm.Projects.TestIamPermissions(e.conf.ProjectId, &cloudresourcemanager.TestIamPermissionsRequest{
 		Permissions: expectedPermissions,

--- a/scrapper/bigquery/query_catalog.go
+++ b/scrapper/bigquery/query_catalog.go
@@ -22,8 +22,10 @@ func (e *BigQueryScrapper) QueryCatalog(ctx context.Context) ([]*scrapper.Catalo
 		WithField("executor", "bigquery").
 		WithField("project_id", e.conf.ProjectId)
 
-	datasets := e.executor.GetBigQueryClient().Datasets(ctx)
-	datasets.ListHidden = true
+	allDatasets, err := e.listDatasets(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	var rows []*scrapper.CatalogColumnRow
 	var mutex sync.Mutex
@@ -33,18 +35,7 @@ func (e *BigQueryScrapper) QueryCatalog(ctx context.Context) ([]*scrapper.Catalo
 
 	numTablesTotal := 0
 
-	for {
-		dataset, err := datasets.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			if errIsNotFound(err) || errIsAccessDenied(err) {
-				continue
-			}
-			return nil, err
-		}
-
+	for _, dataset := range allDatasets {
 		if isPrivateDataset(dataset.DatasetID) {
 			continue
 		}

--- a/scrapper/bigquery/query_sql_definitions.go
+++ b/scrapper/bigquery/query_sql_definitions.go
@@ -43,8 +43,10 @@ func (e *BigQueryScrapper) querySqlDefinitionsApi(ctx context.Context) ([]*scrap
 		WithField("executor", "bigquery").
 		WithField("project_id", e.conf.ProjectId)
 
-	datasets := e.executor.GetBigQueryClient().Datasets(ctx)
-	datasets.ListHidden = true
+	allDatasets, err := e.listDatasets(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	var rows []*scrapper.SqlDefinitionRow
 	var mutex sync.Mutex
@@ -53,23 +55,7 @@ func (e *BigQueryScrapper) querySqlDefinitionsApi(ctx context.Context) ([]*scrap
 	g.SetLimit(e.rateLimitCfg.MetadataConcurrency)
 
 	numTablesTotal := 0
-	for {
-		dataset, err := datasets.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			if errIsNotFound(err) {
-				log.Infof("dataset %s not found", dataset.DatasetID)
-				continue
-			}
-			if errIsAccessDenied(err) {
-				log.Infof("dataset %s access denied", dataset.DatasetID)
-				continue
-			}
-			return nil, err
-		}
-
+	for _, dataset := range allDatasets {
 		if isPrivateDataset(dataset.DatasetID) {
 			continue
 		}

--- a/scrapper/bigquery/query_table_metrics.go
+++ b/scrapper/bigquery/query_table_metrics.go
@@ -3,7 +3,6 @@ package bigquery
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -14,53 +13,10 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-var (
-	tableMetricsLegacySql = `
-	SELECT
-		project_id as database,
-		dataset_id as schema,
-		table_id as table,
-		row_count as row_count,
-		size_bytes as size_bytes,
-		TIMESTAMP_MILLIS(last_modified_time) as updated_at
-	FROM %s.%s.__TABLES__
-`
-
-	tableMetricsInfoSchemaSql = `
-	SELECT
-		t.table_catalog AS database,
-		t.table_schema AS schema,
-		t.table_name AS ` + "`table`" + `,
-		COALESCE(SUM(p.total_rows), 0) AS row_count,
-		COALESCE(SUM(p.total_logical_bytes), 0) AS size_bytes,
-		MAX(p.last_modified_time) AS updated_at
-	FROM %[1]s.%[2]s.INFORMATION_SCHEMA.TABLES AS t
-	LEFT JOIN %[1]s.%[2]s.INFORMATION_SCHEMA.PARTITIONS AS p
-		ON t.table_catalog = p.table_catalog
-		AND t.table_schema = p.table_schema
-		AND t.table_name = p.table_name
-	GROUP BY 1, 2, 3
-`
-)
-
+// QueryTableMetrics collects table metrics (row counts, sizes, freshness) via the
+// BigQuery Tables.Get API. Covers all table types including materialized views.
+// Requires bigquery.tables.get + bigquery.tables.list (metadata permissions).
 func (e *BigQueryScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFetchTime time.Time) ([]*scrapper.TableMetricsRow, error) {
-	if e.conf.UseInformationSchema {
-		return e.queryTableMetricsPerDataset(ctx, tableMetricsInfoSchemaSql, "INFORMATION_SCHEMA")
-	}
-	return e.queryTableMetricsPerDataset(ctx, tableMetricsLegacySql, "__TABLES__")
-}
-
-// QueryTableMetricsV2 uses the BigQuery Tables.Get API instead of SQL queries.
-// It requires only bigquery.tables.get + bigquery.tables.list (metadata permissions)
-// rather than bigquery.tables.getData needed by __TABLES__.
-// Covers all table types including materialized views and has no table count limits.
-// Exposed for side-by-side comparison testing against QueryTableMetrics.
-func (e *BigQueryScrapper) QueryTableMetricsV2(ctx context.Context, lastMetricsFetchTime time.Time) ([]*scrapper.TableMetricsRow, error) {
-	return e.queryTableMetricsApi(ctx)
-}
-
-// queryTableMetricsApi collects table metrics via the BigQuery Tables.Get API.
-func (e *BigQueryScrapper) queryTableMetricsApi(ctx context.Context) ([]*scrapper.TableMetricsRow, error) {
 	log := logging.GetLogger(ctx)
 
 	allDatasets, err := e.listDatasets(ctx)
@@ -143,110 +99,4 @@ func (e *BigQueryScrapper) queryTableMetricsApi(ctx context.Context) ([]*scrappe
 	}
 
 	return collapseShardedMetrics(results)
-}
-
-func (e *BigQueryScrapper) queryTableMetricsPerDataset(ctx context.Context, sqlTemplate string, source string) ([]*scrapper.TableMetricsRow, error) {
-	log := logging.GetLogger(ctx)
-
-	allDatasets, err := e.listDatasets(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	var mutex sync.Mutex
-	var results []*scrapper.TableMetricsRow
-
-	g, groupCtx := errgroup.WithContext(ctx)
-	g.SetLimit(8)
-
-	for _, dataset := range allDatasets {
-		if isPrivateDataset(dataset.DatasetID) {
-			continue
-		}
-
-		if !e.scope.IsSchemaAccepted(e.conf.ProjectId, dataset.DatasetID) {
-			log.Infof("dataset %s excluded by scope filter", dataset.DatasetID)
-			continue
-		}
-
-		select {
-		case <-groupCtx.Done():
-			return nil, groupCtx.Err()
-		default:
-		}
-
-		g.Go(func() error {
-			log.Infof("querying dataset %s via %s", dataset.DatasetID, source)
-
-			project := quoteTable(dataset.ProjectID)
-			ds := quoteTable(dataset.DatasetID)
-			q := fmt.Sprintf(sqlTemplate, project, ds)
-			rows, err := e.queryRows(groupCtx, q)
-			if err != nil {
-				if errIsAccessDenied(err) || errIsNotFound(err) {
-					log.Warnf("skipping dataset %s for metrics (%s): %v", dataset.DatasetID, source, err)
-					return nil
-				}
-				return err
-			}
-
-			var datasetResults []*scrapper.TableMetricsRow
-			for {
-				var res map[string]bigquery.Value
-
-				err := rows.Next(&res)
-				if errors.Is(err, iterator.Done) {
-					break
-				}
-				if err != nil {
-					return err
-				}
-
-				var t *time.Time
-				if updatedAt, ok := res["updated_at"].(time.Time); ok {
-					t = &updatedAt
-				} else {
-					log.Warnf("error extracting updated_at from %s", res["table"].(string))
-				}
-
-				var rowCount *int64
-				if f, ok := res["row_count"]; ok {
-					if c, ok := f.(int64); ok {
-						rowCount = &c
-					}
-				}
-				var sizeBytes *int64
-				if f, ok := res["size_bytes"]; ok {
-					if c, ok := f.(int64); ok {
-						sizeBytes = &c
-					}
-				}
-
-				datasetResults = append(datasetResults, &scrapper.TableMetricsRow{
-					Database:  res["database"].(string),
-					Schema:    res["schema"].(string),
-					Table:     res["table"].(string),
-					RowCount:  rowCount,
-					SizeBytes: sizeBytes,
-					UpdatedAt: t,
-				})
-			}
-
-			mutex.Lock()
-			defer mutex.Unlock()
-			results = append(results, datasetResults...)
-
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		return nil, err
-	}
-
-	return collapseShardedMetrics(results)
-}
-
-func quoteTable(id string) string {
-	return fmt.Sprintf("`%s`", id)
 }

--- a/scrapper/bigquery/query_table_metrics.go
+++ b/scrapper/bigquery/query_table_metrics.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	tableMetricsSql = `
+	tableMetricsLegacySql = `
 	SELECT
 		project_id as database,
 		dataset_id as schema,
@@ -25,13 +25,46 @@ var (
 		TIMESTAMP_MILLIS(last_modified_time) as updated_at
 	FROM %s.%s.__TABLES__
 `
+
+	tableMetricsInfoSchemaSql = `
+	SELECT
+		t.table_catalog AS database,
+		t.table_schema AS schema,
+		t.table_name AS ` + "`table`" + `,
+		COALESCE(SUM(p.total_rows), 0) AS row_count,
+		COALESCE(SUM(p.total_logical_bytes), 0) AS size_bytes,
+		MAX(p.last_modified_time) AS updated_at
+	FROM %[1]s.%[2]s.INFORMATION_SCHEMA.TABLES AS t
+	LEFT JOIN %[1]s.%[2]s.INFORMATION_SCHEMA.PARTITIONS AS p
+		ON t.table_catalog = p.table_catalog
+		AND t.table_schema = p.table_schema
+		AND t.table_name = p.table_name
+	GROUP BY 1, 2, 3
+`
 )
 
 func (e *BigQueryScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFetchTime time.Time) ([]*scrapper.TableMetricsRow, error) {
+	if e.conf.UseInformationSchema {
+		return e.queryTableMetricsPerDataset(ctx, tableMetricsInfoSchemaSql, "INFORMATION_SCHEMA")
+	}
+	return e.queryTableMetricsPerDataset(ctx, tableMetricsLegacySql, "__TABLES__")
+}
+
+// QueryTableMetricsV2 uses INFORMATION_SCHEMA.TABLES+PARTITIONS instead of __TABLES__.
+// It requires only bigquery.tables.get + bigquery.tables.list (metadata permissions)
+// rather than bigquery.tables.getData needed by __TABLES__.
+// Exposed for side-by-side comparison testing against QueryTableMetrics.
+func (e *BigQueryScrapper) QueryTableMetricsV2(ctx context.Context, lastMetricsFetchTime time.Time) ([]*scrapper.TableMetricsRow, error) {
+	return e.queryTableMetricsPerDataset(ctx, tableMetricsInfoSchemaSql, "INFORMATION_SCHEMA")
+}
+
+func (e *BigQueryScrapper) queryTableMetricsPerDataset(ctx context.Context, sqlTemplate string, source string) ([]*scrapper.TableMetricsRow, error) {
 	log := logging.GetLogger(ctx)
 
-	datasets := e.executor.GetBigQueryClient().Datasets(ctx)
-	datasets.ListHidden = true
+	allDatasets, err := e.listDatasets(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	var mutex sync.Mutex
 	var results []*scrapper.TableMetricsRow
@@ -39,18 +72,7 @@ func (e *BigQueryScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFet
 	g, groupCtx := errgroup.WithContext(ctx)
 	g.SetLimit(8)
 
-	for {
-		dataset, err := datasets.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			if errIsNotFound(err) || errIsAccessDenied(err) {
-				continue
-			}
-			return nil, err
-		}
-
+	for _, dataset := range allDatasets {
 		if isPrivateDataset(dataset.DatasetID) {
 			continue
 		}
@@ -67,33 +89,33 @@ func (e *BigQueryScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFet
 		}
 
 		g.Go(func() error {
-			var datasetResults []*scrapper.TableMetricsRow
-			log.Infof("querying dataset %s", dataset.DatasetID)
+			log.Infof("querying dataset %s via %s", dataset.DatasetID, source)
 
-			q := fmt.Sprintf(tableMetricsSql, quoteTable(dataset.ProjectID), quoteTable(dataset.DatasetID))
+			project := quoteTable(dataset.ProjectID)
+			ds := quoteTable(dataset.DatasetID)
+			q := fmt.Sprintf(sqlTemplate, project, ds)
 			rows, err := e.queryRows(groupCtx, q)
 			if err != nil {
 				if errIsAccessDenied(err) || errIsNotFound(err) {
-					log.Warnf("skipping dataset %s for metrics: %v", dataset.DatasetID, err)
+					log.Warnf("skipping dataset %s for metrics (%s): %v", dataset.DatasetID, source, err)
 					return nil
 				}
 				return err
 			}
 
+			var datasetResults []*scrapper.TableMetricsRow
 			for {
 				var res map[string]bigquery.Value
 
 				err := rows.Next(&res)
-
 				if errors.Is(err, iterator.Done) {
 					break
 				}
-
 				if err != nil {
 					return err
 				}
 
-				var t *time.Time = nil
+				var t *time.Time
 				if updatedAt, ok := res["updated_at"].(time.Time); ok {
 					t = &updatedAt
 				} else {
@@ -103,17 +125,13 @@ func (e *BigQueryScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFet
 				var rowCount *int64
 				if f, ok := res["row_count"]; ok {
 					if c, ok := f.(int64); ok {
-						u := int64(c)
-						p := &u
-						rowCount = p
+						rowCount = &c
 					}
 				}
 				var sizeBytes *int64
 				if f, ok := res["size_bytes"]; ok {
 					if c, ok := f.(int64); ok {
-						u := int64(c)
-						p := &u
-						sizeBytes = p
+						sizeBytes = &c
 					}
 				}
 
@@ -135,8 +153,7 @@ func (e *BigQueryScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFet
 		})
 	}
 
-	err := g.Wait()
-	if err != nil {
+	if err := g.Wait(); err != nil {
 		return nil, err
 	}
 

--- a/scrapper/bigquery/query_table_metrics.go
+++ b/scrapper/bigquery/query_table_metrics.go
@@ -50,12 +50,99 @@ func (e *BigQueryScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFet
 	return e.queryTableMetricsPerDataset(ctx, tableMetricsLegacySql, "__TABLES__")
 }
 
-// QueryTableMetricsV2 uses INFORMATION_SCHEMA.TABLES+PARTITIONS instead of __TABLES__.
+// QueryTableMetricsV2 uses the BigQuery Tables.Get API instead of SQL queries.
 // It requires only bigquery.tables.get + bigquery.tables.list (metadata permissions)
 // rather than bigquery.tables.getData needed by __TABLES__.
+// Covers all table types including materialized views and has no table count limits.
 // Exposed for side-by-side comparison testing against QueryTableMetrics.
 func (e *BigQueryScrapper) QueryTableMetricsV2(ctx context.Context, lastMetricsFetchTime time.Time) ([]*scrapper.TableMetricsRow, error) {
-	return e.queryTableMetricsPerDataset(ctx, tableMetricsInfoSchemaSql, "INFORMATION_SCHEMA")
+	return e.queryTableMetricsApi(ctx)
+}
+
+// queryTableMetricsApi collects table metrics via the BigQuery Tables.Get API.
+func (e *BigQueryScrapper) queryTableMetricsApi(ctx context.Context) ([]*scrapper.TableMetricsRow, error) {
+	log := logging.GetLogger(ctx)
+
+	allDatasets, err := e.listDatasets(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var mutex sync.Mutex
+	var results []*scrapper.TableMetricsRow
+
+	g, groupCtx := errgroup.WithContext(ctx)
+	g.SetLimit(e.rateLimitCfg.MetadataConcurrency)
+
+	for _, dataset := range allDatasets {
+		if isPrivateDataset(dataset.DatasetID) {
+			continue
+		}
+
+		if !e.scope.IsSchemaAccepted(e.conf.ProjectId, dataset.DatasetID) {
+			log.Infof("dataset %s excluded by scope filter", dataset.DatasetID)
+			continue
+		}
+
+		tables := e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Tables(groupCtx)
+		for {
+			table, err := tables.Next()
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			if err != nil {
+				if errIsNotFound(err) || errIsAccessDenied(err) {
+					break
+				}
+				return nil, err
+			}
+
+			select {
+			case <-groupCtx.Done():
+				return nil, groupCtx.Err()
+			default:
+			}
+
+			g.Go(func() error {
+				tableMeta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func() (*bigquery.TableMetadata, error) {
+					return table.Metadata(groupCtx)
+				})
+				if err != nil {
+					if errIsNotFound(err) || errIsAccessDenied(err) {
+						return nil
+					}
+					return err
+				}
+
+				numRows := int64(tableMeta.NumRows)
+				numBytes := tableMeta.NumBytes
+				var updatedAt *time.Time
+				if !tableMeta.LastModifiedTime.IsZero() {
+					t := tableMeta.LastModifiedTime
+					updatedAt = &t
+				}
+
+				mutex.Lock()
+				defer mutex.Unlock()
+				results = append(results, &scrapper.TableMetricsRow{
+					Database:  e.conf.ProjectId,
+					Schema:    dataset.DatasetID,
+					Table:     table.TableID,
+					RowCount:  &numRows,
+					SizeBytes: &numBytes,
+					UpdatedAt: updatedAt,
+				})
+
+				return nil
+			})
+		}
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return collapseShardedMetrics(results)
 }
 
 func (e *BigQueryScrapper) queryTableMetricsPerDataset(ctx context.Context, sqlTemplate string, source string) ([]*scrapper.TableMetricsRow, error) {

--- a/scrapper/bigquery/query_tables.go
+++ b/scrapper/bigquery/query_tables.go
@@ -22,8 +22,10 @@ func (e *BigQueryScrapper) QueryTables(ctx context.Context, opts ...scrapper.Que
 		WithField("executor", "bigquery").
 		WithField("project_id", e.conf.ProjectId)
 
-	datasets := e.executor.GetBigQueryClient().Datasets(ctx)
-	datasets.ListHidden = true
+	allDatasets, err := e.listDatasets(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	var rows []*scrapper.TableRow
 	var mutex sync.Mutex
@@ -33,18 +35,7 @@ func (e *BigQueryScrapper) QueryTables(ctx context.Context, opts ...scrapper.Que
 
 	numTablesTotal := 0
 
-	for {
-		dataset, err := datasets.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			if errIsNotFound(err) || errIsAccessDenied(err) {
-				continue
-			}
-			return nil, err
-		}
-
+	for _, dataset := range allDatasets {
 		if isPrivateDataset(dataset.DatasetID) {
 			continue
 		}


### PR DESCRIPTION
## Summary

- Replace `__TABLES__` SQL with BigQuery Tables.Get API for table metrics — no longer requires `bigquery.tables.getData` permission, covers all table types (including materialized views), no table count limits
- Remove `bigquery.tables.getData` from `BaseExpectedPermissions`
- Add `Datasets []string` field for explicit dataset names — enables customers with dataset-level IAM who lack project-level `bigquery.datasets.list`
- Extract shared `listDatasets()` helper used by all 4 scrapper methods (catalog, tables, sql definitions, metrics), replacing duplicated dataset iteration loops
- Skip misleading project-level permission check in `ValidateConfiguration` when `Datasets` is set
- Export all `Connect*` functions for use in tests and tooling

Validated against all 21 BQ customer workspaces (37 integrations, ~40K tables total): 0 failures, only minor timing diffs on actively-written tables.

Related: [PR-7039](https://linear.app/synq/issue/PR-7039), [PR-6954](https://linear.app/synq/issue/PR-6954)