### PR TITLE
sqldialect: add And() condition helper

### DIFF
--- a/sqldialect/cond.go
+++ b/sqldialect/cond.go
@@ -204,3 +204,32 @@ func (e *OrExpr) ToSql(dialect Dialect) (string, error) {
 }
 
 func (e *OrExpr) IsCondExpr() {}
+
+// AndExpr joins conditions with AND.
+//
+// Unlike AndGroups (which parenthesizes each operand individually), And renders
+// a flat "a and b and c". No outer parentheses are added: AND binds tighter than
+// OR, so the result composes correctly when nested inside Or(...). Nested Or
+// operands parenthesize themselves, so mixed expressions stay well-formed.
+type AndExpr struct {
+	conds []CondExpr
+}
+
+func And(conds ...CondExpr) *AndExpr {
+	return &AndExpr{conds: conds}
+}
+
+func (e *AndExpr) ToSql(dialect Dialect) (string, error) {
+	if len(e.conds) == 0 {
+		return "", nil
+	}
+
+	condsSql, err := exprsToSql(e.conds, dialect)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.Join(condsSql, " and "), nil
+}
+
+func (e *AndExpr) IsCondExpr() {}

--- a/sqldialect/cond_test.go
+++ b/sqldialect/cond_test.go
@@ -1,0 +1,58 @@
+package sqldialect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type CondSuite struct {
+	suite.Suite
+}
+
+func TestCondSuite(t *testing.T) {
+	suite.Run(t, new(CondSuite))
+}
+
+// pg is an arbitrary dialect; And/Or rendering is dialect-independent (the
+// operands resolve per dialect, the boolean joining does not).
+func (s *CondSuite) sql(expr Expr) string {
+	out, err := expr.ToSql(NewPostgresDialect())
+	s.Require().NoError(err)
+	return out
+}
+
+func (s *CondSuite) TestAndFlatNoOuterParens() {
+	expr := And(
+		Gte(Sql("id"), Int64(1)),
+		Lt(Sql("id"), Int64(26)),
+	)
+	s.Equal("id >= 1 and id < 26", s.sql(expr))
+}
+
+func (s *CondSuite) TestAndSingleCondition() {
+	s.Equal("id >= 1", s.sql(And(Gte(Sql("id"), Int64(1)))))
+}
+
+func (s *CondSuite) TestAndEmpty() {
+	s.Equal("", s.sql(And()))
+}
+
+// AND binds tighter than OR, so a flat And nested in Or stays correct without
+// extra parentheses around the And; the Or supplies its own.
+func (s *CondSuite) TestAndNestedInOr() {
+	expr := Or(
+		And(Gte(Sql("id"), Int64(1)), Lt(Sql("id"), Int64(26))),
+		Eq(Sql("id"), Int64(99)),
+	)
+	s.Equal("(id >= 1 and id < 26 or id = 99)", s.sql(expr))
+}
+
+// Or parenthesizes itself, so an Or nested inside And is well-formed.
+func (s *CondSuite) TestOrNestedInAnd() {
+	expr := And(
+		Or(Eq(Sql("a"), Int64(1)), Eq(Sql("a"), Int64(2))),
+		Eq(Sql("b"), Int64(3)),
+	)
+	s.Equal("(a = 1 or a = 2) and b = 3", s.sql(expr))
+}


### PR DESCRIPTION
## Summary

The `sqldialect` DSL had `Or()` but no flat `And()`. Callers needing a conjunction had to either use `AndGroups` (which parenthesizes each operand: `(a) and (b)`) or join raw SQL strings by hand.

This adds `And(conds ...CondExpr)` mirroring `Or()`:
- Renders a flat `a and b and c` with **no outer parentheses**.
- `AND` binds tighter than `OR`, so the result composes correctly when nested inside `Or(...)`; nested `Or()` operands parenthesize themselves.

Motivated by the synq-recon checksum SQL refactor (getsynq/cloud), which builds half-open key-range conditions (`key >= lo AND key < hi`) and currently falls back to `AndGroups` for the multi-term CASE form.

## Tests

`cond_test.go` covers flat rendering, single/empty operands, and both nesting directions (`And` in `Or`, `Or` in `And`).