### PR TITLE
scrapper: render UUIDs and Stringer types in RunRawQuery

### DIFF
--- a/scrapper/stdsql/run_raw_query.go
+++ b/scrapper/stdsql/run_raw_query.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/getsynq/dwhsupport/exec/querystats"
 	"github.com/getsynq/dwhsupport/scrapper"
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -132,20 +133,48 @@ func (it *rawRowsIterator) closeLocked() error {
 }
 
 // convertToRawValue mirrors convertToScrapperValue but preserves text
-// (string/[]byte → StringValue) and renders unknown driver types via
-// fmt.Sprint so RunRawQuery never drops a value.
+// (string/[]byte → StringValue), renders UUIDs as their canonical string form,
+// and falls back to Stringer / fmt.Sprint for unknown driver types so
+// RunRawQuery never drops a value.
 func convertToRawValue(v any) scrapper.Value {
 	switch val := v.(type) {
 	case string:
 		return scrapper.StringValue(sanitizeRawString(val))
+	case [16]byte:
+		// Native pgx (and google/uuid) surface UUIDs as a raw 16-byte array.
+		// Format as canonical xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+		return scrapper.StringValue(uuid.UUID(val).String())
 	case []byte:
+		if id, ok := tryUUIDFromBytes(val); ok {
+			return scrapper.StringValue(id)
+		}
 		return scrapper.StringValue(sanitizeRawString(string(val)))
 	}
 	converted := convertToScrapperValue(v)
 	if _, ignored := converted.(scrapper.IgnoredValue); ignored {
+		if s, ok := v.(fmt.Stringer); ok {
+			return scrapper.StringValue(sanitizeRawString(s.String()))
+		}
 		return scrapper.StringValue(sanitizeRawString(fmt.Sprint(v)))
 	}
 	return converted
+}
+
+// tryUUIDFromBytes recognises the two byte shapes a database driver might
+// return for a UUID column: the 16-byte binary form, and the 36-byte canonical
+// text form. Anything else is left to the generic []byte path.
+func tryUUIDFromBytes(b []byte) (string, bool) {
+	switch len(b) {
+	case 16:
+		var arr [16]byte
+		copy(arr[:], b)
+		return uuid.UUID(arr).String(), true
+	case 36:
+		if id, err := uuid.ParseBytes(b); err == nil {
+			return id.String(), true
+		}
+	}
+	return "", false
 }
 
 func sanitizeRawString(s string) string {

--- a/scrapper/stdsql/run_raw_query_test.go
+++ b/scrapper/stdsql/run_raw_query_test.go
@@ -1,0 +1,91 @@
+package stdsql
+
+import (
+	"testing"
+	"time"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertToRawValue(t *testing.T) {
+	canonical := "04fcaa82-51fd-4767-b42a-2df6cdc5d0ca"
+	parsed := uuid.MustParse(canonical)
+
+	tests := []struct {
+		name    string
+		in      any
+		want    scrapper.Value
+		wantStr string
+	}{
+		{
+			name: "plain string preserved",
+			in:   "04fcaa82-51fd-4767-b42a-2df6cdc5d0ca",
+			want: scrapper.StringValue(canonical),
+		},
+		{
+			name: "byte slice with UTF-8 text preserved",
+			in:   []byte("hello"),
+			want: scrapper.StringValue("hello"),
+		},
+		{
+			name: "16-byte array rendered as canonical UUID (native pgx)",
+			in:   [16]byte(parsed),
+			want: scrapper.StringValue(canonical),
+		},
+		{
+			name: "16-byte slice rendered as canonical UUID (binary uuid column)",
+			in:   parsed[:],
+			want: scrapper.StringValue(canonical),
+		},
+		{
+			name: "36-byte canonical-form slice round-trips",
+			in:   []byte(canonical),
+			want: scrapper.StringValue(canonical),
+		},
+		{
+			name: "int preserved via IntValue",
+			in:   int64(42),
+			want: scrapper.IntValue(42),
+		},
+		{
+			name: "Stringer fallback for unknown types",
+			in:   stringerType{s: "via-Stringer"},
+			want: scrapper.StringValue("via-Stringer"),
+		},
+		{
+			name:    "fmt.Sprint fallback for opaque types",
+			in:      opaqueType{n: 7},
+			wantStr: "{7}",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := convertToRawValue(tc.in)
+			if tc.wantStr != "" {
+				sv, ok := got.(scrapper.StringValue)
+				assert.True(t, ok, "expected StringValue, got %T", got)
+				assert.Equal(t, tc.wantStr, string(sv))
+				return
+			}
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestConvertToRawValue_TimeStillTyped(t *testing.T) {
+	// time.Time is a Stringer but must keep going through convertToScrapperValue
+	// so it lands as TimeValue, not a string.
+	ts := time.Date(2026, 5, 11, 8, 0, 3, 0, time.UTC)
+	got := convertToRawValue(ts)
+	_, ok := got.(scrapper.TimeValue)
+	assert.True(t, ok, "expected TimeValue, got %T", got)
+}
+
+type stringerType struct{ s string }
+
+func (s stringerType) String() string { return s.s }
+
+type opaqueType struct{ n int }


### PR DESCRIPTION
## Summary

`convertToRawValue` preserved `string` / `[]byte` verbatim and fell back to `fmt.Sprint` for anything `convertToScrapperValue` tagged as `IgnoredValue`. That meant:

- Native pgx UUIDs (`[16]byte`) and binary-format `uuid` columns rendered as `[1 2 3 ...]` byte dumps.
- Driver types whose only sensible representation is their `String()` method (e.g. `pgtype.UUID`, decimal wrappers) rendered as Go struct dumps.

Consumers reading these columns through a string-typed accessor saw empty/garbage values and silently dropped the rows — surfaced in `synq-recon` as `TERMINATION_REASON_CANNOT_SPLIT` on UUID key columns because the bisection checkpoint extractor got zero usable values back.

Changes:

- `[16]byte` → canonical UUID via `google/uuid` (already a dwhsupport dep).
- `[]byte` of length 16 → binary UUID; of length 36 → canonical text UUID, with `uuid.ParseBytes` validation. Other byte slices keep the existing UTF-8 text path.
- Prefer `fmt.Stringer` over `fmt.Sprint` in the unknown-type fallback. `time.Time` is unaffected — it still routes through `convertToScrapperValue` first and lands as `TimeValue`.

## Test plan

- [x] `go test ./scrapper/stdsql/... -run TestConvertToRawValue -v` — new table-driven tests cover all branches (incl. regression test that `time.Time` doesn't get hijacked by Stringer).
- [x] `go build ./...`