### PR TITLE
querylogs: wire up IsTruncated for Snowflake

### DIFF
--- a/scrapper/databricks/query_logs.go
+++ b/scrapper/databricks/query_logs.go
@@ -203,8 +203,11 @@ func convertDatabricksQueryInfoToQueryLog(
 		status = strings.ToUpper(string(queryInfo.Status))
 	}
 
-	// Get query text, sanitize and apply obfuscation
-	// Skip for INSERT statements (can be huge) and limit size
+	// Get query text, sanitize and apply obfuscation.
+	// Drop SQL for INSERT statements unconditionally: the parser-based obfuscator can
+	// fail-open on literal-dense `INSERT ... VALUES (...)` payloads and leak customer
+	// data. Also drop anything over 1 MB as a hard size cap. Empty SQL is its own
+	// signal to downstream consumers that lineage parsing is not possible.
 	queryText := ""
 	if queryInfo.StatementType != servicesql.QueryStatementTypeInsert && len(queryInfo.QueryText) <= 1*1024*1024 {
 		queryText = strings.TrimSpace(strings.ToValidUTF8(queryInfo.QueryText, ""))

--- a/scrapper/snowflake/query_logs.go
+++ b/scrapper/snowflake/query_logs.go
@@ -87,6 +87,11 @@ type SnowflakeQueryLogSchema struct {
 	QueryParameterizedHashVersion          *int64    `db:"QUERY_PARAMETERIZED_HASH_VERSION"`
 }
 
+// snowflakeQueryTextMaxLen is the maximum length of QUERY_TEXT in ACCOUNT_USAGE.QUERY_HISTORY
+// before Snowflake truncates it. Source:
+// https://docs.snowflake.com/en/sql-reference/account-usage/query_history
+const snowflakeQueryTextMaxLen = 100000
+
 var queryHistoryMandatoryColumns = []string{
 	"QUERY_ID",
 	"QUERY_TEXT",
@@ -424,6 +429,11 @@ func convertSnowflakeRowToQueryLog(
 		dwhContext.Role = *row.RoleName
 	}
 
+	// Snowflake's ACCOUNT_USAGE.QUERY_HISTORY truncates QUERY_TEXT at 100,000 characters
+	// (https://docs.snowflake.com/en/sql-reference/account-usage/query_history). Detect on
+	// the raw value before sanitization since that may shorten the string.
+	isTruncated := len(row.QueryText) >= snowflakeQueryTextMaxLen
+
 	// Sanitize and apply obfuscation to query text
 	// Replace $$$$ with '' (Snowflake-specific escaping) and clean up whitespace/invalid UTF-8
 	queryText := strings.ReplaceAll(strings.TrimSpace(strings.ToValidUTF8(row.QueryText, "")), "$$$$", "''")
@@ -448,5 +458,6 @@ func convertSnowflakeRowToQueryLog(
 		SqlObfuscationMode:       obfuscator.Mode(),
 		HasCompleteNativeLineage: false, // Snowflake doesn't provide lineage in QUERY_HISTORY
 		NativeLineage:            nil,
+		IsTruncated:              isTruncated,
 	}, nil
 }


### PR DESCRIPTION
## Summary

`QueryLog.IsTruncated` was defined in `querylogs/types.go` but never set by any scrapper. The doc on the field says consumers should skip SQL parsing when true — useful, but currently always false.

- **Snowflake**: `ACCOUNT_USAGE.QUERY_HISTORY.QUERY_TEXT` is capped at 100,000 chars by Snowflake. Detect that on the raw value (before our sanitization shortens it) and set `IsTruncated`. Downstream lineage can then fall back to `QUERY_PARAMETERIZED_HASH` instead of parsing a half-query.
- **Databricks**: clarified the existing INSERT/>1 MB SQL drop. It's a defense-in-depth against the literal obfuscator failing open on dense `INSERT ... VALUES (...)` payloads, not just a size optimization — comment now says so. No behavior change here; `IsTruncated` stays false because this is a deliberate scrapper-side redaction, not DWH truncation.

Other warehouses (BigQuery, ClickHouse, Trino, Oracle, MSSQL, Redshift) leave `IsTruncated=false` — under default config their query log sources return full text.