### PR TITLE
bigquery: emit tables.list iteration progress events

### DIFF
--- a/scrapper/bigquery/bigquery.go
+++ b/scrapper/bigquery/bigquery.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	dwhexecbigquery "github.com/getsynq/dwhsupport/exec/bigquery"
 	"github.com/getsynq/dwhsupport/logging"
@@ -12,6 +13,8 @@ import (
 	"github.com/getsynq/dwhsupport/sqldialect"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/api/cloudresourcemanager/v1"
 
 	"google.golang.org/api/googleapi"
@@ -152,30 +155,26 @@ func (e *BigQueryScrapper) listDatasets(ctx context.Context) ([]*bigquery.Datase
 	return result, nil
 }
 
+// tablesListProgressInterval throttles progress events so an enormous dataset
+// can't attach thousands of events to the span; a final summary is always
+// emitted regardless. It is a var so tests can tighten it.
+var tablesListProgressInterval = 5 * time.Second
+
 // listTableIDs lists every table ID in a dataset. The listing runs through
 // withRateLimitRetry so a genuine rate-limit backs off, and each attempt is
 // bounded by CallTimeout so a stalled page can't hang the scrape.
 //
 // A non-Done error from the iterator is TERMINAL: the BigQuery iterator does not
-// advance past it, so `continue` would call Next() again, get the same error, and
-// busy-loop forever — the root cause of the multi-hour catalog hangs. So we
-// always return on error and let the caller fail the scrape (failing is safe:
-// a failed fetch publishes nothing, so no assets are wrongly marked deleted).
+// advance past it, so retrying the same iterator would get the same error and
+// busy-loop forever — the root cause of the multi-hour catalog hangs. The
+// listing (in collectTableIDs) always returns on error, letting the caller fail
+// the scrape (failing is safe: a failed fetch publishes nothing, so no assets
+// are wrongly marked deleted), and emits progress/done span events so a slow or
+// stalled listing is observable.
 func (e *BigQueryScrapper) listTableIDs(ctx context.Context, datasetID string) ([]string, error) {
 	ids, err := withRateLimitRetry(ctx, e.rateLimitCfg, func(ctx context.Context) ([]string, error) {
 		it := e.executor.GetBigQueryClient().Dataset(datasetID).Tables(ctx)
-		var ids []string
-		for {
-			table, err := it.Next()
-			if errors.Is(err, iterator.Done) {
-				break
-			}
-			if err != nil {
-				return nil, err
-			}
-			ids = append(ids, table.TableID)
-		}
-		return ids, nil
+		return collectTableIDs(ctx, datasetID, it)
 	})
 	if err != nil {
 		// 404 means the dataset itself is gone — typically a linked/shared
@@ -194,6 +193,49 @@ func (e *BigQueryScrapper) listTableIDs(ctx context.Context, datasetID string) (
 		}
 		return nil, e.scrapeError(ctx, "tables.list", datasetID, "", err)
 	}
+	return ids, nil
+}
+
+// collectTableIDs iterates a dataset's table listing, returning every table ID.
+// It emits a throttled progress event as the count grows plus a final done event
+// on the active span, so we can see how far a slow listing got before its
+// deadline: a hung dataset produces no progress (and no done — the deadline
+// fires first), while a merely huge one shows the count climbing right up to the
+// CallTimeout. The BigQuery client's own per-request spans are dropped at the
+// export filter, so these events are how we observe listing progress.
+//
+// A non-Done error is returned immediately: the BigQuery iterator never advances
+// past it, so re-reading would busy-loop — the root cause of the multi-hour
+// catalog hangs.
+func collectTableIDs(ctx context.Context, datasetID string, it *bigquery.TableIterator) ([]string, error) {
+	span := trace.SpanFromContext(ctx)
+
+	var ids []string
+	start := time.Now()
+	lastEvent := start
+	for {
+		table, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, table.TableID)
+		if time.Since(lastEvent) >= tablesListProgressInterval {
+			span.AddEvent("bigquery.tables.list.progress", trace.WithAttributes(
+				attribute.String("bq.dataset", datasetID),
+				attribute.Int("bq.tables_list.tables", len(ids)),
+				attribute.Int64("bq.tables_list.elapsed_ms", time.Since(start).Milliseconds()),
+			))
+			lastEvent = time.Now()
+		}
+	}
+	span.AddEvent("bigquery.tables.list.done", trace.WithAttributes(
+		attribute.String("bq.dataset", datasetID),
+		attribute.Int("bq.tables_list.tables", len(ids)),
+		attribute.Int64("bq.tables_list.elapsed_ms", time.Since(start).Milliseconds()),
+	))
 	return ids, nil
 }
 

