### PR TITLE
yamlconfig: clear *_file after ResolveFiles inlines content

### DIFF
--- a/yamlconfig/convert_reverse.go
+++ b/yamlconfig/convert_reverse.go
@@ -71,7 +71,7 @@ func snowflakeConfFromProto(c *agentdwhv1.SnowflakeConf) *SnowflakeConf {
 	if c == nil {
 		return nil
 	}
-	return &SnowflakeConf{
+	sf := &SnowflakeConf{
 		Account:              c.GetAccount(),
 		Warehouse:            c.GetWarehouse(),
 		Role:                 c.GetRole(),
@@ -85,19 +85,27 @@ func snowflakeConfFromProto(c *agentdwhv1.SnowflakeConf) *SnowflakeConf {
 		AccountUsageDb:       c.GetAccountUsageDb(),
 		AuthType:             c.GetAuthType(),
 	}
+	if sf.PrivateKey != "" {
+		sf.PrivateKeyFile = ""
+	}
+	return sf
 }
 
 func bigqueryConfFromProto(c *agentdwhv1.BigQueryConf) *BigQueryConf {
 	if c == nil {
 		return nil
 	}
-	return &BigQueryConf{
+	bq := &BigQueryConf{
 		ProjectId:             c.GetProjectId(),
 		Region:                c.GetRegion(),
 		ServiceAccountKey:     c.GetServiceAccountKey(),
 		ServiceAccountKeyFile: c.GetServiceAccountKeyFile(),
 		Datasets:              c.GetDatasets(),
 	}
+	if bq.ServiceAccountKey != "" {
+		bq.ServiceAccountKeyFile = ""
+	}
+	return bq
 }
 
 func redshiftConfFromProto(c *agentdwhv1.RedshiftConf) *RedshiftConf {

--- a/yamlconfig/parse.go
+++ b/yamlconfig/parse.go
@@ -199,6 +199,9 @@ func ResolveFiles(connections map[string]*Connection, opts ParseOptions) error {
 				return fmt.Errorf("yamlconfig: connection %q: reading file %q: %w", id, *p.fileField, err)
 			}
 			*p.inlineField = string(data)
+			// Clear the _file field so downstream proto validators that enforce
+			// "either inline or file, but not both" don't reject the config.
+			*p.fileField = ""
 		}
 	}
 	return nil

--- a/yamlconfig/parse_test.go
+++ b/yamlconfig/parse_test.go
@@ -223,8 +223,8 @@ func TestResolveFiles_Snowflake(t *testing.T) {
 	err := ResolveFiles(conns, opts)
 	require.NoError(t, err)
 	assert.Equal(t, "PRIVATE_KEY_CONTENT", conns["sf"].Snowflake.PrivateKey)
-	// File path is preserved
-	assert.Equal(t, "keys/snowflake.p8", conns["sf"].Snowflake.PrivateKeyFile)
+	// File path is cleared so proto validators ("either inline or file, not both") pass.
+	assert.Equal(t, "", conns["sf"].Snowflake.PrivateKeyFile)
 }
 
 func TestResolveFiles_BigQuery(t *testing.T) {
@@ -249,6 +249,7 @@ func TestResolveFiles_BigQuery(t *testing.T) {
 	err := ResolveFiles(conns, opts)
 	require.NoError(t, err)
 	assert.Equal(t, `{"type":"service_account"}`, conns["bq"].BigQuery.ServiceAccountKey)
+	assert.Equal(t, "", conns["bq"].BigQuery.ServiceAccountKeyFile)
 }
 
 func TestResolveFiles_AbsolutePath(t *testing.T) {
@@ -275,6 +276,7 @@ func TestResolveFiles_AbsolutePath(t *testing.T) {
 	err := ResolveFiles(conns, opts)
 	require.NoError(t, err)
 	assert.Equal(t, "KEY", conns["sf"].Snowflake.PrivateKey)
+	assert.Equal(t, "", conns["sf"].Snowflake.PrivateKeyFile)
 }
 
 func TestResolveFiles_InlineFieldTakesPrecedence(t *testing.T) {


### PR DESCRIPTION
## Summary

- `ResolveFiles` populated the paired inline field (`ServiceAccountKey`, `PrivateKey`) but left the `*_file` field set, which caused downstream proto validation to reject with `"Either service_account_key or service_account_key_file must be provided, but not both"` (hit in synq-scout when `agent.yaml` used `service_account_key_file: path/to/sa.json`).
- Clear `*p.fileField` in `ResolveFiles` after inlining the content.
- Defensively clear the `*_file` field in `snowflakeConfFromProto` / `bigqueryConfFromProto` when inline content is present, so older protos that carry both fields still produce a valid struct.
- Updated `TestResolveFiles_Snowflake` / `TestResolveFiles_BigQuery` / `TestResolveFiles_AbsolutePath` to assert the `_file` field is cleared after `ResolveFiles`.

Fixes [PR-7094](https://linear.app/synq/issue/PR-7094).