### PR TITLE
sqldialect: add CrossJoin primitive; widen builder fields to interfaces

### DIFF
--- a/querybuilder/query_builder.go
+++ b/querybuilder/query_builder.go
@@ -39,8 +39,8 @@ type QueryBuilder struct {
 
 	table   TableExpr
 	cols    []Expr
-	limit   *LimitExpr
-	orderBy []*OrderExpr
+	limit   LimitClauseExpr
+	orderBy []OrderByExpr
 
 	cteNames   []string
 	cteQueries []CteExpr
@@ -124,7 +124,7 @@ func (b *QueryBuilder) WithLimit(limit int64) *QueryBuilder {
 	return b
 }
 
-func (b *QueryBuilder) OrderBy(orderBy ...*OrderExpr) *QueryBuilder {
+func (b *QueryBuilder) OrderBy(orderBy ...OrderByExpr) *QueryBuilder {
 
 	b.orderBy = append(b.orderBy, orderBy...)
 
@@ -228,7 +228,7 @@ func (b *QueryBuilder) ToSql(dialect Dialect) (string, error) {
 	if len(b.orderBy) > 0 {
 		q = q.OrderBy(b.orderBy...)
 	} else {
-		var orderBy []*OrderExpr
+		var orderBy []OrderByExpr
 		if timeExpr != nil {
 			orderBy = append(orderBy, Asc(AggregationColumnReference(timeExpr, "time_segment")))
 		}

--- a/sqldialect/CrossJoinExpr/bigquery.snap
+++ b/sqldialect/CrossJoinExpr/bigquery.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestCrossJoinExpr - 1]
+cross join (
+SELECT COUNT(*) AS cnt FROM t
+) AS _recon_tgt
+---

--- a/sqldialect/CrossJoinExpr/clickhouse.snap
+++ b/sqldialect/CrossJoinExpr/clickhouse.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestCrossJoinExpr - 1]
+cross join (
+SELECT COUNT(*) AS cnt FROM t
+) AS _recon_tgt
+---

--- a/sqldialect/CrossJoinExpr/databricks.snap
+++ b/sqldialect/CrossJoinExpr/databricks.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestCrossJoinExpr - 1]
+cross join (
+SELECT COUNT(*) AS cnt FROM t
+) AS _recon_tgt
+---

--- a/sqldialect/CrossJoinExpr/duckdb.snap
+++ b/sqldialect/CrossJoinExpr/duckdb.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestCrossJoinExpr - 1]
+cross join (
+SELECT COUNT(*) AS cnt FROM t
+) AS _recon_tgt
+---

--- a/sqldialect/CrossJoinExpr/mssql.snap
+++ b/sqldialect/CrossJoinExpr/mssql.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestCrossJoinExpr - 1]
+cross join (
+SELECT COUNT(*) AS cnt FROM t
+) AS _recon_tgt
+---

--- a/sqldialect/CrossJoinExpr/mysql.snap
+++ b/sqldialect/CrossJoinExpr/mysql.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestCrossJoinExpr - 1]
+cross join (
+SELECT COUNT(*) AS cnt FROM t
+) AS _recon_tgt
+---

--- a/sqldialect/CrossJoinExpr/oracle.snap
+++ b/sqldialect/CrossJoinExpr/oracle.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestCrossJoinExpr - 1]
+cross join (
+SELECT COUNT(*) AS cnt FROM t
+) AS _recon_tgt
+---

--- a/sqldialect/CrossJoinExpr/postgres.snap
+++ b/sqldialect/CrossJoinExpr/postgres.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestCrossJoinExpr - 1]
+cross join (
+SELECT COUNT(*) AS cnt FROM t
+) AS _recon_tgt
+---

--- a/sqldialect/CrossJoinExpr/redshift.snap
+++ b/sqldialect/CrossJoinExpr/redshift.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestCrossJoinExpr - 1]
+cross join (
+SELECT COUNT(*) AS cnt FROM t
+) AS _recon_tgt
+---

