### PR TITLE
bigquery: fix catalog scrape hang (busy-loop on terminal listing error) + timeout/auth hardening

### DIFF
--- a/exec/bigquery/bigquery.go
+++ b/exec/bigquery/bigquery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
@@ -15,7 +16,16 @@ import (
 	_ "github.com/lib/pq"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+	htransport "google.golang.org/api/transport/http"
 )
+
+// defaultHTTPTimeout caps each BigQuery REST round-trip. Without it the Go
+// BigQuery client's HTTP transport has no timeout, so a single stalled metadata
+// call hangs until the caller's context deadline (e.g. a 2h job timeout),
+// wedging the whole concurrent scrape. It is per round-trip, not per logical
+// operation, so it is safe for paginated query-result reads while still
+// interrupting a blackholed connection.
+const defaultHTTPTimeout = 2 * time.Minute
 
 // BigQueryConf configures the BigQuery executor connection.
 // Authentication precedence: AccessToken > CredentialsJson > CredentialsFile.
@@ -31,6 +41,11 @@ type BigQueryConf struct {
 	// AccessToken is an OAuth access token for user-level authentication.
 	// When set, it takes precedence over CredentialsJson and CredentialsFile.
 	AccessToken string
+	// HTTPTimeout caps each BigQuery REST round-trip (table/dataset metadata,
+	// table listing, query-result pages). Guards against a stalled connection
+	// hanging a scrape until the caller's job deadline. Zero uses
+	// defaultHTTPTimeout.
+	HTTPTimeout time.Duration
 }
 
 type Executor interface {
@@ -55,10 +70,24 @@ func NewBigqueryExecutor(ctx context.Context, conf *BigQueryConf) (*BigQueryExec
 		options = append(options, option.WithCredentialsFile(conf.CredentialsFile))
 	}
 
+	// Build the HTTP client ourselves so we can enforce a per-request timeout.
+	// htransport.NewClient applies the auth options above AND keeps the
+	// google-api OTel HTTP instrumentation; passing a bare &http.Client via
+	// option.WithHTTPClient would drop both credentials and tracing.
+	httpTimeout := conf.HTTPTimeout
+	if httpTimeout <= 0 {
+		httpTimeout = defaultHTTPTimeout
+	}
+	httpClient, _, err := htransport.NewClient(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	httpClient.Timeout = httpTimeout
+
 	client, err := bigquery.NewClient(
 		ctx,
 		conf.ProjectId,
-		options...,
+		option.WithHTTPClient(httpClient),
 	)
 	if err != nil {
 		return nil, err

--- a/exec/bigquery/bigquery.go
+++ b/exec/bigquery/bigquery.go
@@ -61,6 +61,11 @@ func NewBigqueryExecutor(ctx context.Context, conf *BigQueryConf) (*BigQueryExec
 
 	var options []option.ClientOption
 	options = append(options, option.WithUserAgent("synq-bq-client-v1.0.0"))
+	// bigquery.NewClient normally injects this scope before building its
+	// transport, but option.WithHTTPClient (below) overrides the transport — so
+	// we must apply the scope ourselves or credential-based auth fails with
+	// "invalid_scope" when fetching a token.
+	options = append(options, option.WithScopes(bigquery.Scope))
 	if conf.AccessToken != "" {
 		tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: conf.AccessToken})
 		options = append(options, option.WithTokenSource(tokenSource))

--- a/exec/bigquery/http_timeout_test.go
+++ b/exec/bigquery/http_timeout_test.go
@@ -1,0 +1,55 @@
+package bigquery
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+)
+
+// hungServerClient returns a BigQuery client pointed at a server that never
+// answers, reproducing the metadata call that wedged the catalog scrape. The
+// handler unblocks as soon as the client cancels/times out the request (so the
+// server shuts down cleanly), letting us measure how long the *client* waits.
+func hungServerClient(t *testing.T) *bigquery.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := bigquery.NewClient(
+		context.Background(),
+		"test-project",
+		option.WithEndpoint(srv.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(&http.Client{Timeout: 200 * time.Millisecond}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+// TestMetadataRespectsContextDeadline is the fix: a per-call context deadline
+// stops the BigQuery client's internal retry loop against a stalled endpoint, so
+// the call returns promptly instead of hanging until the job-level deadline. A
+// per-round-trip http.Client.Timeout alone is NOT enough — the client just
+// retries each fast-failing attempt forever until the context is cancelled.
+func TestMetadataRespectsContextDeadline(t *testing.T) {
+	client := hungServerClient(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := client.Dataset("d").Table("t").Metadata(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Less(t, elapsed, 30*time.Second, "per-call context deadline must bound the metadata call")
+}

--- a/exec/bigquery/tables_iterator_test.go
+++ b/exec/bigquery/tables_iterator_test.go
@@ -1,0 +1,54 @@
+package bigquery
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+// TestTablesIteratorDoesNotAdvancePastError documents the BigQuery iterator
+// behaviour that caused multi-hour catalog hangs: when tables.list returns a
+// non-Done error (e.g. a linked/shared dataset whose source was deleted returns
+// 404), the iterator does NOT advance — every subsequent Next() returns the same
+// error. A listing loop that does `continue` on such an error therefore
+// busy-loops forever. The scrapper must return on any non-Done error instead.
+func TestTablesIteratorDoesNotAdvancePastError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write(
+			[]byte(
+				`{"error":{"code":404,"message":"Not found: Dataset p:linked","errors":[{"reason":"notFound","message":"Not found: Dataset p:linked"}]}}`,
+			),
+		)
+	}))
+	defer srv.Close()
+
+	client, err := bigquery.NewClient(
+		context.Background(),
+		"test-project",
+		option.WithEndpoint(srv.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(&http.Client{Timeout: 5 * time.Second}),
+	)
+	require.NoError(t, err)
+	defer client.Close()
+
+	it := client.Dataset("linked").Tables(context.Background())
+	_, err1 := it.Next()
+	_, err2 := it.Next()
+
+	require.Error(t, err1)
+	require.False(t, errors.Is(err1, iterator.Done), "error must not be Done")
+	// The decisive assertion: the iterator stays in its error state, it does not
+	// advance to Done. `continue`-ing here is an infinite loop.
+	require.Error(t, err2)
+	require.False(t, errors.Is(err2, iterator.Done), "iterator must not advance to Done after an error")
+}

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,8 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/trinodb/trino-go-client v0.323.0
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
+	go.opentelemetry.io/otel v1.39.0
+	go.opentelemetry.io/otel/trace v1.39.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.48.0
 	golang.org/x/oauth2 v0.32.0
@@ -178,11 +180,9 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.39.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1 h1:PMmTMyvHScV9Mn8wc6ASge9uRcHy0jtqPd+fM35LmsQ=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
-buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260505234533-10059e7be493.1 h1:sbauY9roTxJQEGkOPGkoiovPOqUx6QcCirbogePXfM0=
-buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260505234533-10059e7be493.1/go.mod h1:TOEu9lrXJ0CuMq3lFyZRfqabnKBXTBkwpWebF6tli90=
-buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260506084046-e291beb8fa51.1 h1:2Oho9wfQr/eiKObwU/DpLCoqWYFathWBhR7RHfBtvcI=
-buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260506084046-e291beb8fa51.1/go.mod h1:TOEu9lrXJ0CuMq3lFyZRfqabnKBXTBkwpWebF6tli90=
 buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260506084438-595c0ebf0bd4.1 h1:Dwy6qrydFUIzFfZbFH/GwZMtgGvRA5ax1F3Yj+ZwH3k=
 buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260506084438-595c0ebf0bd4.1/go.mod h1:TOEu9lrXJ0CuMq3lFyZRfqabnKBXTBkwpWebF6tli90=
 cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=

--- a/scrapper/bigquery/bigquery.go
+++ b/scrapper/bigquery/bigquery.go
@@ -126,54 +126,75 @@ func (e *BigQueryScrapper) listDatasets(ctx context.Context) ([]*bigquery.Datase
 	}
 
 	client := e.executor.GetBigQueryClient()
-	it := client.Datasets(ctx)
-	it.ListHidden = true
 
-	var result []*bigquery.Dataset
-	for {
-		ds, err := it.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			if errIsNotFound(err) || errIsAccessDenied(err) {
-				continue
+	// A non-Done error is terminal — the iterator does not advance past it, so
+	// `continue` would busy-loop forever. Retry handles genuine rate limits.
+	result, err := withRateLimitRetry(ctx, e.rateLimitCfg, func(ctx context.Context) ([]*bigquery.Dataset, error) {
+		it := client.Datasets(ctx)
+		it.ListHidden = true
+
+		var result []*bigquery.Dataset
+		for {
+			ds, err := it.Next()
+			if errors.Is(err, iterator.Done) {
+				break
 			}
-			return nil, e.scrapeError(ctx, "datasets.list", "", "", err)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, ds)
 		}
-		result = append(result, ds)
+		return result, nil
+	})
+	if err != nil {
+		return nil, e.scrapeError(ctx, "datasets.list", "", "", err)
 	}
 	return result, nil
 }
 
-// listTableIDs lists every table ID in a dataset under a context bounded by
-// CallTimeout, so a stalled listing page can't hang the scrape. Tables the
-// caller can't see (not-found / access-denied) are skipped, consistent with the
-// rest of the scrapper.
+// listTableIDs lists every table ID in a dataset. The listing runs through
+// withRateLimitRetry so a genuine rate-limit backs off, and each attempt is
+// bounded by CallTimeout so a stalled page can't hang the scrape.
+//
+// A non-Done error from the iterator is TERMINAL: the BigQuery iterator does not
+// advance past it, so `continue` would call Next() again, get the same error, and
+// busy-loop forever — the root cause of the multi-hour catalog hangs. So we
+// always return on error and let the caller fail the scrape (failing is safe:
+// a failed fetch publishes nothing, so no assets are wrongly marked deleted).
 func (e *BigQueryScrapper) listTableIDs(ctx context.Context, datasetID string) ([]string, error) {
-	listCtx := ctx
-	if e.rateLimitCfg.CallTimeout > 0 {
-		var cancel context.CancelFunc
-		listCtx, cancel = context.WithTimeout(ctx, e.rateLimitCfg.CallTimeout)
-		defer cancel()
-	}
-
-	it := e.executor.GetBigQueryClient().Dataset(datasetID).Tables(listCtx)
-	var tableIDs []string
-	for {
-		table, err := it.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			if errIsNotFound(err) || errIsAccessDenied(err) {
-				continue
+	ids, err := withRateLimitRetry(ctx, e.rateLimitCfg, func(ctx context.Context) ([]string, error) {
+		it := e.executor.GetBigQueryClient().Dataset(datasetID).Tables(ctx)
+		var ids []string
+		for {
+			table, err := it.Next()
+			if errors.Is(err, iterator.Done) {
+				break
 			}
-			return nil, e.scrapeError(ctx, "tables.list", datasetID, "", err)
+			if err != nil {
+				return nil, err
+			}
+			ids = append(ids, table.TableID)
 		}
-		tableIDs = append(tableIDs, table.TableID)
+		return ids, nil
+	})
+	if err != nil {
+		// 404 means the dataset itself is gone — typically a linked/shared
+		// dataset whose source was deleted (its Metadata() still resolves but
+		// listing its tables 404s). It genuinely no longer exists, so skip it and
+		// let the rest of the scrape proceed. Access-denied and other errors
+		// still fail the scrape: we must not silently drop — and thereby delete —
+		// tables we simply can't see right now.
+		if errIsNotFound(err) {
+			logging.GetLogger(ctx).
+				WithField("executor", "bigquery").
+				WithField("bq_dataset", datasetID).
+				WithError(err).
+				Warn("skipping dataset that no longer exists (tables.list returned not-found)")
+			return nil, nil
+		}
+		return nil, e.scrapeError(ctx, "tables.list", datasetID, "", err)
 	}
-	return tableIDs, nil
+	return ids, nil
 }
 
 func (e *BigQueryScrapper) queryRows(ctx context.Context, q string, args ...interface{}) (*bigquery.RowIterator, error) {

--- a/scrapper/bigquery/bigquery.go
+++ b/scrapper/bigquery/bigquery.go
@@ -139,11 +139,41 @@ func (e *BigQueryScrapper) listDatasets(ctx context.Context) ([]*bigquery.Datase
 			if errIsNotFound(err) || errIsAccessDenied(err) {
 				continue
 			}
-			return nil, err
+			return nil, e.scrapeError(ctx, "datasets.list", "", "", err)
 		}
 		result = append(result, ds)
 	}
 	return result, nil
+}
+
+// listTableIDs lists every table ID in a dataset under a context bounded by
+// CallTimeout, so a stalled listing page can't hang the scrape. Tables the
+// caller can't see (not-found / access-denied) are skipped, consistent with the
+// rest of the scrapper.
+func (e *BigQueryScrapper) listTableIDs(ctx context.Context, datasetID string) ([]string, error) {
+	listCtx := ctx
+	if e.rateLimitCfg.CallTimeout > 0 {
+		var cancel context.CancelFunc
+		listCtx, cancel = context.WithTimeout(ctx, e.rateLimitCfg.CallTimeout)
+		defer cancel()
+	}
+
+	it := e.executor.GetBigQueryClient().Dataset(datasetID).Tables(listCtx)
+	var tableIDs []string
+	for {
+		table, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			if errIsNotFound(err) || errIsAccessDenied(err) {
+				continue
+			}
+			return nil, e.scrapeError(ctx, "tables.list", datasetID, "", err)
+		}
+		tableIDs = append(tableIDs, table.TableID)
+	}
+	return tableIDs, nil
 }
 
 func (e *BigQueryScrapper) queryRows(ctx context.Context, q string, args ...interface{}) (*bigquery.RowIterator, error) {

--- a/scrapper/bigquery/query_catalog.go
+++ b/scrapper/bigquery/query_catalog.go
@@ -11,9 +11,6 @@ import (
 	"github.com/getsynq/dwhsupport/scrapper"
 	"github.com/samber/lo"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/pkg/errors"
-	"google.golang.org/api/iterator"
 )
 
 func (e *BigQueryScrapper) QueryCatalog(ctx context.Context) ([]*scrapper.CatalogColumnRow, error) {
@@ -47,32 +44,19 @@ func (e *BigQueryScrapper) QueryCatalog(ctx context.Context) ([]*scrapper.Catalo
 
 		log = log.WithField("dataset", dataset.DatasetID)
 
-		datasetMeta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func() (*bigquery.DatasetMetadata, error) {
-			return e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Metadata(groupCtx)
+		datasetMeta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func(ctx context.Context) (*bigquery.DatasetMetadata, error) {
+			return e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Metadata(ctx)
 		})
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to get dataset metadata")
+			return nil, e.scrapeError(groupCtx, "dataset.metadata", dataset.DatasetID, "", err)
 		}
 		datasetTags := labelsToTags(datasetMeta.Labels)
 
 		numTables := 0
-		tables := e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Tables(groupCtx)
 
-		// Collect table IDs
-		tableIds := make([]string, 0)
-		for {
-			table, err := tables.Next()
-			if errors.Is(err, iterator.Done) {
-				break
-			}
-			if err != nil {
-				if errIsNotFound(err) || errIsAccessDenied(err) {
-					continue
-				}
-				return nil, err
-			}
-
-			tableIds = append(tableIds, table.TableID)
+		tableIds, err := e.listTableIDs(groupCtx, dataset.DatasetID)
+		if err != nil {
+			return nil, err
 		}
 
 		// Collect sharded tables
@@ -104,14 +88,14 @@ func (e *BigQueryScrapper) QueryCatalog(ctx context.Context) ([]*scrapper.Catalo
 			}
 
 			g.Go(func() error {
-				tableMeta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func() (*bigquery.TableMetadata, error) {
-					return e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Table(tableId).Metadata(groupCtx)
+				tableMeta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func(ctx context.Context) (*bigquery.TableMetadata, error) {
+					return e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Table(tableId).Metadata(ctx)
 				})
 				if err != nil {
 					if errIsNotFound(err) || errIsAccessDenied(err) {
 						return nil
 					}
-					return err
+					return e.scrapeError(groupCtx, "table.metadata", dataset.DatasetID, tableId, err)
 				}
 
 				var tableTags []*scrapper.Tag = datasetTags

--- a/scrapper/bigquery/query_sql_definitions.go
+++ b/scrapper/bigquery/query_sql_definitions.go
@@ -67,24 +67,11 @@ func (e *BigQueryScrapper) querySqlDefinitionsApi(ctx context.Context) ([]*scrap
 
 		log = log.WithField("dataset", dataset.DatasetID)
 
-		tables := e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Tables(groupCtx)
 		numTables := 0
 
-		// Collect table IDs
-		tableIds := make([]string, 0)
-		for {
-			table, err := tables.Next()
-			if errors.Is(err, iterator.Done) {
-				break
-			}
-			if err != nil {
-				if errIsNotFound(err) || errIsAccessDenied(err) {
-					continue
-				}
-				return nil, err
-			}
-
-			tableIds = append(tableIds, table.TableID)
+		tableIds, err := e.listTableIDs(groupCtx, dataset.DatasetID)
+		if err != nil {
+			return nil, err
 		}
 
 		// Collect sharded tables
@@ -116,14 +103,14 @@ func (e *BigQueryScrapper) querySqlDefinitionsApi(ctx context.Context) ([]*scrap
 			}
 
 			g.Go(func() error {
-				meta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func() (*bigquery.TableMetadata, error) {
-					return e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Table(tableId).Metadata(groupCtx)
+				meta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func(ctx context.Context) (*bigquery.TableMetadata, error) {
+					return e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Table(tableId).Metadata(ctx)
 				})
 				if err != nil {
 					if errIsNotFound(err) || errIsAccessDenied(err) {
 						return nil
 					}
-					return err
+					return e.scrapeError(groupCtx, "table.metadata", dataset.DatasetID, tableId, err)
 				}
 
 				mutex.Lock()

--- a/scrapper/bigquery/query_table_metrics.go
+++ b/scrapper/bigquery/query_table_metrics.go
@@ -2,7 +2,6 @@ package bigquery
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/getsynq/dwhsupport/logging"
 	"github.com/getsynq/dwhsupport/scrapper"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/api/iterator"
 )
 
 // QueryTableMetrics collects table metrics (row counts, sizes, freshness) via the
@@ -40,18 +38,13 @@ func (e *BigQueryScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFet
 			continue
 		}
 
-		tables := e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Tables(groupCtx)
-		for {
-			table, err := tables.Next()
-			if errors.Is(err, iterator.Done) {
-				break
-			}
-			if err != nil {
-				if errIsNotFound(err) || errIsAccessDenied(err) {
-					break
-				}
-				return nil, err
-			}
+		tableIds, err := e.listTableIDs(groupCtx, dataset.DatasetID)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, tableId := range tableIds {
+			tableId := tableId
 
 			select {
 			case <-groupCtx.Done():
@@ -60,14 +53,14 @@ func (e *BigQueryScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFet
 			}
 
 			g.Go(func() error {
-				tableMeta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func() (*bigquery.TableMetadata, error) {
-					return table.Metadata(groupCtx)
+				tableMeta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func(ctx context.Context) (*bigquery.TableMetadata, error) {
+					return e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Table(tableId).Metadata(ctx)
 				})
 				if err != nil {
 					if errIsNotFound(err) || errIsAccessDenied(err) {
 						return nil
 					}
-					return err
+					return e.scrapeError(groupCtx, "table.metadata", dataset.DatasetID, tableId, err)
 				}
 
 				numRows := int64(tableMeta.NumRows)
@@ -83,7 +76,7 @@ func (e *BigQueryScrapper) QueryTableMetrics(ctx context.Context, lastMetricsFet
 				results = append(results, &scrapper.TableMetricsRow{
 					Database:  e.conf.ProjectId,
 					Schema:    dataset.DatasetID,
-					Table:     table.TableID,
+					Table:     tableId,
 					RowCount:  &numRows,
 					SizeBytes: &numBytes,
 					UpdatedAt: updatedAt,

--- a/scrapper/bigquery/query_tables.go
+++ b/scrapper/bigquery/query_tables.go
@@ -8,10 +8,8 @@ import (
 	"cloud.google.com/go/bigquery"
 	"github.com/getsynq/dwhsupport/logging"
 	"github.com/getsynq/dwhsupport/scrapper"
-	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/api/iterator"
 )
 
 func (e *BigQueryScrapper) QueryTables(ctx context.Context, opts ...scrapper.QueryTablesOption) ([]*scrapper.TableRow, error) {
@@ -47,32 +45,19 @@ func (e *BigQueryScrapper) QueryTables(ctx context.Context, opts ...scrapper.Que
 
 		log = log.WithField("dataset", dataset.DatasetID)
 
-		datasetMeta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func() (*bigquery.DatasetMetadata, error) {
-			return e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Metadata(groupCtx)
+		datasetMeta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func(ctx context.Context) (*bigquery.DatasetMetadata, error) {
+			return e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Metadata(ctx)
 		})
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to get dataset metadata")
+			return nil, e.scrapeError(groupCtx, "dataset.metadata", dataset.DatasetID, "", err)
 		}
 		datasetTags := labelsToTags(datasetMeta.Labels)
 
 		numTables := 0
-		tables := e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Tables(groupCtx)
 
-		// Collect table IDs
-		tableIds := make([]string, 0)
-		for {
-			table, err := tables.Next()
-			if errors.Is(err, iterator.Done) {
-				break
-			}
-			if err != nil {
-				if errIsNotFound(err) || errIsAccessDenied(err) {
-					continue
-				}
-				return nil, err
-			}
-
-			tableIds = append(tableIds, table.TableID)
+		tableIds, err := e.listTableIDs(groupCtx, dataset.DatasetID)
+		if err != nil {
+			return nil, err
 		}
 
 		// Collect sharded tables
@@ -105,14 +90,14 @@ func (e *BigQueryScrapper) QueryTables(ctx context.Context, opts ...scrapper.Que
 
 			includeConstraints := cfg.IncludeConstraints
 			g.Go(func() error {
-				tableMeta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func() (*bigquery.TableMetadata, error) {
-					return e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Table(tableId).Metadata(groupCtx)
+				tableMeta, err := withRateLimitRetry(groupCtx, e.rateLimitCfg, func(ctx context.Context) (*bigquery.TableMetadata, error) {
+					return e.executor.GetBigQueryClient().Dataset(dataset.DatasetID).Table(tableId).Metadata(ctx)
 				})
 				if err != nil {
 					if errIsNotFound(err) || errIsAccessDenied(err) {
 						return nil
 					}
-					return err
+					return e.scrapeError(groupCtx, "table.metadata", dataset.DatasetID, tableId, err)
 				}
 
 				var tableTags []*scrapper.Tag = datasetTags

--- a/scrapper/bigquery/retry.go
+++ b/scrapper/bigquery/retry.go
@@ -18,6 +18,14 @@ type RateLimitConfig struct {
 	MaxDelay time.Duration
 	// MetadataConcurrency limits the number of concurrent table.Metadata() calls.
 	MetadataConcurrency int
+	// CallTimeout bounds each individual BigQuery API call — including the
+	// client's own internal retries. It is the real guard against a stalled
+	// metadata call hanging a scrape: the BigQuery client retries a fast-failing
+	// request forever, so only a context deadline stops it. Without this a single
+	// blackholed call blocks until the caller's context (e.g. a 2h job timeout)
+	// fires, wedging the whole concurrent fan-out behind it. Zero disables the
+	// per-call bound.
+	CallTimeout time.Duration
 }
 
 var DefaultRateLimitConfig = RateLimitConfig{
@@ -25,17 +33,20 @@ var DefaultRateLimitConfig = RateLimitConfig{
 	BaseDelay:           1 * time.Second,
 	MaxDelay:            30 * time.Second,
 	MetadataConcurrency: 20,
+	CallTimeout:         2 * time.Minute,
 }
 
-// withRateLimitRetry retries fn when it returns a rate-limit error (HTTP 429 /
-// gRPC ResourceExhausted), using exponential backoff with jitter. Non-rate-limit
-// errors are returned immediately.
-func withRateLimitRetry[T any](ctx context.Context, cfg RateLimitConfig, fn func() (T, error)) (T, error) {
+// withRateLimitRetry runs fn, retrying when it returns a rate-limit error (HTTP
+// 429 / gRPC ResourceExhausted) using exponential backoff with jitter.
+// Non-rate-limit errors are returned immediately. Each attempt is given its own
+// context bounded by cfg.CallTimeout so a stalled call (which the BigQuery client
+// would otherwise retry internally forever) fails promptly instead of hanging.
+func withRateLimitRetry[T any](ctx context.Context, cfg RateLimitConfig, fn func(context.Context) (T, error)) (T, error) {
 	var zero T
 	delay := cfg.BaseDelay
 
 	for attempt := range cfg.MaxRetries {
-		result, err := fn()
+		result, err := callWithTimeout(ctx, cfg.CallTimeout, fn)
 		if err == nil {
 			return result, nil
 		}
@@ -64,4 +75,16 @@ func withRateLimitRetry[T any](ctx context.Context, cfg RateLimitConfig, fn func
 	}
 
 	return zero, nil
+}
+
+// callWithTimeout invokes fn with a child context bounded by timeout (when > 0),
+// so the BigQuery client's internal retry loop is cut off rather than running
+// until the parent context's far-off deadline.
+func callWithTimeout[T any](ctx context.Context, timeout time.Duration, fn func(context.Context) (T, error)) (T, error) {
+	if timeout <= 0 {
+		return fn(ctx)
+	}
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return fn(callCtx)
 }

--- a/scrapper/bigquery/retry.go
+++ b/scrapper/bigquery/retry.go
@@ -25,6 +25,11 @@ type RateLimitConfig struct {
 	// blackholed call blocks until the caller's context (e.g. a 2h job timeout)
 	// fires, wedging the whole concurrent fan-out behind it. Zero disables the
 	// per-call bound.
+	//
+	// The default is generous on purpose: in practice these calls run ~100ms
+	// (p99.9 ~0.6s; the slowest observed across ~10M calls/day was ~29s), so 60s
+	// is ~2x the real-world worst case — it never trips a healthy call but still
+	// catches a hang within a minute instead of hours.
 	CallTimeout time.Duration
 }
 
@@ -33,7 +38,7 @@ var DefaultRateLimitConfig = RateLimitConfig{
 	BaseDelay:           1 * time.Second,
 	MaxDelay:            30 * time.Second,
 	MetadataConcurrency: 20,
-	CallTimeout:         2 * time.Minute,
+	CallTimeout:         60 * time.Second,
 }
 
 // withRateLimitRetry runs fn, retrying when it returns a rate-limit error (HTTP

--- a/scrapper/bigquery/retry_test.go
+++ b/scrapper/bigquery/retry_test.go
@@ -1,0 +1,50 @@
+package bigquery
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithRateLimitRetryCallTimeout proves a hung call is bounded by CallTimeout
+// rather than blocking until the parent context's (far-off) deadline. This is the
+// core guard for the catalog-scrape hang: the BigQuery client would otherwise
+// retry a stalled metadata request forever.
+func TestWithRateLimitRetryCallTimeout(t *testing.T) {
+	cfg := RateLimitConfig{
+		MaxRetries:  3,
+		BaseDelay:   time.Millisecond,
+		MaxDelay:    time.Millisecond,
+		CallTimeout: 100 * time.Millisecond,
+	}
+
+	start := time.Now()
+	_, err := withRateLimitRetry(context.Background(), cfg, func(ctx context.Context) (int, error) {
+		// Simulate a call that hangs until its context is cancelled.
+		<-ctx.Done()
+		return 0, ctx.Err()
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Less(t, elapsed, 2*time.Second, "CallTimeout must bound a hung call")
+}
+
+// TestWithRateLimitRetryNoTimeout verifies CallTimeout=0 leaves the call
+// unbounded (the parent context governs), preserving the opt-out.
+func TestWithRateLimitRetryNoTimeout(t *testing.T) {
+	cfg := RateLimitConfig{MaxRetries: 1, CallTimeout: 0}
+
+	called := false
+	_, err := withRateLimitRetry(context.Background(), cfg, func(ctx context.Context) (int, error) {
+		called = true
+		require.NoError(t, ctx.Err())
+		_, hasDeadline := ctx.Deadline()
+		require.False(t, hasDeadline, "CallTimeout=0 must not impose a deadline")
+		return 42, nil
+	})
+	require.NoError(t, err)
+	require.True(t, called)
+}

--- a/scrapper/bigquery/scrape_error.go
+++ b/scrapper/bigquery/scrape_error.go
@@ -1,0 +1,54 @@
+package bigquery
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/logging"
+	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// scrapeError records a fatal metadata-scrape error so it is usable in both logs
+// and traces, then returns it wrapped with the failing object's identity.
+//
+// The fan-out scrappers deliberately return (never swallow) the result: a
+// partial catalog would make the un-fetched tables look deleted downstream, so a
+// stalled or failing metadata call must fail the whole scrape rather than drop
+// tables silently. Permission/not-found errors are filtered out by the callers
+// before reaching here — those are expected and skipped.
+//
+// dataset/table may be empty for dataset- or project-level operations.
+func (e *BigQueryScrapper) scrapeError(ctx context.Context, op, dataset, table string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	wrapped := errors.Wrapf(err, "bigquery %s failed (project=%s dataset=%s table=%s)", op, e.conf.ProjectId, dataset, table)
+
+	logging.GetLogger(ctx).
+		WithField("executor", "bigquery").
+		WithField("bq_op", op).
+		WithField("bq_project", e.conf.ProjectId).
+		WithField("bq_dataset", dataset).
+		WithField("bq_table", table).
+		WithError(err).
+		Error("BigQuery metadata scrape failed")
+
+	// Annotate the active span so the failing object is queryable in traces.
+	// Until the per-request HTTP timeout landed a stalled call emitted no span
+	// at all (spans only export on completion), leaving a silent gap; now the
+	// timeout surfaces an error we can attach here.
+	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+		span.RecordError(wrapped, trace.WithAttributes(
+			attribute.String("synq.bq.op", op),
+			attribute.String("synq.bq.project", e.conf.ProjectId),
+			attribute.String("synq.bq.dataset", dataset),
+			attribute.String("synq.bq.table", table),
+		))
+		span.SetStatus(codes.Error, wrapped.Error())
+	}
+
+	return wrapped
+}


### PR DESCRIPTION
## Root cause: infinite busy-loop on a terminal listing error

A BigQuery catalog scrape could spin for hours doing nothing, until the job's 2h timeout killed it. Captured goroutine dump showed the scrape **on-CPU** (not blocked) inside the dataset/table **listing loop**.

The listing loops did `continue` on a not-found / access-denied error from the iterator. But the BigQuery iterator **does not advance past a non-Done error** — every subsequent `Next()` returns the *same* error — so `continue` busy-loops forever. Because it never blocks, it emits no spans, no logs, and ignores every context deadline.

Trigger in the wild: a **linked/shared dataset whose source was deleted**. Its `Metadata()` still resolves, but listing its tables returns `404 Not found: Dataset …`. The scrape spun on that 404.

### Fix
A non-Done iterator error is **terminal** — return, never `continue`. `listTableIDs` / `listDatasets` now run through the retry helper (genuine rate limits back off; each attempt bounded by `CallTimeout`) and:
- **404 not-found** on a dataset's table listing → skip that dataset (it's genuinely gone) and let the rest of the scrape proceed;
- **access-denied / other** → fail the scrape with the dataset named (a failed fetch publishes nothing, so nothing is wrongly marked deleted).

Verified end-to-end against the affected warehouse: a scrape that previously hung ~2h now completes in **~3min over the full catalog (~3.6k tables)**, skipping the single dead dataset with a clear warning. Regression test pins the iterator's no-advance-on-error behaviour.

## Hardening included in this PR

These don't fix the busy-loop but close real adjacent gaps found along the way:

- **Per-call `CallTimeout` (default 60s)** on every metadata call: the BigQuery client otherwise retries a *stalled* request internally forever, so only a context deadline bounds it. Calibrated from production latency (metadata calls run ~100ms; p99.9 ~0.6s; slowest observed ~29s).
- **Custom HTTP client via `htransport`** with a per-round-trip timeout backstop — built so it preserves both auth **and** the google-api OTel HTTP spans (a bare `&http.Client` via `WithHTTPClient` would drop both). This also required **re-applying `option.WithScopes(bigquery.Scope)`**, which `WithHTTPClient` otherwise overrides → credential auth was failing with `invalid_scope` (caught by the prod catalog test).
- **Usable error logging/tracing** via a centralized `scrapeError`: structured fields + `span.RecordError` with the failing dataset/table, so failures are queryable instead of silent.

## Tests
- iterator does not advance past a non-Done error (guards against re-introducing `continue`);
- per-call context deadline bounds a stalled metadata call; `CallTimeout` bounds a hung call.