### PR TITLE
scrapper: add sanitize and reject wrappers for NUL/invalid UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,29 @@ tables, err := inner.QueryTables(ctx) // filter conditions pushed into SQL
 - **SQL push-down** — scope conditions are injected directly into warehouse queries for efficiency
 - **Post-filtering** — results are filtered in-memory to guarantee compliance
 
+### String Sanitization
+
+NUL bytes (`\x00`) and invalid UTF-8 occasionally leak in from warehouse data (e.g. a
+Snowflake row containing a stray NUL) and break downstream systems that expect clean
+UTF-8 text. Two composable decorators cover the two reasonable responses:
+
+- `scrapper/sanitize` — strips bad bytes in place on every returned row. Clean strings
+  are returned unchanged with zero allocation. Safe for content fields (descriptions,
+  SQL, tag values) where a repaired string is still meaningful.
+- `scrapper/reject` — drops rows whose **identity** fields (those forming the FQN) are
+  invalid, logging each drop via logrus. Appropriate when a sanitised identifier
+  would either collide with another object or fail to resolve against the warehouse.
+  Bad nested items (tags, annotations, constraints, struct fields) are filtered out
+  individually rather than dropping the whole row.
+
+```go
+// Reject unusable rows first, then sanitise the content of what remains.
+safe := sanitize.NewSanitizingScrapper(reject.NewRejectingScrapper(inner))
+
+// Compose with ScopedScrapper as needed.
+scoped := scope.NewScopedScrapper(safe, filter)
+```
+
 ### Query Stats
 
 The `exec/querystats` package provides query execution statistics via context:

--- a/scrapper/identity.go
+++ b/scrapper/identity.go
@@ -1,0 +1,134 @@
+package scrapper
+
+// HasValidIdentity reports whether all identity fields of the row — those that
+// form the object's fully-qualified name — are free of NUL bytes and valid UTF-8.
+// A row with an invalid identity cannot be safely addressed downstream and should
+// be dropped rather than sanitised (a sanitised name might collide with another
+// object or refer to nothing that exists in the warehouse).
+
+func (r *TableMetricsRow) HasValidIdentity() bool {
+	if r == nil {
+		return false
+	}
+	return IsValidString(r.Instance) && IsValidString(r.Database) && IsValidString(r.Schema) && IsValidString(r.Table)
+}
+
+func (r *CatalogColumnRow) HasValidIdentity() bool {
+	if r == nil {
+		return false
+	}
+	return IsValidString(r.Instance) &&
+		IsValidString(r.Database) &&
+		IsValidString(r.Schema) &&
+		IsValidString(r.Table) &&
+		IsValidString(r.Column)
+}
+
+func (r *TableRow) HasValidIdentity() bool {
+	if r == nil {
+		return false
+	}
+	return IsValidString(r.Instance) && IsValidString(r.Database) && IsValidString(r.Schema) && IsValidString(r.Table)
+}
+
+func (r *SqlDefinitionRow) HasValidIdentity() bool {
+	if r == nil {
+		return false
+	}
+	return IsValidString(r.Instance) && IsValidString(r.Database) && IsValidString(r.Schema) && IsValidString(r.Table)
+}
+
+func (r *DatabaseRow) HasValidIdentity() bool {
+	if r == nil {
+		return false
+	}
+	return IsValidString(r.Instance) && IsValidString(r.Database)
+}
+
+func (r *TableConstraintRow) HasValidIdentity() bool {
+	if r == nil {
+		return false
+	}
+	return IsValidString(r.Instance) &&
+		IsValidString(r.Database) &&
+		IsValidString(r.Schema) &&
+		IsValidString(r.Table) &&
+		IsValidString(r.ConstraintName) &&
+		IsValidString(r.ColumnName)
+}
+
+func (r *SegmentRow) HasValidIdentity() bool {
+	if r == nil {
+		return false
+	}
+	return IsValidString(r.Segment)
+}
+
+func (c *QueryShapeColumn) HasValidIdentity() bool {
+	if c == nil {
+		return false
+	}
+	return IsValidString(c.Name)
+}
+
+func (v *SegmentValue) HasValidIdentity() bool {
+	if v == nil {
+		return false
+	}
+	return IsValidString(v.Name)
+}
+
+func (v *ColumnValue) HasValidIdentity() bool {
+	if v == nil {
+		return false
+	}
+	return IsValidString(v.Name)
+}
+
+// HasValidIdentity on CustomMetricsRow requires every segment and column name to be valid;
+// a single bad identifier changes the meaning of the whole row, so we drop rather than partially filter.
+func (r *CustomMetricsRow) HasValidIdentity() bool {
+	if r == nil {
+		return false
+	}
+	for _, s := range r.Segments {
+		if !s.HasValidIdentity() {
+			return false
+		}
+	}
+	for _, c := range r.ColumnValues {
+		if !c.HasValidIdentity() {
+			return false
+		}
+	}
+	return true
+}
+
+func (t *Tag) HasValidIdentity() bool {
+	if t == nil {
+		return false
+	}
+	return IsValidString(t.TagName) && IsValidString(t.TagValue)
+}
+
+func (a *Annotation) HasValidIdentity() bool {
+	if a == nil {
+		return false
+	}
+	return IsValidString(a.AnnotationName) && IsValidString(a.AnnotationValue)
+}
+
+func (f *SchemaColumnField) HasValidIdentity() bool {
+	if f == nil {
+		return false
+	}
+	if !IsValidString(f.Name) || !IsValidString(f.HumanName) || !IsValidString(f.NativeType) {
+		return false
+	}
+	for _, child := range f.Fields {
+		if !child.HasValidIdentity() {
+			return false
+		}
+	}
+	return true
+}

