### PR TITLE
snowflake: surface parsePrivateKey errors instead of falling through to password auth

### DIFF
--- a/exec/snowflake/auth_type_test.go
+++ b/exec/snowflake/auth_type_test.go
@@ -24,7 +24,8 @@ func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_ExternalBrowser() {
 		AuthType:  "externalbrowser",
 		Databases: []string{"DB1", "DB2"},
 	}
-	c := buildSnowflakeConfig(conf)
+	c, err := buildSnowflakeConfig(conf)
+	s.Require().NoError(err)
 
 	s.Equal(gosnowflake.AuthTypeExternalBrowser, c.Authenticator)
 	s.Equal(120*time.Second, c.ExternalBrowserTimeout)
@@ -44,7 +45,8 @@ func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_ExternalBrowserCaseInsensit
 			User:     "user@example.com",
 			AuthType: authType,
 		}
-		c := buildSnowflakeConfig(conf)
+		c, err := buildSnowflakeConfig(conf)
+		s.Require().NoError(err)
 
 		s.Equal(gosnowflake.AuthTypeExternalBrowser, c.Authenticator, "AuthType %q should be recognized as externalbrowser", authType)
 	}
@@ -57,7 +59,8 @@ func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_DefaultAuthType_Empty() {
 		Password: "password123",
 		AuthType: "",
 	}
-	c := buildSnowflakeConfig(conf)
+	c, err := buildSnowflakeConfig(conf)
+	s.Require().NoError(err)
 
 	// Default auth type should not set external browser authenticator
 	s.NotEqual(gosnowflake.AuthTypeExternalBrowser, c.Authenticator)
@@ -71,7 +74,8 @@ func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_DefaultAuthType_Unrecognize
 		Password: "password123",
 		AuthType: "unknowntype",
 	}
-	c := buildSnowflakeConfig(conf)
+	c, err := buildSnowflakeConfig(conf)
+	s.Require().NoError(err)
 
 	// Unrecognized auth type should fall back to default behavior
 	s.NotEqual(gosnowflake.AuthTypeExternalBrowser, c.Authenticator)
@@ -85,7 +89,8 @@ func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_OAuthToken() {
 		Role:      "PUBLIC",
 		Databases: []string{"DB1", "DB2"},
 	}
-	c := buildSnowflakeConfig(conf)
+	c, err := buildSnowflakeConfig(conf)
+	s.Require().NoError(err)
 
 	s.Equal(gosnowflake.AuthTypeOAuth, c.Authenticator)
 	s.Equal("my-oauth-access-token", c.Token)
@@ -103,7 +108,8 @@ func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_PasswordSetsDefaultDatabase
 		Password:  "password",
 		Databases: []string{"DB1", "DB2"},
 	}
-	c := buildSnowflakeConfig(conf)
+	c, err := buildSnowflakeConfig(conf)
+	s.Require().NoError(err)
 
 	s.Equal("DB1", c.Database)
 }
@@ -116,7 +122,8 @@ func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_OAuthTokenTakesPrecedence()
 		Password: "password123",
 		Token:    "my-oauth-access-token",
 	}
-	c := buildSnowflakeConfig(conf)
+	c, err := buildSnowflakeConfig(conf)
+	s.Require().NoError(err)
 
 	s.Equal(gosnowflake.AuthTypeOAuth, c.Authenticator)
 	s.Equal("my-oauth-access-token", c.Token)
@@ -132,9 +139,45 @@ func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_DefaultAuthType_WithPrivate
 		PrivateKey: keyBytes,
 		AuthType:   "",
 	}
-	c := buildSnowflakeConfig(conf)
+	c, err := buildSnowflakeConfig(conf)
+	s.Require().NoError(err)
 
 	s.Equal(gosnowflake.AuthTypeJwt, c.Authenticator)
 	s.NotNil(c.PrivateKey)
 	s.Equal(gosnowflake.ConfigBoolTrue, c.DisableConsoleLogin)
+}
+
+// Regression test: an unencrypted PEM combined with a non-empty passphrase
+// (e.g. browser-autofilled into the form) used to silently fall through to
+// password auth and surface as "260002: password is empty" from the driver.
+// buildSnowflakeConfig must surface the parse error directly.
+func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_UnencryptedPrivateKeyWithPassphrase_ReturnsError() {
+	keyBytes, err := os.ReadFile("test_rsa_key_unencrypted.pem")
+	s.Require().NoError(err)
+
+	conf := &SnowflakeConf{
+		Account:              "myaccount",
+		User:                 "svc_user",
+		PrivateKey:           keyBytes,
+		PrivateKeyPassphrase: "browser-autofilled-password",
+	}
+	c, err := buildSnowflakeConfig(conf)
+
+	s.Require().Error(err)
+	s.Nil(c)
+	s.Contains(err.Error(), "passphrase provided but private key is not encrypted")
+}
+
+// Regression test: a malformed PEM must not silently fall through to password
+// auth either.
+func (s *SnowflakeAuthTypeTestSuite) TestBuildConfig_InvalidPrivateKey_ReturnsError() {
+	conf := &SnowflakeConf{
+		Account:    "myaccount",
+		User:       "svc_user",
+		PrivateKey: []byte("not a valid PEM"),
+	}
+	c, err := buildSnowflakeConfig(conf)
+
+	s.Require().Error(err)
+	s.Nil(c)
 }

