### PR TITLE
scrapper: add RunRawQuery iterator for typed raw query results

### DIFF
--- a/pool/scrapper.go
+++ b/pool/scrapper.go
@@ -180,6 +180,15 @@ func (s *scrapperWrapper[K]) QueryShape(ctx context.Context, sql string) ([]*scr
 	return s.lease.Value().QueryShape(ctx, sql)
 }
 
+func (s *scrapperWrapper[K]) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.lease == nil || s.lease.Released() {
+		return nil, nil
+	}
+	return s.lease.Value().RunRawQuery(ctx, sql)
+}
+
 func (s *scrapperWrapper[K]) QueryTableConstraints(ctx context.Context) ([]*scrapper.TableConstraintRow, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pool/scrapper_test.go
+++ b/pool/scrapper_test.go
@@ -68,6 +68,10 @@ func (m *mockScrapper) QueryShape(ctx context.Context, sql string) ([]*scrapper.
 	return nil, nil
 }
 
+func (m *mockScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	return nil, nil
+}
+
 func (m *mockScrapper) QueryTableConstraints(ctx context.Context) ([]*scrapper.TableConstraintRow, error) {
 	return nil, nil
 }

--- a/scrapper/bigquery/run_raw_query.go
+++ b/scrapper/bigquery/run_raw_query.go
@@ -1,0 +1,158 @@
+package bigquery
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/civil"
+	execbigquery "github.com/getsynq/dwhsupport/exec/bigquery"
+	"github.com/getsynq/dwhsupport/exec/querystats"
+	"github.com/getsynq/dwhsupport/scrapper"
+	"google.golang.org/api/iterator"
+)
+
+func (e *BigQueryScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	collector, ctx := querystats.Start(ctx)
+
+	query := e.executor.GetBigQueryClient().Query(sql)
+	job, err := query.Run(ctx)
+	if err != nil {
+		collector.Finish()
+		return nil, err
+	}
+
+	it, err := job.Read(ctx)
+	if err != nil {
+		collector.Finish()
+		return nil, err
+	}
+	execbigquery.CollectBigQueryStats(ctx, job)
+
+	schema := it.Schema
+	columns := make([]*scrapper.QueryShapeColumn, len(schema))
+	columnNames := make([]string, len(schema))
+	for i, field := range schema {
+		columns[i] = &scrapper.QueryShapeColumn{
+			Name:       field.Name,
+			NativeType: string(field.Type),
+			Position:   int32(i + 1),
+		}
+		columnNames[i] = field.Name
+	}
+
+	return &bqRawRowsIterator{
+		it:          it,
+		columns:     columns,
+		columnNames: columnNames,
+		collector:   collector,
+	}, nil
+}
+
+type bqRawRowsIterator struct {
+	it          *bigquery.RowIterator
+	columns     []*scrapper.QueryShapeColumn
+	columnNames []string
+	collector   *querystats.Collector
+
+	mu       sync.Mutex
+	closed   bool
+	rowCount int64
+}
+
+func (it *bqRawRowsIterator) Columns() []*scrapper.QueryShapeColumn {
+	return it.columns
+}
+
+func (it *bqRawRowsIterator) Next(ctx context.Context) ([]*scrapper.ColumnValue, error) {
+	it.mu.Lock()
+	defer it.mu.Unlock()
+
+	if it.closed {
+		return nil, io.EOF
+	}
+
+	if err := ctx.Err(); err != nil {
+		it.closeLocked()
+		return nil, err
+	}
+
+	var row map[string]bigquery.Value
+	err := it.it.Next(&row)
+	if err == iterator.Done {
+		it.closeLocked()
+		return nil, io.EOF
+	}
+	if err != nil {
+		it.closeLocked()
+		return nil, err
+	}
+	it.rowCount++
+
+	values := make([]*scrapper.ColumnValue, len(it.columnNames))
+	for i, name := range it.columnNames {
+		raw, exists := row[name]
+		cv := &scrapper.ColumnValue{Name: name, IsNull: !exists || raw == nil}
+		if !cv.IsNull {
+			cv.Value = bqValueToScrapperValue(raw)
+		}
+		values[i] = cv
+	}
+	return values, nil
+}
+
+func (it *bqRawRowsIterator) Close() error {
+	it.mu.Lock()
+	defer it.mu.Unlock()
+	it.closeLocked()
+	return nil
+}
+
+func (it *bqRawRowsIterator) closeLocked() {
+	if it.closed {
+		return
+	}
+	it.closed = true
+	it.collector.SetRowsProduced(it.rowCount)
+	it.collector.Finish()
+}
+
+func bqValueToScrapperValue(v bigquery.Value) scrapper.Value {
+	switch val := v.(type) {
+	case int64:
+		return scrapper.IntValue(val)
+	case float64:
+		return scrapper.DoubleValue(val)
+	case bool:
+		if val {
+			return scrapper.IntValue(1)
+		}
+		return scrapper.IntValue(0)
+	case time.Time:
+		return scrapper.TimeValue(val)
+	case civil.DateTime:
+		return scrapper.TimeValue(val.In(time.UTC))
+	case civil.Date:
+		return scrapper.TimeValue(val.In(time.UTC))
+	case civil.Time:
+		return scrapper.StringValue(val.String())
+	case string:
+		return scrapper.StringValue(sanitizeUTF8(val))
+	case []byte:
+		return scrapper.StringValue(sanitizeUTF8(string(val)))
+	default:
+		return scrapper.StringValue(sanitizeUTF8(fmt.Sprint(v)))
+	}
+}
+
+func sanitizeUTF8(s string) string {
+	if !utf8.ValidString(s) {
+		s = strings.ToValidUTF8(s, "")
+	}
+	return s
+}

