### PR TITLE
snowflake: skip default database for user-level auth (OAuth, SSO)

### DIFF
--- a/exec/snowflake/auth_type_test.go
+++ b/exec/snowflake/auth_type_test.go
@@ -19,9 +19,10 @@ func TestSnowflakeAuthTypeTestSuite(t *testing.T) {
 
 func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_ExternalBrowser() {
 	conf := &SnowflakeConf{
-		Account:  "myaccount",
-		User:     "user@example.com",
-		AuthType: "externalbrowser",
+		Account:   "myaccount",
+		User:      "user@example.com",
+		AuthType:  "externalbrowser",
+		Databases: []string{"DB1", "DB2"},
 	}
 	c := buildSnowflakeConfig(conf)
 
@@ -29,6 +30,9 @@ func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_ExternalBrowser() {
 	s.Equal(120*time.Second, c.ExternalBrowserTimeout)
 	s.Equal(gosnowflake.ConfigBoolTrue, c.ClientStoreTemporaryCredential)
 	s.Equal(gosnowflake.ConfigBoolFalse, c.DisableConsoleLogin)
+	// SSO connections should not set a default database — the user's role
+	// may not have access to the workspace integration's databases.
+	s.Empty(c.Database)
 }
 
 func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_ExternalBrowserCaseInsensitive() {
@@ -76,9 +80,10 @@ func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_DefaultAuthType_Unrecognize
 
 func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_OAuthToken() {
 	conf := &SnowflakeConf{
-		Account: "myaccount",
-		Token:   "my-oauth-access-token",
-		Role:    "PUBLIC",
+		Account:   "myaccount",
+		Token:     "my-oauth-access-token",
+		Role:      "PUBLIC",
+		Databases: []string{"DB1", "DB2"},
 	}
 	c := buildSnowflakeConfig(conf)
 
@@ -86,6 +91,21 @@ func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_OAuthToken() {
 	s.Equal("my-oauth-access-token", c.Token)
 	s.Equal("PUBLIC", c.Role)
 	s.Equal(gosnowflake.ConfigBoolTrue, c.DisableConsoleLogin)
+	// OAuth connections should not set a default database — the user's role
+	// may not have access to the workspace integration's databases.
+	s.Empty(c.Database)
+}
+
+func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_PasswordSetsDefaultDatabase() {
+	conf := &SnowflakeConf{
+		Account:   "myaccount",
+		User:      "svc_user",
+		Password:  "password",
+		Databases: []string{"DB1", "DB2"},
+	}
+	c := buildSnowflakeConfig(conf)
+
+	s.Equal("DB1", c.Database)
 }
 
 func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_OAuthTokenTakesPrecedence() {

--- a/exec/snowflake/snowflake.go
+++ b/exec/snowflake/snowflake.go
@@ -137,8 +137,12 @@ func cleanAccountName(account string) string {
 // This is separated from NewSnowflakeExecutor to allow unit testing of the configuration logic.
 // Note: This function does not handle PrivateKeyFile loading (requires file I/O) - that's done in NewSnowflakeExecutor.
 func buildSnowflakeConfig(conf *SnowflakeConf) *gosnowflake.Config {
+	// When connecting as an individual user (OAuth token or SSO browser), don't set a
+	// default database on the connection. The user's role may not have access to the
+	// databases configured in the workspace integration. Queries use fully qualified names.
+	isUserAuth := conf.Token != "" || strings.ToLower(conf.AuthType) == "externalbrowser"
 	database := ""
-	if len(conf.Databases) > 0 {
+	if !isUserAuth && len(conf.Databases) > 0 {
 		database = conf.Databases[0]
 	}
 


### PR DESCRIPTION
## Summary

- When connecting with OAuth tokens or SSO (externalbrowser), don't set the first configured database as the connection's default database
- The user's role may not have access to the workspace integration's databases, causing immediate `390201 (08004): The requested database does not exist or not authorized` connection failures
- Service account connections (password, private key) continue to set the default database as before
- Queries should use fully qualified table names instead of relying on a default database