### PR TITLE
bq scrapper: honor Datasets allowlist in scope filter

### DIFF
--- a/scrapper/bigquery/scope.go
+++ b/scrapper/bigquery/scope.go
@@ -6,23 +6,38 @@ import (
 	"github.com/getsynq/dwhsupport/scrapper/scope"
 )
 
-// ScopeFromConf translates the BigQuery config's Blocklist field into a ScopeFilter.
-// Blocklist patterns are comma-separated dataset (schema) patterns.
-// Returns nil if no filtering is configured.
+// ScopeFromConf translates the BigQuery config's Datasets allowlist and
+// Blocklist into a ScopeFilter.
+//
+//   - Datasets (allowlist) maps to Include rules at the schema level.
+//   - Blocklist (comma-separated patterns) maps to Exclude rules at the schema level.
+//
+// Returns nil if neither field is configured — callers treat nil as accept-all.
 func ScopeFromConf(conf *BigQueryScrapperConf) *scope.ScopeFilter {
-	if conf == nil || conf.Blocklist == "" {
+	if conf == nil {
 		return nil
 	}
-	patterns := strings.Split(conf.Blocklist, ",")
-	var rules []scope.ScopeRule
-	for _, p := range patterns {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			rules = append(rules, scope.ScopeRule{Schema: p})
+
+	var include []scope.ScopeRule
+	for _, ds := range conf.Datasets {
+		ds = strings.TrimSpace(ds)
+		if ds != "" {
+			include = append(include, scope.ScopeRule{Schema: ds})
 		}
 	}
-	if len(rules) == 0 {
+
+	var exclude []scope.ScopeRule
+	if conf.Blocklist != "" {
+		for _, p := range strings.Split(conf.Blocklist, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				exclude = append(exclude, scope.ScopeRule{Schema: p})
+			}
+		}
+	}
+
+	if len(include) == 0 && len(exclude) == 0 {
 		return nil
 	}
-	return &scope.ScopeFilter{Exclude: rules}
+	return &scope.ScopeFilter{Include: include, Exclude: exclude}
 }

--- a/scrapper/bigquery/scope_test.go
+++ b/scrapper/bigquery/scope_test.go
@@ -1,0 +1,69 @@
+package bigquery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScopeFromConf_Nil(t *testing.T) {
+	assert.Nil(t, ScopeFromConf(nil))
+}
+
+func TestScopeFromConf_Empty(t *testing.T) {
+	assert.Nil(t, ScopeFromConf(&BigQueryScrapperConf{}))
+}
+
+func TestScopeFromConf_BlocklistOnly(t *testing.T) {
+	f := ScopeFromConf(&BigQueryScrapperConf{Blocklist: "tmp_*, dbt_pr_*"})
+	if assert.NotNil(t, f) {
+		assert.Empty(t, f.Include)
+		assert.Equal(t, 2, len(f.Exclude))
+		assert.True(t, f.IsSchemaAccepted("proj", "analytics"))
+		assert.False(t, f.IsSchemaAccepted("proj", "tmp_123"))
+		assert.False(t, f.IsSchemaAccepted("proj", "dbt_pr_abc"))
+	}
+}
+
+func TestScopeFromConf_DatasetsAllowlistOnly(t *testing.T) {
+	f := ScopeFromConf(&BigQueryScrapperConf{Datasets: []string{"analytics", "marketing"}})
+	if assert.NotNil(t, f) {
+		assert.Equal(t, 2, len(f.Include))
+		assert.Empty(t, f.Exclude)
+		assert.True(t, f.IsSchemaAccepted("proj", "analytics"))
+		assert.True(t, f.IsSchemaAccepted("proj", "marketing"))
+		assert.False(t, f.IsSchemaAccepted("proj", "finance"))
+		assert.False(t, f.IsSchemaAccepted("proj", "random"))
+	}
+}
+
+func TestScopeFromConf_DatasetsAndBlocklist(t *testing.T) {
+	// Allowlist wins as the base set; blocklist can carve out individual
+	// allowlisted datasets (exclude takes precedence).
+	f := ScopeFromConf(&BigQueryScrapperConf{
+		Datasets:  []string{"analytics", "staging_*"},
+		Blocklist: "staging_tmp",
+	})
+	if assert.NotNil(t, f) {
+		assert.Equal(t, 2, len(f.Include))
+		assert.Equal(t, 1, len(f.Exclude))
+		assert.True(t, f.IsSchemaAccepted("proj", "analytics"))
+		assert.True(t, f.IsSchemaAccepted("proj", "staging_main"))
+		assert.False(t, f.IsSchemaAccepted("proj", "staging_tmp"))
+		assert.False(t, f.IsSchemaAccepted("proj", "finance"))
+	}
+}
+
+func TestScopeFromConf_TrimsAndSkipsEmpty(t *testing.T) {
+	f := ScopeFromConf(&BigQueryScrapperConf{
+		Datasets:  []string{"  analytics ", "", "   "},
+		Blocklist: " tmp_* ,, ,dbt_pr_* ",
+	})
+	if assert.NotNil(t, f) {
+		assert.Equal(t, 1, len(f.Include))
+		assert.Equal(t, "analytics", f.Include[0].Schema)
+		assert.Equal(t, 2, len(f.Exclude))
+		assert.Equal(t, "tmp_*", f.Exclude[0].Schema)
+		assert.Equal(t, "dbt_pr_*", f.Exclude[1].Schema)
+	}
+}


### PR DESCRIPTION
## Summary

`ScopeFromConf` only threaded `Blocklist` into `ScopeFilter.Exclude` — the `Datasets` allowlist was silently ignored by the scope filter. As a result, `querySqlDefinitionsSql` (which runs `SELECT … FROM region-<region>.INFORMATION_SCHEMA.TABLES` and relies on `scope.IsSchemaAccepted` to post-filter rows) returned every dataset the caller had project-level metadata access to, even when the integration was explicitly restricted to a single dataset via `Datasets`.

This PR fixes `ScopeFromConf` to include `Datasets` as schema-level `Include` rules, mirroring the pattern already used by `scrapper/snowflake/scope.go`.

## Observed impact

An integration pointed at a large BigQuery project with `Datasets: ["one_dataset"]` was still scraping hundreds of tables / views from across every other dataset in the project. Only the API fallback path (`querySqlDefinitionsApi`) honored the allowlist via `listDatasets()`; the SQL-first path went through the scope filter, which didn't know about the allowlist.

After the fix the same integration returns only the objects in the configured dataset.

## Scope of the fix

- `scrapper/bigquery/scope.go` — `ScopeFromConf` now emits schema-level `Include` rules from `conf.Datasets` alongside the existing `Exclude` rules from `conf.Blocklist`. When only one is set the other side is left empty; when neither is set the function still returns `nil` so callers treat it as accept-all.
- `scrapper/bigquery/scope_test.go` — new tests cover nil/empty config, blocklist-only, allowlist-only, combined allowlist + blocklist (exclude-takes-precedence), and trimming / empty-token handling.

## Other INFORMATION_SCHEMA callsites

Not touched by this PR:
- `query_logs.go` queries `region-<region>.INFORMATION_SCHEMA.JOBS` and is expected to scan all jobs in the project — filtering happens downstream because rows carry cross-dataset `referenced_tables` / `destination_table`.
- `table_change_history.go` queries JOBS filtered by `destination_table = <fqn>` per-table, so there's no allowlist concern.