--- a/scrapper/clickhouse/run_raw_query.go
+++ b/scrapper/clickhouse/run_raw_query.go
@@ -1,0 +1,12 @@
+package clickhouse
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+)
+
+func (e *ClickhouseScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	return scrapperstdsql.RunRawQuery(ctx, e.executor, sql)
+}

--- a/scrapper/databricks/run_raw_query.go
+++ b/scrapper/databricks/run_raw_query.go
@@ -1,0 +1,16 @@
+package databricks
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+)
+
+func (e *DatabricksScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	executor, err := e.lazyExecutor.Get()
+	if err != nil {
+		return nil, err
+	}
+	return scrapperstdsql.RunRawQuery(ctx, executor, sql)
+}

--- a/scrapper/duckdb/duckdb_test.go
+++ b/scrapper/duckdb/duckdb_test.go
@@ -2,6 +2,7 @@ package duckdb
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -455,4 +456,70 @@ func (s *LocalDuckDBScrapperSuite) TestQueryCustomMetrics_WithHugeInt() {
 	s.IsType((*scrapper.BigIntValue)(nil), result[1].ColumnValues[0].Value)
 	bigVal := result[1].ColumnValues[0].Value.(*scrapper.BigIntValue)
 	s.Equal("170141183460469231731687303715884105727", bigVal.String())
+}
+
+func (s *LocalDuckDBScrapperSuite) TestRunRawQuery_PreservesAllColumns() {
+	sql := `SELECT
+		name                                         AS name_col,
+		amount                                       AS amount_col,
+		created_at                                   AS ts_col,
+		is_active                                    AS bool_col,
+		big_number                                   AS huge_col,
+		NULL::VARCHAR                                AS null_col,
+		'not-a-segment'                              AS plain_string,
+		'seg-value'                                  AS segment_foo
+	FROM test_schema.test_table
+	ORDER BY id`
+
+	iter, err := s.duckdbScrapper.RunRawQuery(s.ctx, sql)
+	s.Require().NoError(err)
+	defer iter.Close()
+
+	cols := iter.Columns()
+	s.Require().Len(cols, 8)
+	s.Equal("name_col", cols[0].Name)
+	s.Equal("segment_foo", cols[7].Name)
+
+	row1, err := iter.Next(s.ctx)
+	s.Require().NoError(err)
+	s.Require().Len(row1, 8)
+
+	// Plain string preserved verbatim (not collapsed to IgnoredValue).
+	s.Equal("name_col", row1[0].Name)
+	s.Equal(scrapper.StringValue("Alice"), row1[0].Value)
+
+	// Decimal → DoubleValue.
+	s.IsType(scrapper.DoubleValue(0), row1[1].Value)
+
+	// Timestamp → TimeValue.
+	s.IsType(scrapper.TimeValue(time.Time{}), row1[2].Value)
+
+	// Bool → IntValue(1/0) per existing convention.
+	s.Equal(scrapper.IntValue(1), row1[3].Value)
+
+	// Hugeint within int64 range → IntValue.
+	s.Equal(scrapper.IntValue(12345), row1[4].Value)
+
+	// NULL cell: IsNull=true, Value=nil, but the *ColumnValue slot is present.
+	s.True(row1[5].IsNull)
+	s.Nil(row1[5].Value)
+
+	// Non-segment string stays in the row (no sidelining).
+	s.Equal(scrapper.StringValue("not-a-segment"), row1[6].Value)
+
+	// segment* column stays in-row too (unlike QueryCustomMetrics which sidelines it).
+	s.Equal("segment_foo", row1[7].Name)
+	s.Equal(scrapper.StringValue("seg-value"), row1[7].Value)
+
+	row2, err := iter.Next(s.ctx)
+	s.Require().NoError(err)
+	s.Equal(scrapper.StringValue("Bob"), row2[0].Value)
+	s.IsType((*scrapper.BigIntValue)(nil), row2[4].Value)
+
+	// Iterator is exhausted.
+	_, err = iter.Next(s.ctx)
+	s.Equal(io.EOF, err)
+
+	// Close is idempotent after auto-close on EOF.
+	s.NoError(iter.Close())
 }