--- a/sqldialect/CrossJoinExpr/snowflake.snap
+++ b/sqldialect/CrossJoinExpr/snowflake.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestCrossJoinExpr - 1]
+cross join (
+SELECT COUNT(*) AS cnt FROM t
+) AS _recon_tgt
+---

--- a/sqldialect/CrossJoinExpr/trino.snap
+++ b/sqldialect/CrossJoinExpr/trino.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestCrossJoinExpr - 1]
+cross join (
+SELECT COUNT(*) AS cnt FROM t
+) AS _recon_tgt
+---

--- a/sqldialect/SelectCrossJoinSubqueries/bigquery.snap
+++ b/sqldialect/SelectCrossJoinSubqueries/bigquery.snap
@@ -1,0 +1,12 @@
+
+[TestCrossJoinSuite/TestSelectCrossJoinSubqueries - 1]
+select
+  _recon_src.cnt as source_cnt, 
+  _recon_tgt.cnt as target_cnt
+from (
+SELECT COUNT(*) AS cnt FROM users
+) AS _recon_src cross join (
+SELECT COUNT(*) AS cnt FROM orders
+) AS _recon_tgt
+ 
+---

--- a/sqldialect/SelectCrossJoinSubqueries/clickhouse.snap
+++ b/sqldialect/SelectCrossJoinSubqueries/clickhouse.snap
@@ -1,0 +1,12 @@
+
+[TestCrossJoinSuite/TestSelectCrossJoinSubqueries - 1]
+select
+  _recon_src.cnt as source_cnt, 
+  _recon_tgt.cnt as target_cnt
+from (
+SELECT COUNT(*) AS cnt FROM users
+) AS _recon_src cross join (
+SELECT COUNT(*) AS cnt FROM orders
+) AS _recon_tgt
+ 
+---

--- a/sqldialect/SelectCrossJoinSubqueries/databricks.snap
+++ b/sqldialect/SelectCrossJoinSubqueries/databricks.snap
@@ -1,0 +1,12 @@
+
+[TestCrossJoinSuite/TestSelectCrossJoinSubqueries - 1]
+select
+  _recon_src.cnt as `source_cnt`, 
+  _recon_tgt.cnt as `target_cnt`
+from (
+SELECT COUNT(*) AS cnt FROM users
+) AS _recon_src cross join (
+SELECT COUNT(*) AS cnt FROM orders
+) AS _recon_tgt
+ 
+---

--- a/sqldialect/SelectCrossJoinSubqueries/duckdb.snap
+++ b/sqldialect/SelectCrossJoinSubqueries/duckdb.snap
@@ -1,0 +1,12 @@
+
+[TestCrossJoinSuite/TestSelectCrossJoinSubqueries - 1]
+select
+  _recon_src.cnt as source_cnt, 
+  _recon_tgt.cnt as target_cnt
+from (
+SELECT COUNT(*) AS cnt FROM users
+) AS _recon_src cross join (
+SELECT COUNT(*) AS cnt FROM orders
+) AS _recon_tgt
+ 
+---

--- a/sqldialect/SelectCrossJoinSubqueries/mssql.snap
+++ b/sqldialect/SelectCrossJoinSubqueries/mssql.snap
@@ -1,0 +1,12 @@
+
+[TestCrossJoinSuite/TestSelectCrossJoinSubqueries - 1]
+select
+  _recon_src.cnt as [source_cnt], 
+  _recon_tgt.cnt as [target_cnt]
+from (
+SELECT COUNT(*) AS cnt FROM users
+) AS _recon_src cross join (
+SELECT COUNT(*) AS cnt FROM orders
+) AS _recon_tgt
+ 
+---

--- a/sqldialect/SelectCrossJoinSubqueries/mysql.snap
+++ b/sqldialect/SelectCrossJoinSubqueries/mysql.snap
@@ -1,0 +1,12 @@
+
+[TestCrossJoinSuite/TestSelectCrossJoinSubqueries - 1]
+select
+  _recon_src.cnt as source_cnt, 
+  _recon_tgt.cnt as target_cnt
+from (
+SELECT COUNT(*) AS cnt FROM users
+) AS _recon_src cross join (
+SELECT COUNT(*) AS cnt FROM orders
+) AS _recon_tgt
+ 
+---