--- a/scrapper/identity_test.go
+++ b/scrapper/identity_test.go
@@ -1,0 +1,54 @@
+package scrapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidString(t *testing.T) {
+	assert.True(t, IsValidString(""))
+	assert.True(t, IsValidString("hello"))
+	assert.True(t, IsValidString("hello — π"))
+	assert.False(t, IsValidString("a\x00b"), "NUL is valid UTF-8 but still rejected")
+	assert.False(t, IsValidString("a\xc3b"), "lone continuation byte")
+}
+
+func TestCatalogColumnRow_HasValidIdentity(t *testing.T) {
+	good := &CatalogColumnRow{Instance: "i", Database: "d", Schema: "s", Table: "t", Column: "c"}
+	assert.True(t, good.HasValidIdentity())
+
+	bad := &CatalogColumnRow{Instance: "i", Database: "d\x00", Schema: "s", Table: "t", Column: "c"}
+	assert.False(t, bad.HasValidIdentity())
+
+	var nilRow *CatalogColumnRow
+	assert.False(t, nilRow.HasValidIdentity())
+}
+
+func TestCustomMetricsRow_HasValidIdentity_BadSegment(t *testing.T) {
+	row := &CustomMetricsRow{
+		Segments: []*SegmentValue{
+			{Name: "ok", Value: "v"},
+			{Name: "bad\x00", Value: "v"},
+		},
+	}
+	assert.False(t, row.HasValidIdentity())
+}
+
+func TestSchemaColumnField_HasValidIdentity_Recursive(t *testing.T) {
+	good := &SchemaColumnField{
+		Name: "outer",
+		Fields: []*SchemaColumnField{
+			{Name: "inner"},
+		},
+	}
+	assert.True(t, good.HasValidIdentity())
+
+	bad := &SchemaColumnField{
+		Name: "outer",
+		Fields: []*SchemaColumnField{
+			{Name: "inner\x00"},
+		},
+	}
+	assert.False(t, bad.HasValidIdentity())
+}

