### PR TITLE
querybuilder: add WithTimeRangeExpr for time bounds

### DIFF
--- a/metrics/PartitionWithTimeRangeExpr/bigquery.snap
+++ b/metrics/PartitionWithTimeRangeExpr/bigquery.snap
@@ -14,8 +14,8 @@ select
   CAST(stddev_samp(run_type) AS FLOAT64) as stddev
 from `db.default.runs` 
 where
-  timestamp(ingested_at) >= {from} and 
-  timestamp(ingested_at) < {to}
+  timestamp(ingested_at) >= CURRENT_DATE - INTERVAL '3 days' and 
+  timestamp(ingested_at) < CURRENT_DATE - INTERVAL '1 day'
 group by TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), DAY), INTERVAL 1 DAY)
 order by TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), DAY), INTERVAL 1 DAY) 
 ---

--- a/metrics/PartitionWithTimeRangeExpr/bigquery.snap
+++ b/metrics/PartitionWithTimeRangeExpr/bigquery.snap
@@ -1,0 +1,21 @@
+
+[TestMetricsSuite/TestPartitionWithTimeRangeExpr - 1]
+select
+  TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), DAY), INTERVAL 1 DAY) as time_segment, 
+  'run_type' as field, 
+  count(*) as num_rows, 
+  count(run_type) as num_not_null, 
+  count(distinct run_type) as num_unique, 
+  countif(run_type = 0) as num_empty, 
+  CAST(avg(run_type) AS FLOAT64) as mean, 
+  CAST(min(run_type) AS FLOAT64) as min, 
+  CAST(max(run_type) AS FLOAT64) as max, 
+  CAST(approx_quantiles(run_type, 2)[offset(1)] AS FLOAT64) as median, 
+  CAST(stddev_samp(run_type) AS FLOAT64) as stddev
+from `db.default.runs` 
+where
+  timestamp(ingested_at) >= {from} and 
+  timestamp(ingested_at) < {to}
+group by TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), DAY), INTERVAL 1 DAY)
+order by TIMESTAMP_ADD(timestamp_trunc(timestamp(ingested_at), DAY), INTERVAL 1 DAY) 
+---

--- a/metrics/PartitionWithTimeRangeExpr/clickhouse.snap
+++ b/metrics/PartitionWithTimeRangeExpr/clickhouse.snap
@@ -14,8 +14,8 @@ select
   toFloat64(stddevSamp(run_type)) as stddev
 from default.runs 
 where
-  ingested_at >= {from} and 
-  ingested_at < {to}
+  ingested_at >= CURRENT_DATE - INTERVAL '3 days' and 
+  ingested_at < CURRENT_DATE - INTERVAL '1 day'
 group by time_segment
 order by time_segment 
 ---

--- a/metrics/PartitionWithTimeRangeExpr/clickhouse.snap
+++ b/metrics/PartitionWithTimeRangeExpr/clickhouse.snap
@@ -1,0 +1,21 @@
+
+[TestMetricsSuite/TestPartitionWithTimeRangeExpr - 1]
+select
+  timestamp_add(toStartOfInterval(ingested_at, interval 1 DAY), interval 1 DAY) as time_segment, 
+  'run_type' as field, 
+  toInt64(count(*)) as num_rows, 
+  toInt64(count(run_type)) as num_not_null, 
+  toInt64(count(distinct run_type)) as num_unique, 
+  toInt64(countIf(run_type = 0)) as num_empty, 
+  toFloat64(avg(run_type)) as mean, 
+  toFloat64(min(run_type)) as min, 
+  toFloat64(max(run_type)) as max, 
+  toFloat64(median(run_type)) as median, 
+  toFloat64(stddevSamp(run_type)) as stddev
+from default.runs 
+where
+  ingested_at >= {from} and 
+  ingested_at < {to}
+group by time_segment
+order by time_segment 
+---

--- a/metrics/PartitionWithTimeRangeExpr/databricks.snap
+++ b/metrics/PartitionWithTimeRangeExpr/databricks.snap
@@ -14,8 +14,8 @@ select
   CAST(stddev(run_type) AS FLOAT) as `stddev`
 from db.default.runs 
 where