--- a/sqldialect/SelectCrossJoinSubqueries/oracle.snap
+++ b/sqldialect/SelectCrossJoinSubqueries/oracle.snap
@@ -1,0 +1,12 @@
+
+[TestCrossJoinSuite/TestSelectCrossJoinSubqueries - 1]
+select
+  _recon_src.cnt as "source_cnt", 
+  _recon_tgt.cnt as "target_cnt"
+from (
+SELECT COUNT(*) AS cnt FROM users
+) AS _recon_src cross join (
+SELECT COUNT(*) AS cnt FROM orders
+) AS _recon_tgt
+ 
+---

--- a/sqldialect/SelectCrossJoinSubqueries/postgres.snap
+++ b/sqldialect/SelectCrossJoinSubqueries/postgres.snap
@@ -1,0 +1,12 @@
+
+[TestCrossJoinSuite/TestSelectCrossJoinSubqueries - 1]
+select
+  _recon_src.cnt as source_cnt, 
+  _recon_tgt.cnt as target_cnt
+from (
+SELECT COUNT(*) AS cnt FROM users
+) AS _recon_src cross join (
+SELECT COUNT(*) AS cnt FROM orders
+) AS _recon_tgt
+ 
+---

--- a/sqldialect/SelectCrossJoinSubqueries/redshift.snap
+++ b/sqldialect/SelectCrossJoinSubqueries/redshift.snap
@@ -1,0 +1,12 @@
+
+[TestCrossJoinSuite/TestSelectCrossJoinSubqueries - 1]
+select
+  _recon_src.cnt as source_cnt, 
+  _recon_tgt.cnt as target_cnt
+from (
+SELECT COUNT(*) AS cnt FROM users
+) AS _recon_src cross join (
+SELECT COUNT(*) AS cnt FROM orders
+) AS _recon_tgt
+ 
+---

--- a/sqldialect/SelectCrossJoinSubqueries/snowflake.snap
+++ b/sqldialect/SelectCrossJoinSubqueries/snowflake.snap
@@ -1,0 +1,12 @@
+
+[TestCrossJoinSuite/TestSelectCrossJoinSubqueries - 1]
+select
+  _recon_src.cnt as "source_cnt", 
+  _recon_tgt.cnt as "target_cnt"
+from (
+SELECT COUNT(*) AS cnt FROM users
+) AS _recon_src cross join (
+SELECT COUNT(*) AS cnt FROM orders
+) AS _recon_tgt
+ 
+---

--- a/sqldialect/SelectCrossJoinSubqueries/trino.snap
+++ b/sqldialect/SelectCrossJoinSubqueries/trino.snap
@@ -1,0 +1,12 @@
+
+[TestCrossJoinSuite/TestSelectCrossJoinSubqueries - 1]
+select
+  _recon_src.cnt as source_cnt, 
+  _recon_tgt.cnt as target_cnt
+from (
+SELECT COUNT(*) AS cnt FROM users
+) AS _recon_src cross join (
+SELECT COUNT(*) AS cnt FROM orders
+) AS _recon_tgt
+ 
+---

--- a/sqldialect/SelectMixedJoins/bigquery.snap
+++ b/sqldialect/SelectMixedJoins/bigquery.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestSelectMixedJoins - 1]
+select *
+from a cross join b join c on a.id = c.id
+ 
+---

--- a/sqldialect/SelectMixedJoins/clickhouse.snap
+++ b/sqldialect/SelectMixedJoins/clickhouse.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestSelectMixedJoins - 1]
+select *
+from a cross join b join c on a.id = c.id
+ 
+---

--- a/sqldialect/SelectMixedJoins/databricks.snap
+++ b/sqldialect/SelectMixedJoins/databricks.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestSelectMixedJoins - 1]
+select *
+from a cross join b join c on a.id = c.id
+ 
+---