--- a/exec/snowflake/snowflake.go
+++ b/exec/snowflake/snowflake.go
@@ -136,7 +136,7 @@ func cleanAccountName(account string) string {
 // buildSnowflakeConfig creates a gosnowflake.Config from SnowflakeConf.
 // This is separated from NewSnowflakeExecutor to allow unit testing of the configuration logic.
 // Note: This function does not handle PrivateKeyFile loading (requires file I/O) - that's done in NewSnowflakeExecutor.
-func buildSnowflakeConfig(conf *SnowflakeConf) *gosnowflake.Config {
+func buildSnowflakeConfig(conf *SnowflakeConf) (*gosnowflake.Config, error) {
 	// When connecting as an individual user (OAuth token or SSO browser), don't set a
 	// default database on the connection. The user's role may not have access to the
 	// databases configured in the workspace integration. Queries use fully qualified names.
@@ -175,22 +175,29 @@ func buildSnowflakeConfig(conf *SnowflakeConf) *gosnowflake.Config {
 		// Allow browser-based login (don't disable console login for SSO)
 		c.DisableConsoleLogin = gosnowflake.ConfigBoolFalse
 	default:
-		// Default: password or private key authentication
-		// Handle inline private key (PrivateKeyFile is handled in NewSnowflakeExecutor)
+		// Default: password or private key authentication.
+		// Handle inline private key (PrivateKeyFile is handled in NewSnowflakeExecutor).
+		// Surface parse errors instead of silently falling through to password auth —
+		// otherwise a bad PEM/passphrase combination becomes a misleading
+		// "260002: password is empty" from the driver.
 		if len(conf.PrivateKey) > 0 {
 			privKey, err := parsePrivateKey(conf.PrivateKey, conf.PrivateKeyPassphrase)
-			if err == nil {
-				c.PrivateKey = privKey
-				c.Authenticator = gosnowflake.AuthTypeJwt
+			if err != nil {
+				return nil, err
 			}
+			c.PrivateKey = privKey
+			c.Authenticator = gosnowflake.AuthTypeJwt
 		}
 	}
 
-	return c
+	return c, nil
 }
 
 func NewSnowflakeExecutor(ctx context.Context, conf *SnowflakeConf) (*SnowflakeExecutor, error) {
-	c := buildSnowflakeConfig(conf)
+	c, err := buildSnowflakeConfig(conf)
+	if err != nil {
+		return nil, exec.NewAuthError(err)
+	}
 
 	// Handle private key file loading (not in buildSnowflakeConfig to keep it side-effect free for testing)
 	if strings.ToLower(conf.AuthType) != "externalbrowser" && c.PrivateKey == nil && len(conf.PrivateKeyFile) > 0 {
@@ -210,8 +217,7 @@ func NewSnowflakeExecutor(ctx context.Context, conf *SnowflakeConf) (*SnowflakeE
 	stdDb := sql.OpenDB(connector)
 	db := sqlx.NewDb(stdDb, "snowflake")
 
-	err := db.PingContext(ctx)
-	if err != nil {
+	if err := db.PingContext(ctx); err != nil {
 		return nil, exec.NewAuthError(err)
 	}
 


### PR DESCRIPTION
## Summary

- `buildSnowflakeConfig` silently swallowed errors from `parsePrivateKey` for inline `PrivateKey` configs, leaving the gosnowflake config with no `Authenticator` and no `PrivateKey`. The driver then defaulted to password auth and surfaced **`260002: password is empty`** — a misleading error that hides the actual cause.
- Real-world trigger: a browser password manager autofilled the "Private Key Passphrase" field while the user was typing in the username field of the integration form. The PEM is unencrypted but a non-empty passphrase was attached, so `parsePrivateKey` returned `passphrase provided but private key is not encrypted` — and the customer saw "password is empty" with no path to the real fix.
- Now we propagate the parse error and wrap it with `exec.NewAuthError` in `NewSnowflakeExecutor`, matching the behaviour of the existing `PrivateKeyFile` branch.

## What changed

- `exec/snowflake/snowflake.go`: `buildSnowflakeConfig` now returns `(*gosnowflake.Config, error)` and propagates `parsePrivateKey` failures. `NewSnowflakeExecutor` wraps that error in `exec.NewAuthError` (same as the file-based branch).
- `exec/snowflake/auth_type_test.go`: updated existing assertions for the new signature; added two regression tests:
  - unencrypted PEM + non-empty passphrase → returns "passphrase provided but private key is not encrypted"
  - malformed PEM → returns an error