-  ingested_at >= {from} and 
-  ingested_at < {to}
+  ingested_at >= CURRENT_DATE - INTERVAL '3 days' and 
+  ingested_at < CURRENT_DATE - INTERVAL '1 day'
 group by `time_segment`
 order by `time_segment` 
 ---

--- a/metrics/PartitionWithTimeRangeExpr/databricks.snap
+++ b/metrics/PartitionWithTimeRangeExpr/databricks.snap
@@ -1,0 +1,21 @@
+
+[TestMetricsSuite/TestPartitionWithTimeRangeExpr - 1]
+select
+  TIMESTAMPADD(DAY, 1, DATE_TRUNC('DAY', ingested_at)) as `time_segment`, 
+  'run_type' as `field`, 
+  count(*) as `num_rows`, 
+  count(run_type) as `num_not_null`, 
+  count(distinct run_type) as `num_unique`, 
+  count_if(run_type = 0) as `num_empty`, 
+  CAST(avg(run_type) AS FLOAT) as `mean`, 
+  CAST(min(run_type) AS FLOAT) as `min`, 
+  CAST(max(run_type) AS FLOAT) as `max`, 
+  CAST(median(run_type) AS FLOAT) as `median`, 
+  CAST(stddev(run_type) AS FLOAT) as `stddev`
+from db.default.runs 
+where
+  ingested_at >= {from} and 
+  ingested_at < {to}
+group by `time_segment`
+order by `time_segment` 
+---

--- a/metrics/PartitionWithTimeRangeExpr/duckdb.snap
+++ b/metrics/PartitionWithTimeRangeExpr/duckdb.snap
@@ -14,8 +14,8 @@ select
   CAST(STDDEV(run_type) AS FLOAT) as stddev
 from default.runs 
 where
-  ingested_at >= {from} and 
-  ingested_at < {to}
+  ingested_at >= CURRENT_DATE - INTERVAL '3 days' and 
+  ingested_at < CURRENT_DATE - INTERVAL '1 day'
 group by time_segment
 order by time_segment 
 ---

--- a/metrics/PartitionWithTimeRangeExpr/duckdb.snap
+++ b/metrics/PartitionWithTimeRangeExpr/duckdb.snap
@@ -1,0 +1,21 @@
+
+[TestMetricsSuite/TestPartitionWithTimeRangeExpr - 1]
+select
+  DATE_TRUNC('DAY', ingested_at) + '1 DAY' as time_segment, 
+  'run_type' as field, 
+  count(*) as num_rows, 
+  count(run_type) as num_not_null, 
+  count(distinct run_type) as num_unique, 
+  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as num_empty, 
+  CAST(avg(run_type) AS FLOAT) as mean, 
+  CAST(min(run_type) AS FLOAT) as min, 
+  CAST(max(run_type) AS FLOAT) as max, 
+  CAST(MEDIAN(run_type) AS FLOAT) as median, 
+  CAST(STDDEV(run_type) AS FLOAT) as stddev
+from default.runs 
+where
+  ingested_at >= {from} and 
+  ingested_at < {to}
+group by time_segment
+order by time_segment 
+---

--- a/metrics/PartitionWithTimeRangeExpr/mssql.snap
+++ b/metrics/PartitionWithTimeRangeExpr/mssql.snap
@@ -14,8 +14,8 @@ select
   CAST(STDEV(run_type) AS FLOAT) as [stddev]
 from [default].[runs] 
 where
-  [ingested_at] >= {from} and 
-  [ingested_at] < {to}
+  [ingested_at] >= CURRENT_DATE - INTERVAL '3 days' and 
+  [ingested_at] < CURRENT_DATE - INTERVAL '1 day'
 group by DATEADD(DAY, 1, DATEADD(DAY, DATEDIFF(DAY, 0, [ingested_at]), 0))
 order by DATEADD(DAY, 1, DATEADD(DAY, DATEDIFF(DAY, 0, [ingested_at]), 0)) 
 ---