--- a/scrapper/bigquery/list_table_ids_test.go
+++ b/scrapper/bigquery/list_table_ids_test.go
@@ -1,0 +1,109 @@
+package bigquery
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"google.golang.org/api/option"
+)
+
+// TestCollectTableIDsPagesAndEmitsEvents verifies that collectTableIDs iterates
+// every tables.list page and records progress/done events on the active span
+// carrying the running table count, so a stalled or oversized listing is
+// observable in traces.
+func TestCollectTableIDsPagesAndEmitsEvents(t *testing.T) {
+	// Force a progress event on every table so we can assert the running count.
+	prev := tablesListProgressInterval
+	tablesListProgressInterval = 0
+	defer func() { tablesListProgressInterval = prev }()
+
+	// Two pages: page 1 returns t1,t2 + a next-page token; page 2 returns t3 and
+	// no token (terminal).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("pageToken") == "" {
+			_, _ = w.Write([]byte(`{"kind":"bigquery#tableList","tables":[
+				{"tableReference":{"projectId":"p","datasetId":"ds","tableId":"t1"}},
+				{"tableReference":{"projectId":"p","datasetId":"ds","tableId":"t2"}}
+			],"nextPageToken":"page2"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"kind":"bigquery#tableList","tables":[
+			{"tableReference":{"projectId":"p","datasetId":"ds","tableId":"t3"}}
+		]}`))
+	}))
+	defer srv.Close()
+
+	client, err := bigquery.NewClient(
+		context.Background(),
+		"test-project",
+		option.WithEndpoint(srv.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(&http.Client{Timeout: 5 * time.Second}),
+	)
+	require.NoError(t, err)
+	defer client.Close()
+
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	ctx, span := tp.Tracer("test").Start(context.Background(), "test")
+
+	ids, err := collectTableIDs(ctx, "ds", client.Dataset("ds").Tables(ctx))
+	require.NoError(t, err)
+	require.Equal(t, []string{"t1", "t2", "t3"}, ids)
+
+	span.End()
+	recorded := sr.Ended()
+	require.Len(t, recorded, 1)
+	events := recorded[0].Events()
+
+	// With a zero throttle interval every table emits a progress event (3),
+	// followed by exactly one done event.
+	var progress, done int
+	for _, e := range events {
+		switch e.Name {
+		case "bigquery.tables.list.progress":
+			progress++
+		case "bigquery.tables.list.done":
+			done++
+		}
+	}
+	require.Equal(t, 3, progress, "one progress event per table at zero throttle")
+	require.Equal(t, 1, done, "exactly one done event")
+
+	// The done event reports the final table total across both pages.
+	doneAttrs := attrMap(t, events, "bigquery.tables.list.done")
+	require.Equal(t, int64(3), doneAttrs["bq.tables_list.tables"])
+	require.Equal(t, "ds", doneAttrs["bq.dataset"])
+}
+
+// attrMap returns the attributes of the first event with the given name as a
+// name->value map (ints as int64, strings as string).
+func attrMap(t *testing.T, events []sdktrace.Event, name string) map[string]any {
+	t.Helper()
+	for _, e := range events {
+		if e.Name != name {
+			continue
+		}
+		out := make(map[string]any, len(e.Attributes))
+		for _, kv := range e.Attributes {
+			switch kv.Value.Type() {
+			case attribute.INT64:
+				out[string(kv.Key)] = kv.Value.AsInt64()
+			default:
+				out[string(kv.Key)] = kv.Value.AsString()
+			}
+		}
+		return out
+	}
+	t.Fatalf("event %q not found", name)
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds span events around BigQuery's dataset table listing so a slow or stalled `tables.list` is observable in traces. The BigQuery client's own per-request spans are dropped at our OTEL export filter, so there was previously no way to tell *how far* a listing got before its deadline.

`collectTableIDs` now emits, on the active span:
- `bigquery.tables.list.progress` — throttled (every 5s), with `bq.dataset`, `bq.tables_list.tables` (running count), `bq.tables_list.elapsed_ms`
- `bigquery.tables.list.done` — final table count + elapsed

This instruments all four listing paths (catalog, tables, metrics, sql definitions) via `listTableIDs`, and preserves the return-on-error behaviour that fixed the iterator busy-loop.

## Why

A dataset whose `tables.list` times out currently surfaces only as `context deadline exceeded`, which can't distinguish two very different failure modes:
- **hang / blackhole** → no progress events and no `done` event (the per-call `CallTimeout` fires before the first page returns)
- **too large to enumerate within the call budget** → progress count climbs steadily right up to the deadline

These events make that distinction directly queryable, and double as a general listing-throughput signal.

## Test

`TestCollectTableIDsPagesAndEmitsEvents` pages a fake `httptest` BigQuery endpoint across two pages and asserts the running count and the final `done` event via an OTEL `SpanRecorder`.