### PR TITLE
snowflake: classify permission errors in IsPermissionError

### DIFF
--- a/scrapper/snowflake/permission_error_test.go
+++ b/scrapper/snowflake/permission_error_test.go
@@ -1,0 +1,40 @@
+package snowflake
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	gosnowflake "github.com/snowflakedb/gosnowflake"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPermissionError(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		assert.False(t, IsPermissionError(nil))
+	})
+
+	t.Run("does not exist or not authorized — bare", func(t *testing.T) {
+		err := errors.New("002003 (02000): SQL compilation error:\nSchema 'SNOWFLAKE.ACCOUNT_USAGE' does not exist or not authorized.")
+		assert.True(t, IsPermissionError(err))
+	})
+
+	t.Run("does not exist or not authorized — wrapped", func(t *testing.T) {
+		inner := errors.New("Object 'FOO' does not exist or not authorized.")
+		err := errors.Wrap(inner, "could not get columns for table SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY")
+		assert.True(t, IsPermissionError(err))
+	})
+
+	t.Run("SnowflakeError 3001 insufficient privileges", func(t *testing.T) {
+		err := &gosnowflake.SnowflakeError{Number: 3001, Message: "Insufficient privileges to operate on schema 'X'"}
+		assert.True(t, IsPermissionError(err))
+	})
+
+	t.Run("unrelated SnowflakeError", func(t *testing.T) {
+		err := &gosnowflake.SnowflakeError{Number: 1234, Message: "syntax error"}
+		assert.False(t, IsPermissionError(err))
+	})
+
+	t.Run("generic error", func(t *testing.T) {
+		assert.False(t, IsPermissionError(errors.New("connection reset by peer")))
+	})
+}

--- a/scrapper/snowflake/snowflake.go
+++ b/scrapper/snowflake/snowflake.go
@@ -108,7 +108,26 @@ func NewSnowflakeScrapper(ctx context.Context, conf *SnowflakeScrapperConf) (*Sn
 }
 
 func (e *SnowflakeScrapper) IsPermissionError(err error) bool {
-	return false
+	return IsPermissionError(err)
+}
+
+// IsPermissionError reports whether err is a Snowflake permission/authorization failure.
+// Recognises:
+//   - SQL compilation error 002003 with the canonical "does not exist or not authorized"
+//     message (most common shape — Snowflake intentionally conflates "no privilege" and
+//     "no such object" to prevent object-existence probing).
+//   - Error 003001 "Insufficient privileges to operate on ...".
+func IsPermissionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var sfErr *gosnowflake.SnowflakeError
+	if errors.As(err, &sfErr) {
+		if sfErr.Number == 3001 {
+			return true
+		}
+	}
+	return strings.Contains(err.Error(), "does not exist or not authorized")
 }
 
 func (e *SnowflakeScrapper) Capabilities() scrapper.Capabilities { return scrapper.Capabilities{} }


### PR DESCRIPTION
## Summary

`SnowflakeScrapper.IsPermissionError` always returned `false`, so downstream callers (notably cloud's `kernel-ext-dwh-metrics` query-logs job) silently treated authorization failures as infra errors and retried them indefinitely instead of surfacing the underlying problem to the user.

Now recognises:
- `gosnowflake.SnowflakeError.Number == 3001` — *"Insufficient privileges to operate on …"*.
- SQL compilation error `002003` with the canonical `"does not exist or not authorized"` message — Snowflake intentionally conflates "no privilege" and "no such object" to prevent existence-probing. In practice, when our code references a known system view (e.g. `SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY`), this is always a permission gap (missing `IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE`).

Also exports a top-level `IsPermissionError(err)` so callers can classify without holding a scrapper instance.

## Test plan
- [x] Added `TestIsPermissionError` covering nil, bare + wrapped 002003, `SnowflakeError{Number:3001}`, unrelated `SnowflakeError`, generic error.
- [x] `go build ./...` clean.
- [x] `go test ./scrapper/snowflake/...` passes.