--- a/metrics/PartitionWithTimeRangeExpr/mssql.snap
+++ b/metrics/PartitionWithTimeRangeExpr/mssql.snap
@@ -1,0 +1,21 @@
+
+[TestMetricsSuite/TestPartitionWithTimeRangeExpr - 1]
+select
+  DATEADD(DAY, 1, DATEADD(DAY, DATEDIFF(DAY, 0, [ingested_at]), 0)) as [time_segment], 
+  'run_type' as [field], 
+  COUNT(*) as [num_rows], 
+  COUNT(run_type) as [num_not_null], 
+  COUNT(distinct run_type) as [num_unique], 
+  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as [num_empty], 
+  CAST(avg(run_type) AS FLOAT) as [mean], 
+  CAST(min(run_type) AS FLOAT) as [min], 
+  CAST(max(run_type) AS FLOAT) as [max], 
+  CAST(NULL AS FLOAT) as [median], 
+  CAST(STDEV(run_type) AS FLOAT) as [stddev]
+from [default].[runs] 
+where
+  [ingested_at] >= {from} and 
+  [ingested_at] < {to}
+group by DATEADD(DAY, 1, DATEADD(DAY, DATEDIFF(DAY, 0, [ingested_at]), 0))
+order by DATEADD(DAY, 1, DATEADD(DAY, DATEDIFF(DAY, 0, [ingested_at]), 0)) 
+---

--- a/metrics/PartitionWithTimeRangeExpr/mysql.snap
+++ b/metrics/PartitionWithTimeRangeExpr/mysql.snap
@@ -14,8 +14,8 @@ select
   CAST(STDDEV(run_type) AS DOUBLE) as stddev
 from default.runs 
 where