--- a/scrapper/duckdb/run_raw_query.go
+++ b/scrapper/duckdb/run_raw_query.go
@@ -1,0 +1,12 @@
+package duckdb
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+)
+
+func (e *DuckDBScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	return scrapperstdsql.RunRawQuery(ctx, e.executor, sql)
+}

--- a/scrapper/interface.go
+++ b/scrapper/interface.go
@@ -100,8 +100,40 @@ type Scrapper interface {
 	QuerySegments(ctx context.Context, sql string, args ...any) ([]*SegmentRow, error)
 	QueryCustomMetrics(ctx context.Context, sql string, args ...any) ([]*CustomMetricsRow, error)
 	QueryShape(ctx context.Context, sql string) ([]*QueryShapeColumn, error)
+	// RunRawQuery executes an arbitrary user-supplied SELECT and returns a
+	// streaming iterator over typed rows. Unlike QueryCustomMetrics it does
+	// not filter segment* columns and does not collapse text columns to
+	// IgnoredValue — it is designed for generic "run this query" surfaces
+	// rather than the agent's metrics/profile/segments path.
+	//
+	// The caller must Close() the iterator. Callers that want a row cap
+	// should stop iteration after N calls to Next().
+	RunRawQuery(ctx context.Context, sql string) (RawQueryRowIterator, error)
 	QueryTableConstraints(ctx context.Context) ([]*TableConstraintRow, error)
 	// This will close underlying execer, such scrapper can't be used anymore
+	Close() error
+}
+
+// RawQueryRowIterator streams typed rows from RunRawQuery. Semantics mirror
+// querylogs.QueryLogIterator: Next returns io.EOF when exhausted, auto-closes
+// on EOF, and Close is idempotent.
+type RawQueryRowIterator interface {
+	// Columns describes the shape of the result. Stable for the lifetime of
+	// the iterator — valid before the first Next call and unchanged after.
+	Columns() []*QueryShapeColumn
+
+	// Next returns the next row or io.EOF when exhausted.
+	//
+	// The returned slice is positional with Columns(); each cell is a fresh
+	// *ColumnValue the caller may retain. NULL cells have IsNull=true and
+	// Value=nil.
+	//
+	// Implementations MUST auto-close resources before returning io.EOF.
+	// Safe to call after EOF (keeps returning io.EOF).
+	Next(ctx context.Context) ([]*ColumnValue, error)
+
+	// Close releases the underlying cursor / driver rows / warehouse job.
+	// Safe to call multiple times.
 	Close() error
 }
 