--- a/sqldialect/SelectMixedJoins/duckdb.snap
+++ b/sqldialect/SelectMixedJoins/duckdb.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestSelectMixedJoins - 1]
+select *
+from a cross join b join c on a.id = c.id
+ 
+---

--- a/sqldialect/SelectMixedJoins/mssql.snap
+++ b/sqldialect/SelectMixedJoins/mssql.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestSelectMixedJoins - 1]
+select *
+from a cross join b join c on a.id = c.id
+ 
+---

--- a/sqldialect/SelectMixedJoins/mysql.snap
+++ b/sqldialect/SelectMixedJoins/mysql.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestSelectMixedJoins - 1]
+select *
+from a cross join b join c on a.id = c.id
+ 
+---

--- a/sqldialect/SelectMixedJoins/oracle.snap
+++ b/sqldialect/SelectMixedJoins/oracle.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestSelectMixedJoins - 1]
+select *
+from a cross join b join c on a.id = c.id
+ 
+---

--- a/sqldialect/SelectMixedJoins/postgres.snap
+++ b/sqldialect/SelectMixedJoins/postgres.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestSelectMixedJoins - 1]
+select *
+from a cross join b join c on a.id = c.id
+ 
+---

--- a/sqldialect/SelectMixedJoins/redshift.snap
+++ b/sqldialect/SelectMixedJoins/redshift.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestSelectMixedJoins - 1]
+select *
+from a cross join b join c on a.id = c.id
+ 
+---

--- a/sqldialect/SelectMixedJoins/snowflake.snap
+++ b/sqldialect/SelectMixedJoins/snowflake.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestSelectMixedJoins - 1]
+select *
+from a cross join b join c on a.id = c.id
+ 
+---

--- a/sqldialect/SelectMixedJoins/trino.snap
+++ b/sqldialect/SelectMixedJoins/trino.snap
@@ -1,0 +1,6 @@
+
+[TestCrossJoinSuite/TestSelectMixedJoins - 1]
+select *
+from a cross join b join c on a.id = c.id
+ 
+---

--- a/sqldialect/base.go
+++ b/sqldialect/base.go
@@ -51,13 +51,20 @@ type CteExpr interface {
 	IsCteExpr()
 }
 
+// LimitClauseExpr is a LIMIT clause expression.
+type LimitClauseExpr interface {
+	Expr
+	IsLimitExpr()
+}
+
 type LimitExpr struct {
 	rows *IntLitExpr
 }
 
 var _ Expr = (*LimitExpr)(nil)
+var _ LimitClauseExpr = (*LimitExpr)(nil)
 
