### PR TITLE
dwhsupport: wire BigQuery datasets field from proto

### DIFF
--- a/connect/connect.go
+++ b/connect/connect.go
@@ -37,6 +37,7 @@ func BigQuery(ctx context.Context, t *agentdwhv1.BigQueryConf) (*scrapperbigquer
 			CredentialsJson: t.GetServiceAccountKey(),
 			CredentialsFile: t.GetServiceAccountKeyFile(),
 		},
+		Datasets: t.GetDatasets(),
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/getsynq/dwhsupport
 go 1.25.5
 
 require (
-	buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260324141730-859a5d6c27f3.1
+	buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260410075358-d0c979344098.1
 	cloud.google.com/go v0.121.6
 	cloud.google.com/go/bigquery v1.69.0
 	github.com/ClickHouse/ch-go v0.68.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1 h1:PMmTMyvHScV9Mn8wc6ASge9uRcHy0jtqPd+fM35LmsQ=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
-buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260324141730-859a5d6c27f3.1 h1:Em1B9xcQFbOsMcd8yNuuk82CP2tYIwRgWnT7PU/XqxY=
-buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260324141730-859a5d6c27f3.1/go.mod h1:TOEu9lrXJ0CuMq3lFyZRfqabnKBXTBkwpWebF6tli90=
+buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260410075358-d0c979344098.1 h1:NgtnPfVDWNIPCDBQIRgLNf1cs7WHLuK0N6FE6gt6iJc=
+buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260410075358-d0c979344098.1/go.mod h1:TOEu9lrXJ0CuMq3lFyZRfqabnKBXTBkwpWebF6tli90=
 cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
 cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 cloud.google.com/go v0.121.6 h1:waZiuajrI28iAf40cWgycWNgaXPO06dupuS+sgibK6c=

--- a/yamlconfig/convert.go
+++ b/yamlconfig/convert.go
@@ -131,6 +131,7 @@ func bigqueryConfToProto(c *BigQueryConf) *agentdwhv1.BigQueryConf {
 		Region:                c.Region,
 		ServiceAccountKey:     c.ServiceAccountKey,
 		ServiceAccountKeyFile: c.ServiceAccountKeyFile,
+		Datasets:              c.Datasets,
 	}
 }
 

--- a/yamlconfig/convert_reverse.go
+++ b/yamlconfig/convert_reverse.go
@@ -96,6 +96,7 @@ func bigqueryConfFromProto(c *agentdwhv1.BigQueryConf) *BigQueryConf {
 		Region:                c.GetRegion(),
 		ServiceAccountKey:     c.GetServiceAccountKey(),
 		ServiceAccountKeyFile: c.GetServiceAccountKeyFile(),
+		Datasets:              c.GetDatasets(),
 	}
 }
 

--- a/yamlconfig/types.go
+++ b/yamlconfig/types.go
@@ -119,6 +119,9 @@ type BigQueryConf struct {
 	ServiceAccountKey string `yaml:"service_account_key,omitempty"`
 	// Path to the service account key JSON file.
 	ServiceAccountKeyFile string `yaml:"service_account_key_file,omitempty"`
+	// Explicit list of dataset names to scrape. When set, only these datasets are queried
+	// and project-level bigquery.datasets.list permission is not required.
+	Datasets []string `yaml:"datasets,omitempty"`
 }
 
 // fileFields returns file field pairs for BigQuery.


### PR DESCRIPTION
## Summary

- Update buf proto dependency to include the new `datasets` field on `BigQueryConf`
- Wire `datasets` through `connect/` and `yamlconfig/` so the agent and YAML configs can pass explicit dataset lists to the BigQuery scrapper

Backports getsynq/cloud#20374 dataset allowlist to dwhsupport.

Related: [PR-7039](https://linear.app/synq/issue/PR-7039), [PR-6954](https://linear.app/synq/issue/PR-6954)