--- a/scrapper/mocks.go
+++ b/scrapper/mocks.go
@@ -560,6 +560,45 @@ func (c *MockScrapperQueryTablesCall) DoAndReturn(f func(context.Context, ...Que
 	return c
 }
 
+// RunRawQuery mocks base method.
+func (m *MockScrapper) RunRawQuery(ctx context.Context, sql string) (RawQueryRowIterator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunRawQuery", ctx, sql)
+	ret0, _ := ret[0].(RawQueryRowIterator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunRawQuery indicates an expected call of RunRawQuery.
+func (mr *MockScrapperMockRecorder) RunRawQuery(ctx, sql any) *MockScrapperRunRawQueryCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunRawQuery", reflect.TypeOf((*MockScrapper)(nil).RunRawQuery), ctx, sql)
+	return &MockScrapperRunRawQueryCall{Call: call}
+}
+
+// MockScrapperRunRawQueryCall wrap *gomock.Call
+type MockScrapperRunRawQueryCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockScrapperRunRawQueryCall) Return(arg0 RawQueryRowIterator, arg1 error) *MockScrapperRunRawQueryCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockScrapperRunRawQueryCall) Do(f func(context.Context, string) (RawQueryRowIterator, error)) *MockScrapperRunRawQueryCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockScrapperRunRawQueryCall) DoAndReturn(f func(context.Context, string) (RawQueryRowIterator, error)) *MockScrapperRunRawQueryCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SqlDialect mocks base method.
 func (m *MockScrapper) SqlDialect() sqldialect.Dialect {
 	m.ctrl.T.Helper()

--- a/scrapper/models.go
+++ b/scrapper/models.go
@@ -217,6 +217,14 @@ type IgnoredValue struct{}
 
 func (IgnoredValue) isValue() {}
 
+// StringValue preserves text values verbatim. Used by RunRawQuery so generic
+// "run this query" surfaces see string columns as strings rather than having
+// them collapsed to IgnoredValue (as QueryCustomMetrics does, which is correct
+// for the metrics/profile agent path but wrong for raw data preview).
+type StringValue string
+
+func (StringValue) isValue() {}
+
 // BigIntValue represents arbitrary precision integers (e.g., DuckDB hugeint, uint128)
 type BigIntValue big.Int
 

--- a/scrapper/mssql/run_raw_query.go
+++ b/scrapper/mssql/run_raw_query.go
@@ -1,0 +1,12 @@
+package mssql
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+)
+
+func (e *MSSQLScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	return scrapperstdsql.RunRawQuery(ctx, e.executor, sql)
+}

--- a/scrapper/mysql/run_raw_query.go
+++ b/scrapper/mysql/run_raw_query.go
@@ -1,0 +1,12 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+)
+
+func (e *MySQLScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	return scrapperstdsql.RunRawQuery(ctx, e.executor, sql)
+}

--- a/scrapper/oracle/run_raw_query.go
+++ b/scrapper/oracle/run_raw_query.go
@@ -1,0 +1,12 @@
+package oracle
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+)
+
+func (e *OracleScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	return scrapperstdsql.RunRawQuery(ctx, e.executor, sql)
+}

--- a/scrapper/postgres/run_raw_query.go
+++ b/scrapper/postgres/run_raw_query.go
@@ -1,0 +1,12 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+)
+
+func (e *PostgresScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	return scrapperstdsql.RunRawQuery(ctx, e.executor, sql)
+}

--- a/scrapper/redshift/run_raw_query.go
+++ b/scrapper/redshift/run_raw_query.go
@@ -1,0 +1,12 @@
+package redshift
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+)
+
+func (e *RedshiftScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	return scrapperstdsql.RunRawQuery(ctx, e.executor, sql)
+}

--- a/scrapper/reject/rejecting_scrapper.go
+++ b/scrapper/reject/rejecting_scrapper.go
@@ -149,6 +149,10 @@ func (s *RejectingScrapper) QueryShape(ctx context.Context, sql string) ([]*scra
 	return filterValid(cols, s.DialectType(), "QueryShape"), nil
 }
 
