### PR TITLE
scrapper: add Unwrap + As helper for decorator chains

### DIFF
--- a/scrapper/interface.go
+++ b/scrapper/interface.go
@@ -58,6 +58,33 @@ type Capabilities struct {
 	ConstraintsViaQueryTables bool
 }
 
+// Unwrapper is implemented by Scrapper decorators (sanitize, reject, scope, ...)
+// so callers can walk to an inner scrapper of a specific type. It mirrors the
+// errors.Unwrap idiom: together with As it lets code type-assert past arbitrary
+// decorator chains without each decorator having to know about every interface
+// a consumer might care about.
+type Unwrapper interface {
+	Unwrap() Scrapper
+}
+
+// As walks the decorator chain rooted at s (following Unwrap) and returns the
+// first value that type-asserts to T. Returns the zero T and false if no value
+// in the chain satisfies T. Safe to call with a nil Scrapper.
+func As[T any](s Scrapper) (T, bool) {
+	for s != nil {
+		if v, ok := s.(T); ok {
+			return v, true
+		}
+		u, ok := s.(Unwrapper)
+		if !ok {
+			break
+		}
+		s = u.Unwrap()
+	}
+	var zero T
+	return zero, false
+}
+
 type Scrapper interface {
 	DialectType() string
 	SqlDialect() sqldialect.Dialect

--- a/scrapper/reject/rejecting_scrapper.go
+++ b/scrapper/reject/rejecting_scrapper.go
@@ -27,6 +27,11 @@ func NewRejectingScrapper(inner scrapper.Scrapper) *RejectingScrapper {
 	return &RejectingScrapper{inner: inner}
 }
 
+// Unwrap returns the inner scrapper, letting callers walk the decorator chain
+// (via scrapper.As) to reach concrete types or interfaces this wrapper does
+// not itself implement.
+func (s *RejectingScrapper) Unwrap() scrapper.Scrapper { return s.inner }
+
 func (s *RejectingScrapper) Capabilities() scrapper.Capabilities { return s.inner.Capabilities() }
 func (s *RejectingScrapper) DialectType() string                 { return s.inner.DialectType() }
 func (s *RejectingScrapper) SqlDialect() sqldialect.Dialect      { return s.inner.SqlDialect() }

--- a/scrapper/sanitize/sanitizing_scrapper.go
+++ b/scrapper/sanitize/sanitizing_scrapper.go
@@ -23,6 +23,11 @@ func NewSanitizingScrapper(inner scrapper.Scrapper) *SanitizingScrapper {
 	return &SanitizingScrapper{inner: inner}
 }
 
+// Unwrap returns the inner scrapper, letting callers walk the decorator chain
+// (via scrapper.As) to reach concrete types or interfaces this wrapper does
+// not itself implement.
+func (s *SanitizingScrapper) Unwrap() scrapper.Scrapper { return s.inner }
+
 func (s *SanitizingScrapper) Capabilities() scrapper.Capabilities { return s.inner.Capabilities() }
 func (s *SanitizingScrapper) DialectType() string                 { return s.inner.DialectType() }
 func (s *SanitizingScrapper) SqlDialect() sqldialect.Dialect      { return s.inner.SqlDialect() }

--- a/scrapper/scope/scoped_scrapper.go
+++ b/scrapper/scope/scoped_scrapper.go
@@ -27,6 +27,11 @@ func (s *ScopedScrapper) BaseScope() *ScopeFilter {
 	return s.baseScope
 }
 
+// Unwrap returns the inner scrapper, letting callers walk the decorator chain
+// (via scrapper.As) to reach concrete types or interfaces this wrapper does
+// not itself implement.
+func (s *ScopedScrapper) Unwrap() scrapper.Scrapper { return s.inner }
+
 func (s *ScopedScrapper) effectiveCtx(ctx context.Context) context.Context {
 	return WithScope(ctx, s.baseScope)
 }

--- a/scrapper/unwrap_test.go
+++ b/scrapper/unwrap_test.go
@@ -1,0 +1,118 @@
+package scrapper_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	"github.com/getsynq/dwhsupport/scrapper/reject"
+	"github.com/getsynq/dwhsupport/scrapper/sanitize"
+	"github.com/getsynq/dwhsupport/sqldialect"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubLeaf struct{}
+
+func (stubLeaf) Capabilities() scrapper.Capabilities                    { return scrapper.Capabilities{} }
+func (stubLeaf) DialectType() string                                    { return "stub" }
+func (stubLeaf) SqlDialect() sqldialect.Dialect                         { return nil }
+func (stubLeaf) IsPermissionError(error) bool                           { return false }
+func (stubLeaf) Close() error                                           { return nil }
+func (stubLeaf) ValidateConfiguration(context.Context) ([]string, error) {
+	return nil, nil
+}
+func (stubLeaf) QueryCatalog(context.Context) ([]*scrapper.CatalogColumnRow, error) {
+	return nil, nil
+}
+func (stubLeaf) QueryTableMetrics(context.Context, time.Time) ([]*scrapper.TableMetricsRow, error) {
+	return nil, nil
+}
+func (stubLeaf) QuerySqlDefinitions(context.Context) ([]*scrapper.SqlDefinitionRow, error) {
+	return nil, nil
+}
+func (stubLeaf) QueryTables(context.Context, ...scrapper.QueryTablesOption) ([]*scrapper.TableRow, error) {
+	return nil, nil
+}
+func (stubLeaf) QueryDatabases(context.Context) ([]*scrapper.DatabaseRow, error) {
+	return nil, nil
+}
+func (stubLeaf) QuerySegments(context.Context, string, ...any) ([]*scrapper.SegmentRow, error) {
+	return nil, nil
+}
+func (stubLeaf) QueryCustomMetrics(context.Context, string, ...any) ([]*scrapper.CustomMetricsRow, error) {
+	return nil, nil
+}
+func (stubLeaf) QueryShape(context.Context, string) ([]*scrapper.QueryShapeColumn, error) {
+	return nil, nil
+}
+func (stubLeaf) QueryTableConstraints(context.Context) ([]*scrapper.TableConstraintRow, error) {
+	return nil, nil
+}
+
+// extrasLeaf embeds stubLeaf so it satisfies scrapper.Scrapper, and also
+// exposes an extra method that callers may want to reach past decorators.
+type extrasLeaf struct {
+	stubLeaf
+	called bool
+}
+
+type extraCapable interface {
+	ExtraCall() string
+}
+
+func (e *extrasLeaf) ExtraCall() string {
+	e.called = true
+	return "ok"
+}
+
+func TestAs_ReachesPastDecorators(t *testing.T) {
+	leaf := &extrasLeaf{}
+	wrapped := sanitize.NewSanitizingScrapper(reject.NewRejectingScrapper(leaf))
+
+	// Directly asserting on the outermost wrapper fails — it does not itself
+	// implement extraCapable.
+	_, ok := any(wrapped).(extraCapable)
+	assert.False(t, ok, "sanity: direct assertion on wrapped must fail")
+
+	found, ok := scrapper.As[extraCapable](wrapped)
+	if assert.True(t, ok, "As must reach extrasLeaf through two decorators") {
+		assert.Equal(t, "ok", found.ExtraCall())
+		assert.True(t, leaf.called)
+	}
+}
+
+func TestAs_ReachesLeafConcreteType(t *testing.T) {
+	leaf := &extrasLeaf{}
+	wrapped := sanitize.NewSanitizingScrapper(reject.NewRejectingScrapper(leaf))
+
+	found, ok := scrapper.As[*extrasLeaf](wrapped)
+	if assert.True(t, ok) {
+		assert.Same(t, leaf, found)
+	}
+}
+
+func TestAs_ReturnsZeroWhenNotFound(t *testing.T) {
+	wrapped := sanitize.NewSanitizingScrapper(reject.NewRejectingScrapper(stubLeaf{}))
+
+	found, ok := scrapper.As[extraCapable](wrapped)
+	assert.False(t, ok)
+	assert.Nil(t, found)
+}
+
+func TestAs_NilScrapperReturnsZero(t *testing.T) {
+	found, ok := scrapper.As[extraCapable](nil)
+	assert.False(t, ok)
+	assert.Nil(t, found)
+}
+
+func TestAs_FirstMatchWins(t *testing.T) {
+	// When the outermost decorator already satisfies T, As must return it
+	// rather than walking further.
+	wrapped := sanitize.NewSanitizingScrapper(&extrasLeaf{})
+
+	found, ok := scrapper.As[scrapper.Unwrapper](wrapped)
+	if assert.True(t, ok) {
+		assert.Same(t, wrapped, found)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds optional `Unwrapper` interface (`Unwrap() Scrapper`) to the decorator wrappers in `scrapper/sanitize`, `scrapper/reject`, `scrapper/scope`.
- Adds `scrapper.As[T](s Scrapper) (T, bool)` — walks the decorator chain the way `errors.As` walks wrapped errors, returning the first value in the chain that satisfies `T`.

## Why

Consumers that stack decorators (e.g. `sanitize.NewSanitizingScrapper(reject.NewRejectingScrapper(inner))`) lose the ability to type-assert past the outermost wrapper. Callers today commonly type-assert to:

- concrete wrapper types such as `*SnowflakeExtendedScrapper` (for warehouse-specific methods like tasks/lineage fetch)
- consumer-side interfaces such as `ScrapperWithExtraData` defined outside `dwhsupport` (for extras querying)

Neither is reachable through a decorator. Rather than having every decorator forward every possible consumer interface (which requires coordinating schema changes across repos), we mirror the Go stdlib `errors.Unwrap` / `errors.As` pattern: optional `Unwrap()` on the decorators, generic `As[T]` walker on the leaf package.

Kept `Unwrap()` **off** the `Scrapper` interface itself — matches the stdlib idiom (`error` doesn't have `Unwrap`, neither should `Scrapper`), avoids boilerplate on every base scrapper, and keeps decorator-specific concerns out of the core interface.