-  ingested_at >= {from} and 
-  ingested_at < {to}
+  ingested_at >= CURRENT_DATE - INTERVAL '3 days' and 
+  ingested_at < CURRENT_DATE - INTERVAL '1 day'
 group by DATE_ADD(STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d 00:00:00'), '%Y-%m-%d %H:%i:%s'), INTERVAL 1 DAY)
 order by DATE_ADD(STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d 00:00:00'), '%Y-%m-%d %H:%i:%s'), INTERVAL 1 DAY) 
 ---

--- a/metrics/PartitionWithTimeRangeExpr/mysql.snap
+++ b/metrics/PartitionWithTimeRangeExpr/mysql.snap
@@ -1,0 +1,21 @@
+
+[TestMetricsSuite/TestPartitionWithTimeRangeExpr - 1]
+select
+  DATE_ADD(STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d 00:00:00'), '%Y-%m-%d %H:%i:%s'), INTERVAL 1 DAY) as time_segment, 
+  'run_type' as field, 
+  count(*) as num_rows, 
+  count(run_type) as num_not_null, 
+  count(distinct run_type) as num_unique, 
+  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as num_empty, 
+  CAST(avg(run_type) AS DOUBLE) as mean, 
+  CAST(min(run_type) AS DOUBLE) as min, 
+  CAST(max(run_type) AS DOUBLE) as max, 
+  CAST(NULL AS DOUBLE) as median, 
+  CAST(STDDEV(run_type) AS DOUBLE) as stddev
+from default.runs 
+where
+  ingested_at >= {from} and 
+  ingested_at < {to}
+group by DATE_ADD(STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d 00:00:00'), '%Y-%m-%d %H:%i:%s'), INTERVAL 1 DAY)
+order by DATE_ADD(STR_TO_DATE(DATE_FORMAT(ingested_at, '%Y-%m-%d 00:00:00'), '%Y-%m-%d %H:%i:%s'), INTERVAL 1 DAY) 
+---

--- a/metrics/PartitionWithTimeRangeExpr/oracle.snap
+++ b/metrics/PartitionWithTimeRangeExpr/oracle.snap
@@ -14,8 +14,8 @@ select
   CAST(STDDEV(run_type) AS BINARY_DOUBLE) as "stddev"
 from "default"."runs" 
 where
-  "ingested_at" >= {from} and 
-  "ingested_at" < {to}
+  "ingested_at" >= CURRENT_DATE - INTERVAL '3 days' and 
+  "ingested_at" < CURRENT_DATE - INTERVAL '1 day'
 group by (TRUNC("ingested_at", 'DD') + INTERVAL '1' DAY)
 order by (TRUNC("ingested_at", 'DD') + INTERVAL '1' DAY) 
 ---

--- a/metrics/PartitionWithTimeRangeExpr/oracle.snap
+++ b/metrics/PartitionWithTimeRangeExpr/oracle.snap
@@ -1,0 +1,21 @@
+
+[TestMetricsSuite/TestPartitionWithTimeRangeExpr - 1]
+select
+  (TRUNC("ingested_at", 'DD') + INTERVAL '1' DAY) as "time_segment", 
+  'run_type' as "field", 
+  COUNT(*) as "num_rows", 
+  COUNT(run_type) as "num_not_null", 
+  COUNT(distinct run_type) as "num_unique", 
+  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as "num_empty", 
+  CAST(avg(run_type) AS BINARY_DOUBLE) as "mean", 
+  CAST(min(run_type) AS BINARY_DOUBLE) as "min", 
+  CAST(max(run_type) AS BINARY_DOUBLE) as "max", 
+  CAST(MEDIAN(run_type) AS BINARY_DOUBLE) as "median", 
+  CAST(STDDEV(run_type) AS BINARY_DOUBLE) as "stddev"
+from "default"."runs" 
+where
+  "ingested_at" >= {from} and 
+  "ingested_at" < {to}
+group by (TRUNC("ingested_at", 'DD') + INTERVAL '1' DAY)
+order by (TRUNC("ingested_at", 'DD') + INTERVAL '1' DAY) 
+---

--- a/metrics/PartitionWithTimeRangeExpr/postgres.snap
+++ b/metrics/PartitionWithTimeRangeExpr/postgres.snap
@@ -1,0 +1,21 @@
+
+[TestMetricsSuite/TestPartitionWithTimeRangeExpr - 1]
+select
+  DATE_TRUNC('DAY', ingested_at) + '1 DAY' as time_segment, 
+  'run_type' as field, 
+  count(*) as num_rows, 
+  count(run_type) as num_not_null, 
+  count(distinct run_type) as num_unique, 
+  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as num_empty, 
+  CAST(avg(run_type) AS FLOAT) as mean, 
+  CAST(min(run_type) AS FLOAT) as min, 
+  CAST(max(run_type) AS FLOAT) as max, 
+  CAST(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY run_type) AS FLOAT) as median, 
+  CAST(STDDEV(run_type) AS FLOAT) as stddev
+from default.runs 
+where
+  ingested_at >= {from} and 
+  ingested_at < {to}
+group by DATE_TRUNC('DAY', ingested_at) + '1 DAY'
+order by DATE_TRUNC('DAY', ingested_at) + '1 DAY' 
+---

--- a/metrics/PartitionWithTimeRangeExpr/postgres.snap
+++ b/metrics/PartitionWithTimeRangeExpr/postgres.snap
@@ -14,8 +14,8 @@ select
   CAST(STDDEV(run_type) AS FLOAT) as stddev
 from default.runs 
 where
-  ingested_at >= {from} and 
-  ingested_at < {to}
+  ingested_at >= CURRENT_DATE - INTERVAL '3 days' and 
+  ingested_at < CURRENT_DATE - INTERVAL '1 day'
 group by DATE_TRUNC('DAY', ingested_at) + '1 DAY'
 order by DATE_TRUNC('DAY', ingested_at) + '1 DAY' 
 ---

--- a/metrics/PartitionWithTimeRangeExpr/redshift.snap
+++ b/metrics/PartitionWithTimeRangeExpr/redshift.snap
@@ -1,0 +1,20 @@
+
+[TestMetricsSuite/TestPartitionWithTimeRangeExpr - 1]
+select
+  DATEADD(DAY, 1, DATE_TRUNC('DAY', ingested_at)) as time_segment, 
+  'run_type' as field, 
+  count(*) as num_rows, 
+  count(run_type) as num_not_null, 
+  SUM(CASE WHEN run_type = 0 THEN 1 ELSE 0 END) as num_empty, 
+  CAST(avg(run_type) AS FLOAT) as mean, 
+  CAST(min(run_type) AS FLOAT) as min, 
+  CAST(max(run_type) AS FLOAT) as max, 
+  CAST(MEDIAN(run_type) AS FLOAT) as median, 
+  CAST(STDDEV(run_type) AS FLOAT) as stddev
+from "db"."default"."runs" 
+where
+  ingested_at >= {from} and 
+  ingested_at < {to}
+group by DATEADD(DAY, 1, DATE_TRUNC('DAY', ingested_at))
+order by DATEADD(DAY, 1, DATE_TRUNC('DAY', ingested_at)) 
+---

--- a/metrics/PartitionWithTimeRangeExpr/redshift.snap
+++ b/metrics/PartitionWithTimeRangeExpr/redshift.snap
@@ -13,8 +13,8 @@ select
   CAST(STDDEV(run_type) AS FLOAT) as stddev
 from "db"."default"."runs" 
 where
-  ingested_at >= {from} and 
-  ingested_at < {to}
+  ingested_at >= CURRENT_DATE - INTERVAL '3 days' and 
+  ingested_at < CURRENT_DATE - INTERVAL '1 day'
 group by DATEADD(DAY, 1, DATE_TRUNC('DAY', ingested_at))
 order by DATEADD(DAY, 1, DATE_TRUNC('DAY', ingested_at)) 
 ---

--- a/metrics/PartitionWithTimeRangeExpr/snowflake.snap
+++ b/metrics/PartitionWithTimeRangeExpr/snowflake.snap
@@ -1,0 +1,21 @@
+
+[TestMetricsSuite/TestPartitionWithTimeRangeExpr - 1]
+select
+  TIMESTAMPADD(DAY, 1, time_slice(to_timestamp_ntz(ingested_at), 1, 'DAY')) as "time_segment", 
+  'run_type' as "field", 
+  count(*) as "num_rows", 
+  count(run_type) as "num_not_null", 
+  count(distinct run_type) as "num_unique", 
+  count_if(run_type = 0) as "num_empty", 
+  CAST(avg(run_type) AS FLOAT) as "mean", 
+  CAST(min(run_type) AS FLOAT) as "min", 
+  CAST(max(run_type) AS FLOAT) as "max", 
+  CAST(median(run_type) AS FLOAT) as "median", 
+  CAST(stddev(run_type) AS FLOAT) as "stddev"
+from db.default.runs 
+where
+  ingested_at >= {from} and 
+  ingested_at < {to}
+group by "time_segment"
+order by "time_segment" 
+---

--- a/metrics/PartitionWithTimeRangeExpr/snowflake.snap
+++ b/metrics/PartitionWithTimeRangeExpr/snowflake.snap
@@ -14,8 +14,8 @@ select
   CAST(stddev(run_type) AS FLOAT) as "stddev"
 from db.default.runs 
 where
-  ingested_at >= {from} and 
-  ingested_at < {to}
+  ingested_at >= CURRENT_DATE - INTERVAL '3 days' and 
+  ingested_at < CURRENT_DATE - INTERVAL '1 day'
 group by "time_segment"
 order by "time_segment" 
 ---

--- a/metrics/PartitionWithTimeRangeExpr/trino.snap
+++ b/metrics/PartitionWithTimeRangeExpr/trino.snap
@@ -1,0 +1,21 @@
+
+[TestMetricsSuite/TestPartitionWithTimeRangeExpr - 1]
+select
+  DATE_ADD('DAY', 1, DATE_TRUNC('DAY', ingested_at)) as time_segment, 
+  'run_type' as field, 
+  count(*) as num_rows, 
+  count(run_type) as num_not_null, 
+  count(distinct run_type) as num_unique, 
+  count_if(run_type = 0) as num_empty, 
+  CAST(avg(run_type) AS DOUBLE) as mean, 
+  CAST(min(run_type) AS DOUBLE) as min, 
+  CAST(max(run_type) AS DOUBLE) as max, 
+  CAST(approx_percentile(run_type, 0.5) AS DOUBLE) as median, 
+  CAST(STDDEV(run_type) AS DOUBLE) as stddev
+from db.default.runs 
+where
+  ingested_at >= {from} and 
+  ingested_at < {to}
+group by DATE_ADD('DAY', 1, DATE_TRUNC('DAY', ingested_at))
+order by DATE_ADD('DAY', 1, DATE_TRUNC('DAY', ingested_at)) 
+---

--- a/metrics/PartitionWithTimeRangeExpr/trino.snap
+++ b/metrics/PartitionWithTimeRangeExpr/trino.snap
@@ -14,8 +14,8 @@ select
   CAST(STDDEV(run_type) AS DOUBLE) as stddev
 from db.default.runs 
 where
-  ingested_at >= {from} and 
-  ingested_at < {to}
+  ingested_at >= CURRENT_DATE - INTERVAL '3 days' and 
+  ingested_at < CURRENT_DATE - INTERVAL '1 day'
 group by DATE_ADD('DAY', 1, DATE_TRUNC('DAY', ingested_at))
 order by DATE_ADD('DAY', 1, DATE_TRUNC('DAY', ingested_at)) 
 ---

--- a/metrics/queries_test.go
+++ b/metrics/queries_test.go
@@ -304,7 +304,10 @@ func (s *MetricsSuite) TestPartitionWithTimeRangeExpr() {
 
 		queryBuilder := querybuilder.NewQueryBuilder(tableFqnExpr, expressions)
 		queryBuilder = queryBuilder.WithTimeSegment(dwhsql.TimeCol("ingested_at"), 24*time.Hour)
-		queryBuilder = queryBuilder.WithTimeRangeExpr(dwhsql.Sql("{from}"), dwhsql.Sql("{to}"))
+		queryBuilder = queryBuilder.WithTimeRangeExpr(
+			dwhsql.Sql("CURRENT_DATE - INTERVAL '3 days'"),
+			dwhsql.Sql("CURRENT_DATE - INTERVAL '1 day'"),
+		)
 		sql, err := queryBuilder.ToSql(dialect.Dialect)
 		s.Require().NoError(err)
 		s.Require().NotEmpty(sql)
@@ -330,12 +333,15 @@ func (s *MetricsSuite) TestTimeRangeExprPrecedence() {
 	expressions := NumericMetricsCols("run_type", dialect)
 	queryBuilder := querybuilder.NewQueryBuilder(tableFqnExpr, expressions)
 	queryBuilder = queryBuilder.WithFieldTimeRange(dwhsql.TimeCol("ingested_at"), from, to)
-	queryBuilder = queryBuilder.WithTimeRangeExpr(dwhsql.Sql("{from}"), dwhsql.Sql("{to}"))
+	queryBuilder = queryBuilder.WithTimeRangeExpr(
+		dwhsql.Sql("CURRENT_DATE - INTERVAL '3 days'"),
+		dwhsql.Sql("CURRENT_DATE - INTERVAL '1 day'"),
+	)
 
 	sql, err := queryBuilder.ToSql(dialect)
 	s.Require().NoError(err)
-	s.Contains(sql, "ingested_at >= {from}")
-	s.Contains(sql, "ingested_at < {to}")
+	s.Contains(sql, "ingested_at >= CURRENT_DATE - INTERVAL '3 days'")
+	s.Contains(sql, "ingested_at < CURRENT_DATE - INTERVAL '1 day'")
 	s.NotContains(sql, fromLit)
 	s.NotContains(sql, toLit)
 }

--- a/metrics/queries_test.go
+++ b/metrics/queries_test.go
@@ -294,6 +294,52 @@ func (s *MetricsSuite) TestSegmentWithTimeRangeWithFilter() {
 	}
 }
 
+func (s *MetricsSuite) TestPartitionWithTimeRangeExpr() {
+
+	tableFqnExpr := dwhsql.TableFqn("db", "default", "runs")
+
+	for _, dialect := range dwhsql.DialectsToTest() {
+
+		expressions := NumericMetricsCols("run_type", dialect.Dialect)
+
+		queryBuilder := querybuilder.NewQueryBuilder(tableFqnExpr, expressions)
+		queryBuilder = queryBuilder.WithTimeSegment(dwhsql.TimeCol("ingested_at"), 24*time.Hour)
+		queryBuilder = queryBuilder.WithTimeRangeExpr(dwhsql.Sql("{from}"), dwhsql.Sql("{to}"))
+		sql, err := queryBuilder.ToSql(dialect.Dialect)
+		s.Require().NoError(err)
+		s.Require().NotEmpty(sql)
+		s.T().Log(sql)
+
+		snaps.WithConfig(snaps.Dir("PartitionWithTimeRangeExpr"), snaps.Filename(dialect.Name)).MatchSnapshot(s.T(), sql)
+	}
+}
+
+func (s *MetricsSuite) TestTimeRangeExprPrecedence() {
+	// WithTimeRangeExpr should override any prior WithFieldTimeRange / WithTimeRange call.
+	tableFqnExpr := dwhsql.TableFqn("db", "default", "runs")
+	dialect := dwhsql.NewPostgresDialect()
+
+	now := time.Now().UTC().Truncate(time.Minute)
+	from := now.AddDate(0, 0, -3)
+	to := now.AddDate(0, 0, -1)
+	fromLit, err := dialect.ResolveTime(from)
+	s.Require().NoError(err)
+	toLit, err := dialect.ResolveTime(to)
+	s.Require().NoError(err)
+
+	expressions := NumericMetricsCols("run_type", dialect)
+	queryBuilder := querybuilder.NewQueryBuilder(tableFqnExpr, expressions)
+	queryBuilder = queryBuilder.WithFieldTimeRange(dwhsql.TimeCol("ingested_at"), from, to)
+	queryBuilder = queryBuilder.WithTimeRangeExpr(dwhsql.Sql("{from}"), dwhsql.Sql("{to}"))
+
+	sql, err := queryBuilder.ToSql(dialect)
+	s.Require().NoError(err)
+	s.Contains(sql, "ingested_at >= {from}")
+	s.Contains(sql, "ingested_at < {to}")
+	s.NotContains(sql, fromLit)
+	s.NotContains(sql, toLit)
+}
+
 func (s *MetricsSuite) TestFilters() {
 	for _, dialect := range dwhsql.DialectsToTest() {
 		tableFqnExpr := dwhsql.TableFqn("db", "default", "runs")

--- a/querybuilder/query_builder.go
+++ b/querybuilder/query_builder.go
@@ -20,9 +20,11 @@ func NewQueryBuilder(table TableExpr, cols []Expr) *QueryBuilder {
 }
 
 type QueryBuilder struct {
-	timeCol  *TimeColExpr
-	timeFrom time.Time
-	timeTo   time.Time
+	timeCol      *TimeColExpr
+	timeFrom     time.Time
+	timeTo       time.Time
+	timeFromExpr Expr
+	timeToExpr   Expr
 
 	timeSegment      *time.Duration
 	timeSegmentShift *time.Duration
@@ -76,6 +78,19 @@ func (b *QueryBuilder) WithFieldTimeRange(col *TimeColExpr, from, to time.Time) 
 	b.timeCol = col
 	b.timeFrom = from.Round(time.Minute)
 	b.timeTo = to.Round(time.Minute)
+
+	return b
+}
+
+// WithTimeRangeExpr sets arbitrary expressions for the lower (inclusive) and upper
+// (exclusive) bounds of the time-range WHERE clause. Useful for emitting SQL with
+// placeholder bounds (e.g. {from}, {to}) instead of materialized timestamp literals.
+// Requires the time column to be set via WithTimeSegment / WithShiftedTimeSegment /
+// WithFieldTimeRange; otherwise the WHERE clause is omitted (same gate as the
+// time.Time-based path).
+func (b *QueryBuilder) WithTimeRangeExpr(from, to Expr) *QueryBuilder {
+	b.timeFromExpr = from
+	b.timeToExpr = to
 
 	return b
 }
@@ -196,11 +211,14 @@ func (b *QueryBuilder) ToSql(dialect Dialect) (string, error) {
 	}
 
 	// Apply time constraint and segment if given. Not using BETWEEN as its inclusive for both limits and we risk double counting.
-	if b.timeCol != nil && b.timeFrom != (time.Time{}) && b.timeTo != (time.Time{}) {
-		q = q.Where(
-			Gte(b.timeCol, Time(b.timeFrom)),
-			Lt(b.timeCol, Time(b.timeTo)),
-		)
+	if b.timeCol != nil {
+		fromExpr, toExpr := b.resolveTimeBoundExprs()
+		if fromExpr != nil && toExpr != nil {
+			q = q.Where(
+				Gte(b.timeCol, fromExpr),
+				Lt(b.timeCol, toExpr),
+			)
+		}
 	}
 
 	if len(b.groupBy) > 0 {
@@ -234,6 +252,24 @@ func (b *QueryBuilder) ToSql(dialect Dialect) (string, error) {
 	}
 
 	return q.ToSql(dialect)
+}
+
+// resolveTimeBoundExprs returns the (from, to) WHERE-clause bound expressions.
+// Expression-typed bounds (WithTimeRangeExpr) take precedence over time.Time bounds.
+// Returns (nil, nil) if neither pair is fully set.
+func (b *QueryBuilder) resolveTimeBoundExprs() (Expr, Expr) {
+	fromExpr := b.timeFromExpr
+	toExpr := b.timeToExpr
+	if fromExpr == nil && b.timeFrom != (time.Time{}) {
+		fromExpr = Time(b.timeFrom)
+	}
+	if toExpr == nil && b.timeTo != (time.Time{}) {
+		toExpr = Time(b.timeTo)
+	}
+	if fromExpr == nil || toExpr == nil {
+		return nil, nil
+	}
+	return fromExpr, toExpr
 }
 
 func (b *QueryBuilder) segmentColumnName(i int) string {


### PR DESCRIPTION
## Summary

Adds `QueryBuilder.WithTimeRangeExpr(from, to Expr)` so callers can render the time-range `WHERE` clause with arbitrary expressions instead of materialized timestamp literals. Use cases include placeholder bounds (`{from}` / `{to}`) and dialect-native date math (`CURRENT_DATE - INTERVAL '3 days'`). Expression-typed bounds take precedence over `time.Time` bounds set by `WithFieldTimeRange` / `WithTimeRange`.

## Why

Cloud `kernel-anomalies` exposes monitor SQL on the asset graph (`MonitorAsset.executable_sqls`) so FE / Scout / MCP can render the exact SQL each monitor runs. The displayed SQL should advertise its time-window filter shape without committing to a specific tick's from/to range — `{from}`/`{to}` is the natural notation, but SQL date math (`CURRENT_DATE - INTERVAL '3 days'`) is equally valid and immediately runnable in a warehouse console.

Without this, the cloud caller would have to either (a) render with sentinel times and post-process the SQL string per dialect, or (b) skip the WHERE clause entirely. Both are worse than letting the builder produce expression-aware SQL natively.

## Examples

**Placeholder bounds** (templating/UI use case):
```go
qb.WithTimeRangeExpr(dwhsql.Sql("{from}"), dwhsql.Sql("{to}"))
// → WHERE ingested_at >= {from} AND ingested_at < {to}
```

**SQL date expressions** (runnable-in-console use case):
```go
qb.WithTimeRangeExpr(
    dwhsql.Sql("CURRENT_DATE - INTERVAL '3 days'"),
    dwhsql.Sql("CURRENT_DATE - INTERVAL '1 day'"),
)
// → WHERE ingested_at >= CURRENT_DATE - INTERVAL '3 days'
//     AND ingested_at < CURRENT_DATE - INTERVAL '1 day'
```

## Behavior

- `b.timeCol != nil` gate unchanged — no WHERE clause without a time column.
- If both `timeFromExpr` and `timeToExpr` are set: WHERE uses them.
- If only `timeFrom` / `timeTo` `time.Time` values are set: existing behavior (renders as `Time(...)` literals).
- Mixed (one Expr, one Time): falls back to whichever pair is fully set; otherwise omits the WHERE.

## Test plan
- [x] `TestPartitionWithTimeRangeExpr` — snapshot per dialect, uses `CURRENT_DATE - INTERVAL '3 days'` / `... '1 day'` to demonstrate dialect-native date math in `WHERE col >= ... and col < ...`
- [x] `TestTimeRangeExprPrecedence` — when both `WithFieldTimeRange` and `WithTimeRangeExpr` are called, expression bounds win; rendered timestamp literals are absent
- [x] Existing `TestPartitionWithTimeRange` / `TestSegmentWithTimeRangeWithFilter` still pass (time.Time-bound path unaffected)