+func (s *RejectingScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	return s.inner.RunRawQuery(ctx, sql)
+}
+
 func (s *RejectingScrapper) QueryTableConstraints(ctx context.Context) ([]*scrapper.TableConstraintRow, error) {
 	rows, err := s.inner.QueryTableConstraints(ctx)
 	if err != nil {

--- a/scrapper/reject/rejecting_scrapper_test.go
+++ b/scrapper/reject/rejecting_scrapper_test.go
@@ -64,6 +64,10 @@ func (s *stubScrapper) QueryShape(context.Context, string) ([]*scrapper.QuerySha
 	return s.shape, nil
 }
 
+func (s *stubScrapper) RunRawQuery(context.Context, string) (scrapper.RawQueryRowIterator, error) {
+	return nil, nil
+}
+
 func (s *stubScrapper) QueryTableConstraints(context.Context) ([]*scrapper.TableConstraintRow, error) {
 	return s.constraints, nil
 }

--- a/scrapper/sanitize.go
+++ b/scrapper/sanitize.go
@@ -187,7 +187,9 @@ func (v *ColumnValue) Sanitize() {
 		return
 	}
 	v.Name = SanitizeString(v.Name)
-	// Value is a typed Value interface (numeric or time) — never carries strings.
+	if s, ok := v.Value.(StringValue); ok {
+		v.Value = StringValue(SanitizeString(string(s)))
+	}
 }
 
 func (r *CustomMetricsRow) Sanitize() {

--- a/scrapper/sanitize/sanitizing_scrapper.go
+++ b/scrapper/sanitize/sanitizing_scrapper.go
@@ -130,6 +130,40 @@ func (s *SanitizingScrapper) QueryShape(ctx context.Context, sql string) ([]*scr
 	return cols, nil
 }
 
+func (s *SanitizingScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	iter, err := s.inner.RunRawQuery(ctx, sql)
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range iter.Columns() {
+		c.Sanitize()
+	}
+	return &sanitizingRawQueryRows{inner: iter}, nil
+}
+
+type sanitizingRawQueryRows struct {
+	inner scrapper.RawQueryRowIterator
+}
+
+func (s *sanitizingRawQueryRows) Columns() []*scrapper.QueryShapeColumn {
+	return s.inner.Columns()
+}
+
+func (s *sanitizingRawQueryRows) Next(ctx context.Context) ([]*scrapper.ColumnValue, error) {
+	row, err := s.inner.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, cv := range row {
+		cv.Sanitize()
+	}
+	return row, nil
+}
+
+func (s *sanitizingRawQueryRows) Close() error {
+	return s.inner.Close()
+}
+
 func (s *SanitizingScrapper) QueryTableConstraints(ctx context.Context) ([]*scrapper.TableConstraintRow, error) {
 	rows, err := s.inner.QueryTableConstraints(ctx)
 	if err != nil {

--- a/scrapper/sanitize/sanitizing_scrapper_test.go
+++ b/scrapper/sanitize/sanitizing_scrapper_test.go
@@ -66,6 +66,10 @@ func (s *stubScrapper) QueryShape(context.Context, string) ([]*scrapper.QuerySha
 	return s.shape, nil
 }
 
+func (s *stubScrapper) RunRawQuery(context.Context, string) (scrapper.RawQueryRowIterator, error) {
+	return nil, nil
+}
+
 func (s *stubScrapper) QueryTableConstraints(context.Context) ([]*scrapper.TableConstraintRow, error) {
 	return s.constraints, nil
 }

--- a/scrapper/scope/scoped_scrapper.go
+++ b/scrapper/scope/scoped_scrapper.go
@@ -67,6 +67,10 @@ func (s *ScopedScrapper) QueryShape(ctx context.Context, sql string) ([]*scrappe
 	return s.inner.QueryShape(ctx, sql)
 }
 
+func (s *ScopedScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	return s.inner.RunRawQuery(ctx, sql)
+}
+
 // Scrapper interface — filtered methods.
 // These inject the base scope into the context (enabling SQL push-down in the inner scrapper)
 // and post-filter returned rows to guarantee scope compliance even when the inner scrapper

--- a/scrapper/scope/scoped_scrapper_test.go
+++ b/scrapper/scope/scoped_scrapper_test.go
@@ -63,6 +63,10 @@ func (m *mockScrapper) QueryShape(context.Context, string) ([]*scrapper.QuerySha
 	return nil, nil
 }
 
+func (m *mockScrapper) RunRawQuery(context.Context, string) (scrapper.RawQueryRowIterator, error) {
+	return nil, nil
+}
+
 func (m *mockScrapper) QueryTableConstraints(context.Context) ([]*scrapper.TableConstraintRow, error) {
 	return m.constraintRows, nil
 }

--- a/scrapper/snowflake/run_raw_query.go
+++ b/scrapper/snowflake/run_raw_query.go
@@ -1,0 +1,12 @@
+package snowflake
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+)
+
+func (e *SnowflakeScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	return scrapperstdsql.RunRawQuery(ctx, e.executor, sql)
+}

--- a/scrapper/stdsql/run_raw_query.go
+++ b/scrapper/stdsql/run_raw_query.go
@@ -1,0 +1,156 @@
+package stdsql
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/getsynq/dwhsupport/exec/querystats"
+	"github.com/getsynq/dwhsupport/scrapper"
+	"github.com/jmoiron/sqlx"
+)
+
+// RunRawQuery executes sqlQuery and returns an iterator over typed rows. The
+// iterator must be Close()'d by the caller; it also auto-closes on io.EOF.
+//
+// Unlike QueryCustomMetrics this path preserves every column: segment* names
+// are not sidelined, and string columns come back as StringValue rather than
+// being re-parsed and collapsed to IgnoredValue. Unknown driver types fall
+// back to StringValue(fmt.Sprint(v)) so nothing is silently dropped.
+func RunRawQuery(ctx context.Context, db RowQuerier, sqlQuery string) (scrapper.RawQueryRowIterator, error) {
+	collector, ctx := querystats.Start(ctx)
+
+	sqlRows, err := db.QueryRows(ctx, sqlQuery)
+	if err != nil {
+		collector.Finish()
+		return nil, err
+	}
+
+	columnTypes, err := sqlRows.ColumnTypes()
+	if err != nil {
+		_ = sqlRows.Close()
+		collector.Finish()
+		return nil, err
+	}
+
+	columns := make([]*scrapper.QueryShapeColumn, len(columnTypes))
+	columnNames := make([]string, len(columnTypes))
+	for i, ct := range columnTypes {
+		columns[i] = &scrapper.QueryShapeColumn{
+			Name:       ct.Name(),
+			NativeType: ct.DatabaseTypeName(),
+			Position:   int32(i + 1),
+		}
+		columnNames[i] = ct.Name()
+	}
+
+	return &rawRowsIterator{
+		rows:        sqlRows,
+		columns:     columns,
+		columnNames: columnNames,
+		collector:   collector,
+	}, nil
+}
+
+type rawRowsIterator struct {
+	rows        *sqlx.Rows
+	columns     []*scrapper.QueryShapeColumn
+	columnNames []string
+	collector   *querystats.Collector
+
+	mu       sync.Mutex
+	closed   bool
+	rowCount int64
+}
+
+func (it *rawRowsIterator) Columns() []*scrapper.QueryShapeColumn {
+	return it.columns
+}
+
+func (it *rawRowsIterator) Next(ctx context.Context) ([]*scrapper.ColumnValue, error) {
+	it.mu.Lock()
+	defer it.mu.Unlock()
+
+	if it.closed {
+		return nil, io.EOF
+	}
+
+	if err := ctx.Err(); err != nil {
+		it.closeLocked()
+		return nil, err
+	}
+
+	if !it.rows.Next() {
+		if err := it.rows.Err(); err != nil {
+			it.closeLocked()
+			return nil, err
+		}
+		it.closeLocked()
+		return nil, io.EOF
+	}
+	it.rowCount++
+
+	scanners := make([]any, len(it.columnNames))
+	for i := range it.columnNames {
+		scanners[i] = new(any)
+	}
+	if err := it.rows.Scan(scanners...); err != nil {
+		it.closeLocked()
+		return nil, err
+	}
+
+	values := make([]*scrapper.ColumnValue, len(it.columnNames))
+	for i, name := range it.columnNames {
+		raw := *(scanners[i].(*any))
+		cv := &scrapper.ColumnValue{Name: name, IsNull: raw == nil}
+		if raw != nil {
+			cv.Value = convertToRawValue(raw)
+		}
+		values[i] = cv
+	}
+	return values, nil
+}
+
+func (it *rawRowsIterator) Close() error {
+	it.mu.Lock()
+	defer it.mu.Unlock()
+	return it.closeLocked()
+}
+
+func (it *rawRowsIterator) closeLocked() error {
+	if it.closed {
+		return nil
+	}
+	it.closed = true
+	err := it.rows.Close()
+	it.collector.SetRowsProduced(it.rowCount)
+	it.collector.Finish()
+	return err
+}
+
+// convertToRawValue mirrors convertToScrapperValue but preserves text
+// (string/[]byte → StringValue) and renders unknown driver types via
+// fmt.Sprint so RunRawQuery never drops a value.
+func convertToRawValue(v any) scrapper.Value {
+	switch val := v.(type) {
+	case string:
+		return scrapper.StringValue(sanitizeRawString(val))
+	case []byte:
+		return scrapper.StringValue(sanitizeRawString(string(val)))
+	}
+	converted := convertToScrapperValue(v)
+	if _, ignored := converted.(scrapper.IgnoredValue); ignored {
+		return scrapper.StringValue(sanitizeRawString(fmt.Sprint(v)))
+	}
+	return converted
+}
+
+func sanitizeRawString(s string) string {
+	if !utf8.ValidString(s) {
+		s = strings.ToValidUTF8(s, "")
+	}
+	return s
+}

--- a/scrapper/trino/run_raw_query.go
+++ b/scrapper/trino/run_raw_query.go
@@ -1,0 +1,12 @@
+package trino
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+)
+
+func (e *TrinoScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
+	return scrapperstdsql.RunRawQuery(ctx, e.executor, sql)
+}

--- a/scrapper/unwrap_test.go
+++ b/scrapper/unwrap_test.go
@@ -14,11 +14,11 @@ import (
 
 type stubLeaf struct{}
 
-func (stubLeaf) Capabilities() scrapper.Capabilities                    { return scrapper.Capabilities{} }
-func (stubLeaf) DialectType() string                                    { return "stub" }
-func (stubLeaf) SqlDialect() sqldialect.Dialect                         { return nil }
-func (stubLeaf) IsPermissionError(error) bool                           { return false }
-func (stubLeaf) Close() error                                           { return nil }
+func (stubLeaf) Capabilities() scrapper.Capabilities { return scrapper.Capabilities{} }
+func (stubLeaf) DialectType() string                 { return "stub" }
+func (stubLeaf) SqlDialect() sqldialect.Dialect      { return nil }
+func (stubLeaf) IsPermissionError(error) bool        { return false }
+func (stubLeaf) Close() error                        { return nil }
 func (stubLeaf) ValidateConfiguration(context.Context) ([]string, error) {
 	return nil, nil
 }
@@ -44,6 +44,9 @@ func (stubLeaf) QueryCustomMetrics(context.Context, string, ...any) ([]*scrapper
 	return nil, nil
 }
 func (stubLeaf) QueryShape(context.Context, string) ([]*scrapper.QueryShapeColumn, error) {
+	return nil, nil
+}
+func (stubLeaf) RunRawQuery(context.Context, string) (scrapper.RawQueryRowIterator, error) {
 	return nil, nil
 }
 func (stubLeaf) QueryTableConstraints(context.Context) ([]*scrapper.TableConstraintRow, error) {


### PR DESCRIPTION
## Summary

Adds `Scrapper.RunRawQuery(ctx, sql) (RawQueryRowIterator, error)` — a streaming, typed alternative to `QueryCustomMetrics` for generic "run this query" surfaces.

`QueryCustomMetrics` is load-bearing for the metrics/profile/segments agent: it sidelines `segment*` columns into a separate slice and collapses unparseable text to `IgnoredValue{}`. That's correct for the agent but makes it unfit for a data-preview / SQL-console API. `RunRawQuery` keeps those invariants for the agent path untouched and adds a new parallel path that preserves every column.

## Design notes

- **Iterator**, mirroring the existing `querylogs.QueryLogIterator` pattern already used across every warehouse. `Next(ctx)` returns `io.EOF` when exhausted, auto-closes on EOF/error, `Close` is idempotent. No result buffering in the library — the caller bounds memory by stopping iteration early.
- **Typed values preserved.** New `StringValue` variant on the `Value` interface keeps text verbatim. Numeric / time / bigint columns reuse the existing `convertToScrapperValue` path, so `IntValue`/`DoubleValue`/`TimeValue`/`BigIntValue` behave exactly as they do for `QueryCustomMetrics` today. Unknown driver types fall back to `StringValue(fmt.Sprint(v))` so nothing is silently dropped.
- **NULL** uses the existing `ColumnValue.IsNull` convention — the `*ColumnValue` pointer is always non-nil, only the inner `Value` is nil when `IsNull=true`. Every output column gets a slot even for all-null rows (positional alignment with `Columns()`).
- **stdsql** powers the 10 sqlx-based warehouses. **BigQuery** has its own impl over `bigquery.RowIterator`. Per-warehouse files are one-line pass-throughs.
- **Decorators**: `SanitizingScrapper` wraps the iterator and sanitizes each scanned row in-place; `ScopedScrapper` / `RejectingScrapper` / pool wrapper pass through. `ColumnValue.Sanitize` now cleans `StringValue` contents too.

## Follow-up

Consumed by PR-7162 on the cloud side: a new `DwhService.RunQuery` RPC in `kernel-ext-dwh-metrics` will call this to back a data-preview / SQL-console surface.