-func Limit(rows *IntLitExpr) *LimitExpr {
+func Limit(rows *IntLitExpr) LimitClauseExpr {
 	return &LimitExpr{rows}
 }
 
@@ -69,6 +76,8 @@ func (e *LimitExpr) ToSql(dialect Dialect) (string, error) {
 
 	return dialect.FormatLimit(rowsSql), nil
 }
+
+func (e *LimitExpr) IsLimitExpr() {}
 
 type NotImplementedExpr struct {
 	msg string
@@ -110,20 +119,29 @@ func (s *IdentifierExpr) IsTextExpr() {}
 // OrderExpr
 //
 
+// OrderByExpr is an ORDER BY term (an expression with an optional direction).
+type OrderByExpr interface {
+	Expr
+	IsOrderByExpr()
+}
+
 type OrderExpr struct {
 	expr Expr
 	desc bool
 }
 
 var _ Expr = (*OrderExpr)(nil)
+var _ OrderByExpr = (*OrderExpr)(nil)
 
-func Asc(expr Expr) *OrderExpr {
+func Asc(expr Expr) OrderByExpr {
 	return &OrderExpr{expr: expr, desc: false}
 }
 
-func Desc(expr Expr) *OrderExpr {
+func Desc(expr Expr) OrderByExpr {
 	return &OrderExpr{expr: expr, desc: true}
 }
+
+func (e *OrderExpr) IsOrderByExpr() {}
 
 func (e *OrderExpr) ToSql(dialect Dialect) (string, error) {
 	exprSql, err := e.expr.ToSql(dialect)
@@ -146,12 +164,12 @@ type Select struct {
 	ctes    []*Cte
 	cols    []Expr
 	table   TableExpr
-	joins   []*JoinExpr
+	joins   []JoinTableExpr
 	where   []CondExpr
 	groupBy []Expr
-	orderBy []*OrderExpr
+	orderBy []OrderByExpr
 	having  []CondExpr
-	limit   *LimitExpr
+	limit   LimitClauseExpr
 }
 
 func NewSelect() *Select {
@@ -204,17 +222,22 @@ func (s *Select) Join(other TableExpr, how JoinDefExpr) *Select {
 	return s
 }
 
+func (s *Select) CrossJoin(other TableExpr) *Select {
+	s.joins = append(s.joins, CrossJoin(other))
+	return s
+}
+
 func (s *Select) GroupBy(groupBy ...Expr) *Select {
 	s.groupBy = append(s.groupBy, groupBy...)
 	return s
 }
 
-func (s *Select) OrderBy(orderBy ...*OrderExpr) *Select {
+func (s *Select) OrderBy(orderBy ...OrderByExpr) *Select {
 	s.orderBy = append(s.orderBy, orderBy...)
 	return s
 }
 
-func (s *Select) WithLimit(limit *LimitExpr) *Select {
+func (s *Select) WithLimit(limit LimitClauseExpr) *Select {
 	s.limit = limit
 	return s
 }
@@ -556,6 +579,14 @@ func (t *CteAliasExpr) IsTableExpr() {}
 // JoinExpr
 //
 
+// JoinTableExpr is a table expression that contributes a join clause to a
+// Select — either a conditional JOIN (*JoinExpr) or a CROSS JOIN
+// (*CrossJoinExpr).
+type JoinTableExpr interface {
+	TableExpr
+	IsJoinExpr()
+}
+
 type JoinExpr struct {
 	other TableExpr
 	how   JoinDefExpr
@@ -587,6 +618,37 @@ func (t *JoinExpr) ToSql(dialect Dialect) (string, error) {
 
 func (t *JoinExpr) IsJoinExpr()  {}
 func (t *JoinExpr) IsTableExpr() {}
+
+//
+// CrossJoinExpr
+//
+
+// CrossJoinExpr renders a CROSS JOIN against another table expression. Unlike a
+// regular Join it carries no join condition, producing the Cartesian product of
+// the two inputs (commonly used to combine two single-row subqueries).
+type CrossJoinExpr struct {
+	other TableExpr
+}
+
+var _ Expr = (*CrossJoinExpr)(nil)
+var _ TableExpr = (*CrossJoinExpr)(nil)
+
+// CrossJoin builds a CROSS JOIN expression against the given table.
+func CrossJoin(other TableExpr) JoinTableExpr {
+	return &CrossJoinExpr{other: other}
+}
+
+func (t *CrossJoinExpr) ToSql(dialect Dialect) (string, error) {
+	tableSql, err := t.other.ToSql(dialect)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("cross join %s", tableSql), nil
+}
+
+func (t *CrossJoinExpr) IsJoinExpr()  {}
+func (t *CrossJoinExpr) IsTableExpr() {}
 
 type JoinDefExpr interface {
 	Expr

--- a/sqldialect/cross_join_test.go
+++ b/sqldialect/cross_join_test.go
@@ -1,0 +1,70 @@
+package sqldialect
+
+import (
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/suite"
+)
+
+type CrossJoinSuite struct {
+	suite.Suite
+}
+
+func TestCrossJoinSuite(t *testing.T) {
+	suite.Run(t, new(CrossJoinSuite))
+}
+
+// TestCrossJoinExpr renders a bare CROSS JOIN clause against a table.
+func (s *CrossJoinSuite) TestCrossJoinExpr() {
+	for _, dialect := range DialectsToTest() {
+		expr := CrossJoin(SubqueryTable("SELECT COUNT(*) AS cnt FROM t", "_recon_tgt"))
+		sql, err := expr.ToSql(dialect.Dialect)
+		s.Require().NoError(err)
+		s.Require().NotEmpty(sql)
+		s.T().Log(sql)
+
+		snaps.WithConfig(snaps.Dir("CrossJoinExpr"), snaps.Filename(dialect.Name)).MatchSnapshot(s.T(), sql)
+	}
+}
+
+// TestSelectCrossJoinSubqueries combines two single-row subqueries into one
+// statement via CROSS JOIN — the shape used to fuse a source/target comparison
+// into a single round-trip when both run on the same connection.
+func (s *CrossJoinSuite) TestSelectCrossJoinSubqueries() {
+	for _, dialect := range DialectsToTest() {
+		sel := NewSelect().
+			From(SubqueryTable("SELECT COUNT(*) AS cnt FROM users", "_recon_src")).
+			CrossJoin(SubqueryTable("SELECT COUNT(*) AS cnt FROM orders", "_recon_tgt")).
+			Cols(
+				As(Sql("_recon_src.cnt"), Identifier("source_cnt")),
+				As(Sql("_recon_tgt.cnt"), Identifier("target_cnt")),
+			)
+
+		sql, err := sel.ToSql(dialect.Dialect)
+		s.Require().NoError(err)
+		s.Require().NotEmpty(sql)
+		s.T().Log(sql)
+
+		snaps.WithConfig(snaps.Dir("SelectCrossJoinSubqueries"), snaps.Filename(dialect.Name)).MatchSnapshot(s.T(), sql)
+	}
+}
+
+// TestSelectMixedJoins verifies a CROSS JOIN and a conditional JOIN can coexist
+// on the same Select (exercising the JoinTableExpr slice).
+func (s *CrossJoinSuite) TestSelectMixedJoins() {
+	for _, dialect := range DialectsToTest() {
+		sel := NewSelect().
+			From(Sql("a")).
+			CrossJoin(Sql("b")).
+			Join(Sql("c"), On(Eq(Sql("a.id"), Sql("c.id")))).
+			Cols(Sql("*"))
+
+		sql, err := sel.ToSql(dialect.Dialect)
+		s.Require().NoError(err)
+		s.Require().NotEmpty(sql)
+		s.T().Log(sql)
+
+		snaps.WithConfig(snaps.Dir("SelectMixedJoins"), snaps.Filename(dialect.Name)).MatchSnapshot(s.T(), sql)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `CROSS JOIN` primitive to the `sqldialect` AST builder and widens the `Select` builder's concrete field/return types to the broadest conforming interface.

### CrossJoin
- `CrossJoin(table) JoinTableExpr` and `Select.CrossJoin(table)` emit a `cross join <table>` clause — a cartesian product with no join condition. The motivating use case is fusing two single-row subqueries (e.g. source/target `COUNT/SUM` aggregates) into one statement so a same-connection comparison needs a single round-trip.

### Interface widening
Previously the builder stored concrete pointers in several slices. They now use the broadest interface that conforms, so any conforming implementation is accepted:
- `joins  []*JoinExpr`  → `[]JoinTableExpr` (new interface, satisfied by `*JoinExpr` and `*CrossJoinExpr`)
- `orderBy []*OrderExpr` → `[]OrderByExpr` (new interface); `Asc`/`Desc` now return `OrderByExpr`
- `limit   *LimitExpr`   → `LimitClauseExpr` (new interface); `Limit` now returns `LimitClauseExpr`

This is backward compatible — the existing concrete types satisfy the new interfaces, and `querybuilder` was updated to the interface types.

### Tests
- `sqldialect/cross_join_test.go` adds go-snaps coverage across all dialects: a bare `CROSS JOIN` clause, a two-subquery `CROSS JOIN` select, and a mixed `CROSS JOIN` + conditional `JOIN` select.

Consumed by synq-recon's same-DB optimized comparison (QUA-68).