--- a/scrapper/reject/rejecting_scrapper.go
+++ b/scrapper/reject/rejecting_scrapper.go
@@ -1,0 +1,155 @@
+// Package reject provides a Scrapper decorator that drops rows whose identity
+// fields (the parts forming an object's fully-qualified name) contain NUL bytes
+// or invalid UTF-8.
+//
+// Unlike sanitize, which repairs bad strings in place, reject discards the row
+// entirely — because a sanitised identifier might collide with another object or
+// fail to resolve against the warehouse. For non-identity content (descriptions,
+// SQL, tag values), compose with sanitize:
+//
+//	sanitize.NewSanitizingScrapper(reject.NewRejectingScrapper(inner))
+package reject
+
+import (
+	"context"
+	"time"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	"github.com/getsynq/dwhsupport/sqldialect"
+	"github.com/sirupsen/logrus"
+)
+
+type RejectingScrapper struct {
+	inner scrapper.Scrapper
+}
+
+func NewRejectingScrapper(inner scrapper.Scrapper) *RejectingScrapper {
+	return &RejectingScrapper{inner: inner}
+}
+
+func (s *RejectingScrapper) Capabilities() scrapper.Capabilities { return s.inner.Capabilities() }
+func (s *RejectingScrapper) DialectType() string                 { return s.inner.DialectType() }
+func (s *RejectingScrapper) SqlDialect() sqldialect.Dialect      { return s.inner.SqlDialect() }
+func (s *RejectingScrapper) IsPermissionError(err error) bool    { return s.inner.IsPermissionError(err) }
+func (s *RejectingScrapper) Close() error                        { return s.inner.Close() }
+
+func (s *RejectingScrapper) ValidateConfiguration(ctx context.Context) (warnings []string, err error) {
+	return s.inner.ValidateConfiguration(ctx)
+}
+
+type identified interface {
+	HasValidIdentity() bool
+}
+
+// filterValid returns only the entries with valid identity. Drops are logged
+// at Warn level with the scrapper's dialect and the calling method for traceability.
+func filterValid[T identified](rows []T, dialect, method string) []T {
+	kept := rows[:0]
+	dropped := 0
+	for _, r := range rows {
+		if r.HasValidIdentity() {
+			kept = append(kept, r)
+			continue
+		}
+		dropped++
+	}
+	if dropped > 0 {
+		logrus.WithFields(logrus.Fields{
+			"dialect": dialect,
+			"method":  method,
+			"dropped": dropped,
+			"kept":    len(kept),
+		}).Warn("rejected rows with invalid identity fields (NUL bytes or invalid UTF-8)")
+	}
+	return kept
+}
+
+func (s *RejectingScrapper) QueryCatalog(ctx context.Context) ([]*scrapper.CatalogColumnRow, error) {
+	rows, err := s.inner.QueryCatalog(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows = filterValid(rows, s.DialectType(), "QueryCatalog")
+	for _, r := range rows {
+		r.ColumnTags = filterValid(r.ColumnTags, s.DialectType(), "QueryCatalog.ColumnTags")
+		r.TableTags = filterValid(r.TableTags, s.DialectType(), "QueryCatalog.TableTags")
+		r.FieldSchemas = filterValid(r.FieldSchemas, s.DialectType(), "QueryCatalog.FieldSchemas")
+	}
+	return rows, nil
+}
+
+func (s *RejectingScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFetchTime time.Time) ([]*scrapper.TableMetricsRow, error) {
+	rows, err := s.inner.QueryTableMetrics(ctx, lastMetricsFetchTime)
+	if err != nil {
+		return nil, err
+	}
+	return filterValid(rows, s.DialectType(), "QueryTableMetrics"), nil
+}
+
+func (s *RejectingScrapper) QuerySqlDefinitions(ctx context.Context) ([]*scrapper.SqlDefinitionRow, error) {
+	rows, err := s.inner.QuerySqlDefinitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows = filterValid(rows, s.DialectType(), "QuerySqlDefinitions")
+	for _, r := range rows {
+		r.Tags = filterValid(r.Tags, s.DialectType(), "QuerySqlDefinitions.Tags")
+	}
+	return rows, nil
+}
+
+func (s *RejectingScrapper) QueryTables(ctx context.Context, opts ...scrapper.QueryTablesOption) ([]*scrapper.TableRow, error) {
+	rows, err := s.inner.QueryTables(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	rows = filterValid(rows, s.DialectType(), "QueryTables")
+	for _, r := range rows {
+		r.Tags = filterValid(r.Tags, s.DialectType(), "QueryTables.Tags")
+		r.Annotations = filterValid(r.Annotations, s.DialectType(), "QueryTables.Annotations")
+		r.Constraints = filterValid(r.Constraints, s.DialectType(), "QueryTables.Constraints")
+	}
+	return rows, nil
+}
+
+func (s *RejectingScrapper) QueryDatabases(ctx context.Context) ([]*scrapper.DatabaseRow, error) {
+	rows, err := s.inner.QueryDatabases(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return filterValid(rows, s.DialectType(), "QueryDatabases"), nil
+}
+
+func (s *RejectingScrapper) QuerySegments(ctx context.Context, sql string, args ...any) ([]*scrapper.SegmentRow, error) {
+	rows, err := s.inner.QuerySegments(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	return filterValid(rows, s.DialectType(), "QuerySegments"), nil
+}
+
+func (s *RejectingScrapper) QueryCustomMetrics(ctx context.Context, sql string, args ...any) ([]*scrapper.CustomMetricsRow, error) {
+	rows, err := s.inner.QueryCustomMetrics(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	return filterValid(rows, s.DialectType(), "QueryCustomMetrics"), nil
+}
+
+func (s *RejectingScrapper) QueryShape(ctx context.Context, sql string) ([]*scrapper.QueryShapeColumn, error) {
+	cols, err := s.inner.QueryShape(ctx, sql)
+	if err != nil {
+		return nil, err
+	}
+	return filterValid(cols, s.DialectType(), "QueryShape"), nil
+}
+
+func (s *RejectingScrapper) QueryTableConstraints(ctx context.Context) ([]*scrapper.TableConstraintRow, error) {
+	rows, err := s.inner.QueryTableConstraints(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return filterValid(rows, s.DialectType(), "QueryTableConstraints"), nil
+}
+
+var _ scrapper.Scrapper = (*RejectingScrapper)(nil)

--- a/scrapper/reject/rejecting_scrapper_test.go
+++ b/scrapper/reject/rejecting_scrapper_test.go
@@ -1,0 +1,170 @@
+package reject
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	"github.com/getsynq/dwhsupport/sqldialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubScrapper struct {
+	catalog     []*scrapper.CatalogColumnRow
+	tables      []*scrapper.TableRow
+	metrics     []*scrapper.TableMetricsRow
+	sqlDefs     []*scrapper.SqlDefinitionRow
+	databases   []*scrapper.DatabaseRow
+	constraints []*scrapper.TableConstraintRow
+	segments    []*scrapper.SegmentRow
+	customMet   []*scrapper.CustomMetricsRow
+	shape       []*scrapper.QueryShapeColumn
+}
+
+func (s *stubScrapper) Capabilities() scrapper.Capabilities { return scrapper.Capabilities{} }
+func (s *stubScrapper) DialectType() string                 { return "stub" }
+func (s *stubScrapper) SqlDialect() sqldialect.Dialect      { return nil }
+func (s *stubScrapper) IsPermissionError(error) bool        { return false }
+func (s *stubScrapper) Close() error                        { return nil }
+func (s *stubScrapper) ValidateConfiguration(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (s *stubScrapper) QueryCatalog(context.Context) ([]*scrapper.CatalogColumnRow, error) {
+	return s.catalog, nil
+}
+
+func (s *stubScrapper) QueryTableMetrics(context.Context, time.Time) ([]*scrapper.TableMetricsRow, error) {
+	return s.metrics, nil
+}
+
+func (s *stubScrapper) QuerySqlDefinitions(context.Context) ([]*scrapper.SqlDefinitionRow, error) {
+	return s.sqlDefs, nil
+}
+
+func (s *stubScrapper) QueryTables(context.Context, ...scrapper.QueryTablesOption) ([]*scrapper.TableRow, error) {
+	return s.tables, nil
+}
+
+func (s *stubScrapper) QueryDatabases(context.Context) ([]*scrapper.DatabaseRow, error) {
+	return s.databases, nil
+}
+
+func (s *stubScrapper) QuerySegments(context.Context, string, ...any) ([]*scrapper.SegmentRow, error) {
+	return s.segments, nil
+}
+
+func (s *stubScrapper) QueryCustomMetrics(context.Context, string, ...any) ([]*scrapper.CustomMetricsRow, error) {
+	return s.customMet, nil
+}
+
+func (s *stubScrapper) QueryShape(context.Context, string) ([]*scrapper.QueryShapeColumn, error) {
+	return s.shape, nil
+}
+
+func (s *stubScrapper) QueryTableConstraints(context.Context) ([]*scrapper.TableConstraintRow, error) {
+	return s.constraints, nil
+}
+
+func TestRejectingScrapper_QueryCatalog_DropsBadRowsAndNestedTags(t *testing.T) {
+	comment := "desc\x00" // content NUL — content is NOT identity, row stays
+	inner := &stubScrapper{
+		catalog: []*scrapper.CatalogColumnRow{
+			{Database: "good_db", Schema: "s", Table: "t", Column: "c", Comment: &comment,
+				ColumnTags: []*scrapper.Tag{
+					{TagName: "ok", TagValue: "v"},
+					{TagName: "bad\x00", TagValue: "v"},
+				},
+				FieldSchemas: []*scrapper.SchemaColumnField{
+					{Name: "ok_field"},
+					{Name: "bad\x00field"},
+				},
+			},
+			{Database: "bad\x00db", Schema: "s", Table: "t", Column: "c"},
+		},
+	}
+	ss := NewRejectingScrapper(inner)
+	rows, err := ss.QueryCatalog(context.Background())
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "row with NUL in Database must be dropped")
+	assert.Equal(t, "good_db", rows[0].Database)
+	require.Len(t, rows[0].ColumnTags, 1)
+	assert.Equal(t, "ok", rows[0].ColumnTags[0].TagName)
+	require.Len(t, rows[0].FieldSchemas, 1)
+	assert.Equal(t, "ok_field", rows[0].FieldSchemas[0].Name)
+	// Content field passes through untouched — caller composes with sanitize to clean it.
+	require.NotNil(t, rows[0].Comment)
+	assert.Equal(t, "desc\x00", *rows[0].Comment)
+}
+
+func TestRejectingScrapper_QueryTables_FiltersNested(t *testing.T) {
+	inner := &stubScrapper{
+		tables: []*scrapper.TableRow{
+			{
+				Database: "db", Schema: "s", Table: "t",
+				Tags:        []*scrapper.Tag{{TagName: "k", TagValue: "v"}, {TagName: "k\x00", TagValue: "v"}},
+				Annotations: []*scrapper.Annotation{{AnnotationName: "ok", AnnotationValue: "v"}, nil},
+				Constraints: []*scrapper.TableConstraintRow{
+					{Instance: "i", Database: "db", Schema: "s", Table: "t", ConstraintName: "pk", ColumnName: "id"},
+					{Instance: "i", Database: "db", Schema: "s", Table: "t\x00", ConstraintName: "pk", ColumnName: "id"},
+				},
+			},
+			{Database: "db\x00"},
+		},
+	}
+	ss := NewRejectingScrapper(inner)
+	rows, err := ss.QueryTables(context.Background())
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Len(t, rows[0].Tags, 1)
+	require.Len(t, rows[0].Annotations, 1)
+	require.Len(t, rows[0].Constraints, 1)
+	assert.Equal(t, "pk", rows[0].Constraints[0].ConstraintName)
+}
+
+func TestRejectingScrapper_SimpleRowTypes(t *testing.T) {
+	inner := &stubScrapper{
+		metrics:     []*scrapper.TableMetricsRow{{Database: "ok", Table: "t"}, {Database: "bad\x00", Table: "t"}},
+		sqlDefs:     []*scrapper.SqlDefinitionRow{{Database: "ok"}, {Database: "bad\x00"}},
+		databases:   []*scrapper.DatabaseRow{{Database: "ok"}, {Database: "bad\x00"}},
+		constraints: []*scrapper.TableConstraintRow{{Database: "ok", ConstraintName: "pk", ColumnName: "id"}, {Database: "bad\x00"}},
+		segments:    []*scrapper.SegmentRow{{Segment: "ok"}, {Segment: "bad\x00"}},
+		customMet: []*scrapper.CustomMetricsRow{
+			{Segments: []*scrapper.SegmentValue{{Name: "ok"}}},
+			{Segments: []*scrapper.SegmentValue{{Name: "bad\x00"}}},
+		},
+		shape: []*scrapper.QueryShapeColumn{{Name: "ok"}, {Name: "bad\x00"}},
+	}
+	ss := NewRejectingScrapper(inner)
+	ctx := context.Background()
+
+	met, err := ss.QueryTableMetrics(ctx, time.Time{})
+	require.NoError(t, err)
+	assert.Len(t, met, 1)
+
+	defs, err := ss.QuerySqlDefinitions(ctx)
+	require.NoError(t, err)
+	assert.Len(t, defs, 1)
+
+	dbs, err := ss.QueryDatabases(ctx)
+	require.NoError(t, err)
+	assert.Len(t, dbs, 1)
+
+	cons, err := ss.QueryTableConstraints(ctx)
+	require.NoError(t, err)
+	assert.Len(t, cons, 1)
+
+	segs, err := ss.QuerySegments(ctx, "sql")
+	require.NoError(t, err)
+	assert.Len(t, segs, 1)
+
+	cm, err := ss.QueryCustomMetrics(ctx, "sql")
+	require.NoError(t, err)
+	assert.Len(t, cm, 1)
+
+	shape, err := ss.QueryShape(ctx, "sql")
+	require.NoError(t, err)
+	assert.Len(t, shape, 1)
+}

--- a/scrapper/sanitize.go
+++ b/scrapper/sanitize.go
@@ -1,0 +1,203 @@
+package scrapper
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// IsValidString reports whether s contains no NUL bytes and is valid UTF-8.
+// Used both as the fast-path check in SanitizeString and as the identity-field
+// validity predicate by the rejecting scrapper decorator.
+func IsValidString(s string) bool {
+	return strings.IndexByte(s, 0) == -1 && utf8.ValidString(s)
+}
+
+// SanitizeString drops NUL bytes and invalid UTF-8 sequences.
+// Returns the input unchanged (no allocation) when it contains neither — the common case.
+// Dropping rather than substituting (e.g. with U+FFFD) avoids visible replacement-character
+// artifacts in downstream UIs that would otherwise surface data corruption to end users.
+func SanitizeString(s string) string {
+	if IsValidString(s) {
+		return s
+	}
+	return strings.ReplaceAll(strings.ToValidUTF8(s, ""), "\x00", "")
+}
+
+// SanitizeStringPtr applies SanitizeString through a *string, leaving nil pointers untouched.
+func SanitizeStringPtr(s *string) {
+	if s == nil {
+		return
+	}
+	*s = SanitizeString(*s)
+}
+
+func (r *TableMetricsRow) Sanitize() {
+	if r == nil {
+		return
+	}
+	r.Instance = SanitizeString(r.Instance)
+	r.Database = SanitizeString(r.Database)
+	r.Schema = SanitizeString(r.Schema)
+	r.Table = SanitizeString(r.Table)
+}
+
+func (t *Tag) Sanitize() {
+	if t == nil {
+		return
+	}
+	t.TagName = SanitizeString(t.TagName)
+	t.TagValue = SanitizeString(t.TagValue)
+}
+
+func (a *Annotation) Sanitize() {
+	if a == nil {
+		return
+	}
+	a.AnnotationName = SanitizeString(a.AnnotationName)
+	a.AnnotationValue = SanitizeString(a.AnnotationValue)
+}
+
+func (f *SchemaColumnField) Sanitize() {
+	if f == nil {
+		return
+	}
+	f.Name = SanitizeString(f.Name)
+	f.HumanName = SanitizeString(f.HumanName)
+	f.NativeType = SanitizeString(f.NativeType)
+	SanitizeStringPtr(f.Description)
+	for _, child := range f.Fields {
+		child.Sanitize()
+	}
+}
+
+func (r *CatalogColumnRow) Sanitize() {
+	if r == nil {
+		return
+	}
+	r.Instance = SanitizeString(r.Instance)
+	r.Database = SanitizeString(r.Database)
+	r.Schema = SanitizeString(r.Schema)
+	r.Table = SanitizeString(r.Table)
+	r.TableType = SanitizeString(r.TableType)
+	r.Column = SanitizeString(r.Column)
+	r.Type = SanitizeString(r.Type)
+	SanitizeStringPtr(r.Comment)
+	SanitizeStringPtr(r.TableComment)
+	for _, t := range r.ColumnTags {
+		t.Sanitize()
+	}
+	for _, t := range r.TableTags {
+		t.Sanitize()
+	}
+	for _, f := range r.FieldSchemas {
+		f.Sanitize()
+	}
+}
+
+func (r *TableRow) Sanitize() {
+	if r == nil {
+		return
+	}
+	r.Instance = SanitizeString(r.Instance)
+	r.Database = SanitizeString(r.Database)
+	r.Schema = SanitizeString(r.Schema)
+	r.Table = SanitizeString(r.Table)
+	r.TableType = SanitizeString(r.TableType)
+	SanitizeStringPtr(r.Description)
+	for _, t := range r.Tags {
+		t.Sanitize()
+	}
+	for _, a := range r.Annotations {
+		a.Sanitize()
+	}
+	for _, c := range r.Constraints {
+		c.Sanitize()
+	}
+	// Options holds warehouse-specific metadata (map[string]interface{}); its string
+	// values originate from typed warehouse APIs (bigquery.TableMetadata, etc.) rather
+	// than raw column data, so they are not sanitised here.
+}
+
+func (r *SqlDefinitionRow) Sanitize() {
+	if r == nil {
+		return
+	}
+	r.Instance = SanitizeString(r.Instance)
+	r.Database = SanitizeString(r.Database)
+	r.Schema = SanitizeString(r.Schema)
+	r.Table = SanitizeString(r.Table)
+	r.TableType = SanitizeString(r.TableType)
+	r.Sql = SanitizeString(r.Sql)
+	SanitizeStringPtr(r.Description)
+	for _, t := range r.Tags {
+		t.Sanitize()
+	}
+}
+
+func (r *DatabaseRow) Sanitize() {
+	if r == nil {
+		return
+	}
+	r.Instance = SanitizeString(r.Instance)
+	r.Database = SanitizeString(r.Database)
+	SanitizeStringPtr(r.Description)
+	SanitizeStringPtr(r.DatabaseType)
+	SanitizeStringPtr(r.DatabaseOwner)
+}
+
+func (r *TableConstraintRow) Sanitize() {
+	if r == nil {
+		return
+	}
+	r.Instance = SanitizeString(r.Instance)
+	r.Database = SanitizeString(r.Database)
+	r.Schema = SanitizeString(r.Schema)
+	r.Table = SanitizeString(r.Table)
+	r.ConstraintName = SanitizeString(r.ConstraintName)
+	r.ColumnName = SanitizeString(r.ColumnName)
+	r.ConstraintType = SanitizeString(r.ConstraintType)
+	r.ConstraintExpression = SanitizeString(r.ConstraintExpression)
+}
+
+func (r *SegmentRow) Sanitize() {
+	if r == nil {
+		return
+	}
+	r.Segment = SanitizeString(r.Segment)
+}
+
+func (c *QueryShapeColumn) Sanitize() {
+	if c == nil {
+		return
+	}
+	c.Name = SanitizeString(c.Name)
+	c.NativeType = SanitizeString(c.NativeType)
+}
+
+func (v *SegmentValue) Sanitize() {
+	if v == nil {
+		return
+	}
+	v.Name = SanitizeString(v.Name)
+	v.Value = SanitizeString(v.Value)
+}
+
+func (v *ColumnValue) Sanitize() {
+	if v == nil {
+		return
+	}
+	v.Name = SanitizeString(v.Name)
+	// Value is a typed Value interface (numeric or time) — never carries strings.
+}
+
+func (r *CustomMetricsRow) Sanitize() {
+	if r == nil {
+		return
+	}
+	for _, s := range r.Segments {
+		s.Sanitize()
+	}
+	for _, c := range r.ColumnValues {
+		c.Sanitize()
+	}
+}

--- a/scrapper/sanitize/sanitizing_scrapper.go
+++ b/scrapper/sanitize/sanitizing_scrapper.go
@@ -1,0 +1,139 @@
+// Package sanitize provides a Scrapper decorator that strips NUL bytes and
+// repairs invalid UTF-8 in every row returned by the underlying scrapper.
+// Downstream systems (Postgres text columns, JSON encoders, protobuf text fields)
+// reject these byte sequences, so every scrapper should be wrapped at construction.
+package sanitize
+
+import (
+	"context"
+	"time"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	"github.com/getsynq/dwhsupport/sqldialect"
+)
+
+type SanitizingScrapper struct {
+	inner scrapper.Scrapper
+}
+
+// NewSanitizingScrapper wraps inner so that every returned row has its string
+// fields cleaned via each row type's Sanitize() method. Clean strings are returned
+// unchanged with zero allocation, so the overhead on well-formed data is negligible.
+func NewSanitizingScrapper(inner scrapper.Scrapper) *SanitizingScrapper {
+	return &SanitizingScrapper{inner: inner}
+}
+
+func (s *SanitizingScrapper) Capabilities() scrapper.Capabilities { return s.inner.Capabilities() }
+func (s *SanitizingScrapper) DialectType() string                 { return s.inner.DialectType() }
+func (s *SanitizingScrapper) SqlDialect() sqldialect.Dialect      { return s.inner.SqlDialect() }
+func (s *SanitizingScrapper) IsPermissionError(err error) bool    { return s.inner.IsPermissionError(err) }
+func (s *SanitizingScrapper) Close() error                        { return s.inner.Close() }
+
+func (s *SanitizingScrapper) ValidateConfiguration(ctx context.Context) (warnings []string, err error) {
+	warnings, err = s.inner.ValidateConfiguration(ctx)
+	for i, w := range warnings {
+		warnings[i] = scrapper.SanitizeString(w)
+	}
+	return warnings, err
+}
+
+func (s *SanitizingScrapper) QueryCatalog(ctx context.Context) ([]*scrapper.CatalogColumnRow, error) {
+	rows, err := s.inner.QueryCatalog(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		r.Sanitize()
+	}
+	return rows, nil
+}
+
+func (s *SanitizingScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFetchTime time.Time) ([]*scrapper.TableMetricsRow, error) {
+	rows, err := s.inner.QueryTableMetrics(ctx, lastMetricsFetchTime)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		r.Sanitize()
+	}
+	return rows, nil
+}
+
+func (s *SanitizingScrapper) QuerySqlDefinitions(ctx context.Context) ([]*scrapper.SqlDefinitionRow, error) {
+	rows, err := s.inner.QuerySqlDefinitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		r.Sanitize()
+	}
+	return rows, nil
+}
+
+func (s *SanitizingScrapper) QueryTables(ctx context.Context, opts ...scrapper.QueryTablesOption) ([]*scrapper.TableRow, error) {
+	rows, err := s.inner.QueryTables(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		r.Sanitize()
+	}
+	return rows, nil
+}
+
+func (s *SanitizingScrapper) QueryDatabases(ctx context.Context) ([]*scrapper.DatabaseRow, error) {
+	rows, err := s.inner.QueryDatabases(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		r.Sanitize()
+	}
+	return rows, nil
+}
+
+func (s *SanitizingScrapper) QuerySegments(ctx context.Context, sql string, args ...any) ([]*scrapper.SegmentRow, error) {
+	rows, err := s.inner.QuerySegments(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		r.Sanitize()
+	}
+	return rows, nil
+}
+
+func (s *SanitizingScrapper) QueryCustomMetrics(ctx context.Context, sql string, args ...any) ([]*scrapper.CustomMetricsRow, error) {
+	rows, err := s.inner.QueryCustomMetrics(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		r.Sanitize()
+	}
+	return rows, nil
+}
+
+func (s *SanitizingScrapper) QueryShape(ctx context.Context, sql string) ([]*scrapper.QueryShapeColumn, error) {
+	cols, err := s.inner.QueryShape(ctx, sql)
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range cols {
+		c.Sanitize()
+	}
+	return cols, nil
+}
+
+func (s *SanitizingScrapper) QueryTableConstraints(ctx context.Context) ([]*scrapper.TableConstraintRow, error) {
+	rows, err := s.inner.QueryTableConstraints(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		r.Sanitize()
+	}
+	return rows, nil
+}
+
+var _ scrapper.Scrapper = (*SanitizingScrapper)(nil)

--- a/scrapper/sanitize/sanitizing_scrapper_test.go
+++ b/scrapper/sanitize/sanitizing_scrapper_test.go
@@ -1,0 +1,157 @@
+package sanitize
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	"github.com/getsynq/dwhsupport/sqldialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubScrapper struct {
+	catalog     []*scrapper.CatalogColumnRow
+	tables      []*scrapper.TableRow
+	metrics     []*scrapper.TableMetricsRow
+	sqlDefs     []*scrapper.SqlDefinitionRow
+	databases   []*scrapper.DatabaseRow
+	constraints []*scrapper.TableConstraintRow
+	segments    []*scrapper.SegmentRow
+	customMet   []*scrapper.CustomMetricsRow
+	shape       []*scrapper.QueryShapeColumn
+	warnings    []string
+}
+
+func (s *stubScrapper) Capabilities() scrapper.Capabilities { return scrapper.Capabilities{} }
+func (s *stubScrapper) DialectType() string                 { return "stub" }
+func (s *stubScrapper) SqlDialect() sqldialect.Dialect      { return nil }
+func (s *stubScrapper) IsPermissionError(error) bool        { return false }
+func (s *stubScrapper) Close() error                        { return nil }
+
+func (s *stubScrapper) ValidateConfiguration(context.Context) ([]string, error) {
+	return s.warnings, nil
+}
+
+func (s *stubScrapper) QueryCatalog(context.Context) ([]*scrapper.CatalogColumnRow, error) {
+	return s.catalog, nil
+}
+
+func (s *stubScrapper) QueryTableMetrics(context.Context, time.Time) ([]*scrapper.TableMetricsRow, error) {
+	return s.metrics, nil
+}
+
+func (s *stubScrapper) QuerySqlDefinitions(context.Context) ([]*scrapper.SqlDefinitionRow, error) {
+	return s.sqlDefs, nil
+}
+
+func (s *stubScrapper) QueryTables(context.Context, ...scrapper.QueryTablesOption) ([]*scrapper.TableRow, error) {
+	return s.tables, nil
+}
+
+func (s *stubScrapper) QueryDatabases(context.Context) ([]*scrapper.DatabaseRow, error) {
+	return s.databases, nil
+}
+
+func (s *stubScrapper) QuerySegments(context.Context, string, ...any) ([]*scrapper.SegmentRow, error) {
+	return s.segments, nil
+}
+
+func (s *stubScrapper) QueryCustomMetrics(context.Context, string, ...any) ([]*scrapper.CustomMetricsRow, error) {
+	return s.customMet, nil
+}
+
+func (s *stubScrapper) QueryShape(context.Context, string) ([]*scrapper.QueryShapeColumn, error) {
+	return s.shape, nil
+}
+
+func (s *stubScrapper) QueryTableConstraints(context.Context) ([]*scrapper.TableConstraintRow, error) {
+	return s.constraints, nil
+}
+
+func TestSanitizingScrapper_CleansAllSources(t *testing.T) {
+	inner := &stubScrapper{
+		catalog: []*scrapper.CatalogColumnRow{
+			{Database: "db\x00", Table: "t\x00", Column: "c"},
+		},
+		tables: []*scrapper.TableRow{
+			{Database: "db\x00", Table: "t\x00"},
+		},
+		metrics: []*scrapper.TableMetricsRow{
+			{Database: "db\x00", Table: "t"},
+		},
+		sqlDefs: []*scrapper.SqlDefinitionRow{
+			{Database: "db\x00", Sql: "select \x00 from x"},
+		},
+		databases: []*scrapper.DatabaseRow{
+			{Database: "db\x00"},
+		},
+		constraints: []*scrapper.TableConstraintRow{
+			{Database: "db\x00", ConstraintName: "pk\x00"},
+		},
+		segments: []*scrapper.SegmentRow{
+			{Segment: "seg\x00"},
+		},
+		customMet: []*scrapper.CustomMetricsRow{
+			{Segments: []*scrapper.SegmentValue{{Name: "n\x00", Value: "v"}}},
+		},
+		shape: []*scrapper.QueryShapeColumn{
+			{Name: "col\x00", NativeType: "INT\x00"},
+		},
+		warnings: []string{"warn\x00ing"},
+	}
+	ss := NewSanitizingScrapper(inner)
+	ctx := context.Background()
+
+	cat, err := ss.QueryCatalog(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "db", cat[0].Database)
+	assert.Equal(t, "t", cat[0].Table)
+
+	tbl, err := ss.QueryTables(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "t", tbl[0].Table)
+
+	met, err := ss.QueryTableMetrics(ctx, time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, "db", met[0].Database)
+
+	defs, err := ss.QuerySqlDefinitions(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "select  from x", defs[0].Sql)
+
+	dbs, err := ss.QueryDatabases(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "db", dbs[0].Database)
+
+	cons, err := ss.QueryTableConstraints(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "pk", cons[0].ConstraintName)
+
+	segs, err := ss.QuerySegments(ctx, "sql")
+	require.NoError(t, err)
+	assert.Equal(t, "seg", segs[0].Segment)
+
+	cm, err := ss.QueryCustomMetrics(ctx, "sql")
+	require.NoError(t, err)
+	assert.Equal(t, "n", cm[0].Segments[0].Name)
+
+	shape, err := ss.QueryShape(ctx, "sql")
+	require.NoError(t, err)
+	assert.Equal(t, "col", shape[0].Name)
+	assert.Equal(t, "INT", shape[0].NativeType)
+
+	warnings, err := ss.ValidateConfiguration(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"warning"}, warnings)
+}
+
+func TestSanitizingScrapper_PropagatesErrors(t *testing.T) {
+	// Errors bypass the loops — verified by not panicking on nil rows.
+	ss := NewSanitizingScrapper(&stubScrapper{})
+	ctx := context.Background()
+
+	_, err := ss.QueryCatalog(ctx)
+	assert.NoError(t, err)
+}

--- a/scrapper/sanitize_test.go
+++ b/scrapper/sanitize_test.go
@@ -1,0 +1,169 @@
+package scrapper
+
+import (
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeString_CleanPassthrough(t *testing.T) {
+	clean := "hello world — π"
+	out := SanitizeString(clean)
+	assert.Equal(t, clean, out)
+
+	// The clean path must share the input's backing array — proof we skipped the copy.
+	assert.Same(t, unsafe.StringData(clean), unsafe.StringData(out))
+}
+
+func TestSanitizeString_StripsNullBytes(t *testing.T) {
+	assert.Equal(t, "abc", SanitizeString("a\x00b\x00c"))
+	assert.Equal(t, "", SanitizeString("\x00\x00"))
+	assert.Equal(t, "trailing", SanitizeString("trailing\x00"))
+}
+
+func TestSanitizeString_DropsInvalidUTF8(t *testing.T) {
+	// Lone 0xC3 continuation byte without its follow-up — invalid UTF-8.
+	assert.Equal(t, "prepost", SanitizeString("pre\xc3post"))
+}
+
+func TestSanitizeString_HandlesBoth(t *testing.T) {
+	assert.Equal(t, "abc", SanitizeString("a\x00b\xc3c\x00"))
+}
+
+func TestSanitizeString_NoAllocOnCleanPath(t *testing.T) {
+	s := strings.Repeat("hello world ", 1000)
+	allocs := testing.AllocsPerRun(100, func() {
+		_ = SanitizeString(s)
+	})
+	assert.Zero(t, allocs, "clean path must not allocate")
+}
+
+func TestSanitizeStringPtr_NilSafe(t *testing.T) {
+	SanitizeStringPtr(nil)
+	s := "a\x00b"
+	SanitizeStringPtr(&s)
+	assert.Equal(t, "ab", s)
+}
+
+func TestCatalogColumnRow_Sanitize_Recursive(t *testing.T) {
+	comment := "col\x00comment"
+	row := &CatalogColumnRow{
+		Database:     "dirty\x00value",
+		Schema:       "ok",
+		Table:        "users\x00",
+		Column:       "id",
+		Type:         "INT",
+		Comment:      &comment,
+		TableComment: nil,
+		ColumnTags:   []*Tag{{TagName: "a\x00b", TagValue: "v"}},
+		TableTags:    []*Tag{nil, {TagName: "ok", TagValue: "also\x00bad"}},
+		FieldSchemas: []*SchemaColumnField{
+			{
+				Name:      "outer\x00",
+				HumanName: "Outer",
+				Fields: []*SchemaColumnField{
+					{Name: "inner\x00", NativeType: "STRING\x00"},
+				},
+			},
+		},
+	}
+	row.Sanitize()
+
+	assert.Equal(t, "dirtyvalue", row.Database)
+	assert.Equal(t, "users", row.Table)
+	require.NotNil(t, row.Comment)
+	assert.Equal(t, "colcomment", *row.Comment)
+	assert.Equal(t, "ab", row.ColumnTags[0].TagName)
+	assert.Nil(t, row.TableTags[0])
+	assert.Equal(t, "alsobad", row.TableTags[1].TagValue)
+	assert.Equal(t, "outer", row.FieldSchemas[0].Name)
+	assert.Equal(t, "inner", row.FieldSchemas[0].Fields[0].Name)
+	assert.Equal(t, "STRING", row.FieldSchemas[0].Fields[0].NativeType)
+}
+
+func TestTableRow_Sanitize(t *testing.T) {
+	desc := "hello\x00world"
+	row := &TableRow{
+		Database:    "db\x00",
+		Table:       "t",
+		Description: &desc,
+		Tags:        []*Tag{{TagName: "k\x00", TagValue: "v"}},
+		Annotations: []*Annotation{{AnnotationName: "a\x00", AnnotationValue: "b"}},
+		Constraints: []*TableConstraintRow{{ConstraintName: "pk\x00", ColumnName: "id"}},
+	}
+	row.Sanitize()
+
+	assert.Equal(t, "db", row.Database)
+	assert.Equal(t, "helloworld", *row.Description)
+	assert.Equal(t, "k", row.Tags[0].TagName)
+	assert.Equal(t, "a", row.Annotations[0].AnnotationName)
+	assert.Equal(t, "pk", row.Constraints[0].ConstraintName)
+}
+
+func TestDatabaseRow_Sanitize(t *testing.T) {
+	desc := "d\x00e"
+	owner := "ow\x00ner"
+	row := &DatabaseRow{
+		Database:      "db\x00",
+		Description:   &desc,
+		DatabaseOwner: &owner,
+	}
+	row.Sanitize()
+	assert.Equal(t, "db", row.Database)
+	assert.Equal(t, "de", *row.Description)
+	assert.Equal(t, "owner", *row.DatabaseOwner)
+	assert.Nil(t, row.DatabaseType)
+}
+
+func TestCustomMetricsRow_Sanitize(t *testing.T) {
+	row := &CustomMetricsRow{
+		Segments: []*SegmentValue{
+			{Name: "seg\x00", Value: "v\x00al"},
+			nil,
+		},
+		ColumnValues: []*ColumnValue{
+			{Name: "col\x00", Value: IntValue(1)},
+		},
+	}
+	row.Sanitize()
+	assert.Equal(t, "seg", row.Segments[0].Name)
+	assert.Equal(t, "val", row.Segments[0].Value)
+	assert.Equal(t, "col", row.ColumnValues[0].Name)
+	assert.Equal(t, IntValue(1), row.ColumnValues[0].Value)
+}
+
+func TestSanitize_NilReceiverSafe(t *testing.T) {
+	var (
+		cat    *CatalogColumnRow
+		table  *TableRow
+		sqldef *SqlDefinitionRow
+		db     *DatabaseRow
+		cons   *TableConstraintRow
+		seg    *SegmentRow
+		qs     *QueryShapeColumn
+		cm     *CustomMetricsRow
+		tag    *Tag
+		ann    *Annotation
+		fs     *SchemaColumnField
+		sv     *SegmentValue
+		cv     *ColumnValue
+		tm     *TableMetricsRow
+	)
+	cat.Sanitize()
+	table.Sanitize()
+	sqldef.Sanitize()
+	db.Sanitize()
+	cons.Sanitize()
+	seg.Sanitize()
+	qs.Sanitize()
+	cm.Sanitize()
+	tag.Sanitize()
+	ann.Sanitize()
+	fs.Sanitize()
+	sv.Sanitize()
+	cv.Sanitize()
+	tm.Sanitize()
+}


### PR DESCRIPTION
## Summary

Some warehouse rows (observed on Snowflake) contain NUL bytes (`\x00`) or invalid UTF-8 in object names and content. NUL is valid UTF-8 (U+0000), so `utf8.ValidString` alone does not catch it — but it still breaks Postgres `text` columns, C string APIs, and several JSON/protobuf encoders downstream.

Two composable `Scrapper` decorators cover the two reasonable responses:

- **`scrapper/sanitize`** — strips NUL and invalid UTF-8 in place on every returned row via typed pointer-receiver `Sanitize()` methods. Clean strings are returned unchanged with zero allocation (fast-path: `IsValidString` → short-circuit), so the overhead on well-formed data is negligible.
- **`scrapper/reject`** — drops rows whose **identity** fields (those forming the FQN — Instance/Database/Schema/Table, plus Column/ConstraintName where relevant) are invalid, logging each drop via logrus. Sanitising an identifier could collide with another object or fail to resolve, so dropping is safer. Bad nested items (tags, annotations, constraints, struct fields) are filtered out individually rather than nuking the parent row.

Typical wiring: `sanitize.NewSanitizingScrapper(reject.NewRejectingScrapper(inner))` — reject unaddressable rows first, then sanitise content of what remains. Composes with `scope.NewScopedScrapper` the same way.

Dropped bad bytes entirely rather than substituting U+FFFD, so end users don't see `�` artifacts in UIs.