### PR TITLE
metrics: fix profiling of STRUCT/RECORD columns and nested struct fields

### DIFF
--- a/metrics/ProfileColumns/bigquery.snap
+++ b/metrics/ProfileColumns/bigquery.snap
@@ -27,7 +27,8 @@ select
   CAST(stddev_samp(run_status) AS FLOAT64) as run_status__stddev, 
   count(timestamp(created_at)) as created_at__num_not_null, 
   min(timestamp(created_at)) as created_at__min, 
-  max(timestamp(created_at)) as created_at__max
+  max(timestamp(created_at)) as created_at__max, 
+  countif(sku is not null) as sku__num_not_null
 from `db.default.runs` 
 where (run_status > 0) and (run_type > 0)
 group by
@@ -62,7 +63,8 @@ select
   CAST(stddev_samp(run_status) AS FLOAT64) as run_status__stddev, 
   count(timestamp(created_at)) as created_at__num_not_null, 
   min(timestamp(created_at)) as created_at__min, 
-  max(timestamp(created_at)) as created_at__max
+  max(timestamp(created_at)) as created_at__max, 
+  countif(sku is not null) as sku__num_not_null
 from `db.default.runs` 
 where (run_status > 0) and (run_type > 0)
 order by num_rows desc limit 1000
@@ -94,7 +96,8 @@ select
   CAST(stddev_samp(run_status) AS FLOAT64) as run_status__stddev, 
   count(timestamp(created_at)) as created_at__num_not_null, 
   min(timestamp(created_at)) as created_at__min, 
-  max(timestamp(created_at)) as created_at__max
+  max(timestamp(created_at)) as created_at__max, 
+  countif(sku is not null) as sku__num_not_null
 from `db.default.runs` 
 where (run_status > 0) and (run_type > 0)
 group by SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100)
@@ -129,7 +132,8 @@ select
   CAST(stddev_samp(run_status) AS FLOAT64) as run_status__stddev, 
   count(timestamp(created_at)) as created_at__num_not_null, 
   min(timestamp(created_at)) as created_at__min, 
-  max(timestamp(created_at)) as created_at__max
+  max(timestamp(created_at)) as created_at__max, 
+  countif(sku is not null) as sku__num_not_null
 from `db.default.runs` 
 group by
   SUBSTR(SAFE_CAST(workspace AS STRING), 1, 100), 
@@ -163,7 +167,8 @@ select
   CAST(stddev_samp(run_status) AS FLOAT64) as run_status__stddev, 
   count(timestamp(created_at)) as created_at__num_not_null, 
   min(timestamp(created_at)) as created_at__min, 
-  max(timestamp(created_at)) as created_at__max
+  max(timestamp(created_at)) as created_at__max, 
+  countif(sku is not null) as sku__num_not_null
 from `db.default.runs` 
 order by num_rows desc limit 1000
 ---
@@ -194,7 +199,8 @@ select
   CAST(stddev_samp(run_status) AS FLOAT64) as run_status__stddev, 
   count(timestamp(created_at)) as created_at__num_not_null, 
   min(timestamp(created_at)) as created_at__min, 
-  max(timestamp(created_at)) as created_at__max
+  max(timestamp(created_at)) as created_at__max, 
+  countif(sku is not null) as sku__num_not_null
 from `db.default.runs` 
 group by SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100)
 order by num_rows desc limit 1000
@@ -228,7 +234,8 @@ select
   CAST(stddev_samp(run_status) AS FLOAT64) as run_status__stddev, 
   count(timestamp(created_at)) as created_at__num_not_null, 
   min(timestamp(created_at)) as created_at__min, 
-  max(timestamp(created_at)) as created_at__max
+  max(timestamp(created_at)) as created_at__max, 
+  countif(sku is not null) as sku__num_not_null
 from `db.default.runs` 
 where (1=1)
 group by
@@ -263,7 +270,8 @@ select
   CAST(stddev_samp(run_status) AS FLOAT64) as run_status__stddev, 
   count(timestamp(created_at)) as created_at__num_not_null, 
   min(timestamp(created_at)) as created_at__min, 
-  max(timestamp(created_at)) as created_at__max
+  max(timestamp(created_at)) as created_at__max, 
+  countif(sku is not null) as sku__num_not_null
 from `db.default.runs` 
 where (1=1)
 order by num_rows desc limit 1000
@@ -295,7 +303,8 @@ select
   CAST(stddev_samp(run_status) AS FLOAT64) as run_status__stddev, 
   count(timestamp(created_at)) as created_at__num_not_null, 
   min(timestamp(created_at)) as created_at__min, 
-  max(timestamp(created_at)) as created_at__max
+  max(timestamp(created_at)) as created_at__max, 
+  countif(sku is not null) as sku__num_not_null
 from `db.default.runs` 
 where (1=1)
 group by SUBSTR(SAFE_CAST(run_type AS STRING), 1, 100)

--- a/metrics/ProfileColumns/clickhouse.snap
+++ b/metrics/ProfileColumns/clickhouse.snap
@@ -27,7 +27,8 @@ select
   toFloat64(stddevSamp(run_status)) as run_status__stddev, 
   toInt64(count(created_at)) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  toInt64(countIf(sku is not null)) as sku__num_not_null
 from default.runs 
 where (run_status > 0) and (run_type > 0)
 group by
@@ -62,7 +63,8 @@ select
   toFloat64(stddevSamp(run_status)) as run_status__stddev, 
   toInt64(count(created_at)) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  toInt64(countIf(sku is not null)) as sku__num_not_null
 from default.runs 
 where (run_status > 0) and (run_type > 0)
 order by num_rows desc limit 1000
@@ -94,7 +96,8 @@ select
   toFloat64(stddevSamp(run_status)) as run_status__stddev, 
   toInt64(count(created_at)) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  toInt64(countIf(sku is not null)) as sku__num_not_null
 from default.runs 
 where (run_status > 0) and (run_type > 0)
 group by segment
@@ -129,7 +132,8 @@ select
   toFloat64(stddevSamp(run_status)) as run_status__stddev, 
   toInt64(count(created_at)) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  toInt64(countIf(sku is not null)) as sku__num_not_null
 from default.runs 
 group by
   segment, 
@@ -163,7 +167,8 @@ select
   toFloat64(stddevSamp(run_status)) as run_status__stddev, 
   toInt64(count(created_at)) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  toInt64(countIf(sku is not null)) as sku__num_not_null
 from default.runs 
 order by num_rows desc limit 1000
 ---
@@ -194,7 +199,8 @@ select
   toFloat64(stddevSamp(run_status)) as run_status__stddev, 
   toInt64(count(created_at)) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  toInt64(countIf(sku is not null)) as sku__num_not_null
 from default.runs 
 group by segment
 order by num_rows desc limit 1000
@@ -228,7 +234,8 @@ select
   toFloat64(stddevSamp(run_status)) as run_status__stddev, 
   toInt64(count(created_at)) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  toInt64(countIf(sku is not null)) as sku__num_not_null
 from default.runs 
 where (1=1)
 group by
@@ -263,7 +270,8 @@ select
   toFloat64(stddevSamp(run_status)) as run_status__stddev, 
   toInt64(count(created_at)) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  toInt64(countIf(sku is not null)) as sku__num_not_null
 from default.runs 
 where (1=1)
 order by num_rows desc limit 1000
@@ -295,7 +303,8 @@ select
   toFloat64(stddevSamp(run_status)) as run_status__stddev, 
   toInt64(count(created_at)) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  toInt64(countIf(sku is not null)) as sku__num_not_null
 from default.runs 
 where (1=1)
 group by segment

--- a/metrics/ProfileColumns/databricks.snap
+++ b/metrics/ProfileColumns/databricks.snap
@@ -27,7 +27,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as `run_status__stddev`, 
   count(created_at) as `created_at__num_not_null`, 
   min(created_at) as `created_at__min`, 
-  max(created_at) as `created_at__max`
+  max(created_at) as `created_at__max`, 
+  count_if(sku is not null) as `sku__num_not_null`
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
 group by
@@ -62,7 +63,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as `run_status__stddev`, 
   count(created_at) as `created_at__num_not_null`, 
   min(created_at) as `created_at__min`, 
-  max(created_at) as `created_at__max`
+  max(created_at) as `created_at__max`, 
+  count_if(sku is not null) as `sku__num_not_null`
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
 order by `num_rows` desc limit 1000
@@ -94,7 +96,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as `run_status__stddev`, 
   count(created_at) as `created_at__num_not_null`, 
   min(created_at) as `created_at__min`, 
-  max(created_at) as `created_at__max`
+  max(created_at) as `created_at__max`, 
+  count_if(sku is not null) as `sku__num_not_null`
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
 group by `segment`
@@ -129,7 +132,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as `run_status__stddev`, 
   count(created_at) as `created_at__num_not_null`, 
   min(created_at) as `created_at__min`, 
-  max(created_at) as `created_at__max`
+  max(created_at) as `created_at__max`, 
+  count_if(sku is not null) as `sku__num_not_null`
 from db.default.runs 
 group by
   `segment`, 
@@ -163,7 +167,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as `run_status__stddev`, 
   count(created_at) as `created_at__num_not_null`, 
   min(created_at) as `created_at__min`, 
-  max(created_at) as `created_at__max`
+  max(created_at) as `created_at__max`, 
+  count_if(sku is not null) as `sku__num_not_null`
 from db.default.runs 
 order by `num_rows` desc limit 1000
 ---
@@ -194,7 +199,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as `run_status__stddev`, 
   count(created_at) as `created_at__num_not_null`, 
   min(created_at) as `created_at__min`, 
-  max(created_at) as `created_at__max`
+  max(created_at) as `created_at__max`, 
+  count_if(sku is not null) as `sku__num_not_null`
 from db.default.runs 
 group by `segment`
 order by `num_rows` desc limit 1000
@@ -228,7 +234,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as `run_status__stddev`, 
   count(created_at) as `created_at__num_not_null`, 
   min(created_at) as `created_at__min`, 
-  max(created_at) as `created_at__max`
+  max(created_at) as `created_at__max`, 
+  count_if(sku is not null) as `sku__num_not_null`
 from db.default.runs 
 where (1=1)
 group by
@@ -263,7 +270,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as `run_status__stddev`, 
   count(created_at) as `created_at__num_not_null`, 
   min(created_at) as `created_at__min`, 
-  max(created_at) as `created_at__max`
+  max(created_at) as `created_at__max`, 
+  count_if(sku is not null) as `sku__num_not_null`
 from db.default.runs 
 where (1=1)
 order by `num_rows` desc limit 1000
@@ -295,7 +303,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as `run_status__stddev`, 
   count(created_at) as `created_at__num_not_null`, 
   min(created_at) as `created_at__min`, 
-  max(created_at) as `created_at__max`
+  max(created_at) as `created_at__max`, 
+  count_if(sku is not null) as `sku__num_not_null`
 from db.default.runs 
 where (1=1)
 group by `segment`

--- a/metrics/ProfileColumns/duckdb.snap
+++ b/metrics/ProfileColumns/duckdb.snap
@@ -27,7 +27,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (run_status > 0) and (run_type > 0)
 group by
@@ -62,7 +63,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (run_status > 0) and (run_type > 0)
 order by num_rows desc limit 1000
@@ -94,7 +96,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (run_status > 0) and (run_type > 0)
 group by segment
@@ -129,7 +132,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 group by
   segment, 
@@ -163,7 +167,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 order by num_rows desc limit 1000
 ---
@@ -194,7 +199,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 group by segment
 order by num_rows desc limit 1000
@@ -228,7 +234,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (1=1)
 group by
@@ -263,7 +270,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (1=1)
 order by num_rows desc limit 1000
@@ -295,7 +303,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (1=1)
 group by segment

--- a/metrics/ProfileColumns/mssql.snap
+++ b/metrics/ProfileColumns/mssql.snap
@@ -27,7 +27,8 @@ select
   CAST(STDEV(run_status) AS FLOAT) as [run_status__stddev], 
   COUNT(created_at) as [created_at__num_not_null], 
   min(created_at) as [created_at__min], 
-  max(created_at) as [created_at__max]
+  max(created_at) as [created_at__max], 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
 where (run_status > 0) and (run_type > 0)
 group by
@@ -62,7 +63,8 @@ select
   CAST(STDEV(run_status) AS FLOAT) as [run_status__stddev], 
   COUNT(created_at) as [created_at__num_not_null], 
   min(created_at) as [created_at__min], 
-  max(created_at) as [created_at__max]
+  max(created_at) as [created_at__max], 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
 where (run_status > 0) and (run_type > 0)
 order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
@@ -94,7 +96,8 @@ select
   CAST(STDEV(run_status) AS FLOAT) as [run_status__stddev], 
   COUNT(created_at) as [created_at__num_not_null], 
   min(created_at) as [created_at__min], 
-  max(created_at) as [created_at__max]
+  max(created_at) as [created_at__max], 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
 where (run_status > 0) and (run_type > 0)
 group by SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100)
@@ -129,7 +132,8 @@ select
   CAST(STDEV(run_status) AS FLOAT) as [run_status__stddev], 
   COUNT(created_at) as [created_at__num_not_null], 
   min(created_at) as [created_at__min], 
-  max(created_at) as [created_at__max]
+  max(created_at) as [created_at__max], 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
 group by
   SUBSTRING(CAST(workspace AS NVARCHAR(MAX)), 1, 100), 
@@ -163,7 +167,8 @@ select
   CAST(STDEV(run_status) AS FLOAT) as [run_status__stddev], 
   COUNT(created_at) as [created_at__num_not_null], 
   min(created_at) as [created_at__min], 
-  max(created_at) as [created_at__max]
+  max(created_at) as [created_at__max], 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
 order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
 ---
@@ -194,7 +199,8 @@ select
   CAST(STDEV(run_status) AS FLOAT) as [run_status__stddev], 
   COUNT(created_at) as [created_at__num_not_null], 
   min(created_at) as [created_at__min], 
-  max(created_at) as [created_at__max]
+  max(created_at) as [created_at__max], 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
 group by SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100)
 order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
@@ -228,7 +234,8 @@ select
   CAST(STDEV(run_status) AS FLOAT) as [run_status__stddev], 
   COUNT(created_at) as [created_at__num_not_null], 
   min(created_at) as [created_at__min], 
-  max(created_at) as [created_at__max]
+  max(created_at) as [created_at__max], 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
 where (1=1)
 group by
@@ -263,7 +270,8 @@ select
   CAST(STDEV(run_status) AS FLOAT) as [run_status__stddev], 
   COUNT(created_at) as [created_at__num_not_null], 
   min(created_at) as [created_at__min], 
-  max(created_at) as [created_at__max]
+  max(created_at) as [created_at__max], 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
 where (1=1)
 order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
@@ -295,7 +303,8 @@ select
   CAST(STDEV(run_status) AS FLOAT) as [run_status__stddev], 
   COUNT(created_at) as [created_at__num_not_null], 
   min(created_at) as [created_at__min], 
-  max(created_at) as [created_at__max]
+  max(created_at) as [created_at__max], 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
 where (1=1)
 group by SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100)

--- a/metrics/ProfileColumns/mysql.snap
+++ b/metrics/ProfileColumns/mysql.snap
@@ -27,7 +27,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (run_status > 0) and (run_type > 0)
 group by
@@ -62,7 +63,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (run_status > 0) and (run_type > 0)
 order by num_rows desc limit 1000
@@ -94,7 +96,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (run_status > 0) and (run_type > 0)
 group by SUBSTRING(CAST(run_type AS CHAR), 1, 100)
@@ -129,7 +132,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 group by
   SUBSTRING(CAST(workspace AS CHAR), 1, 100), 
@@ -163,7 +167,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 order by num_rows desc limit 1000
 ---
@@ -194,7 +199,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 group by SUBSTRING(CAST(run_type AS CHAR), 1, 100)
 order by num_rows desc limit 1000
@@ -228,7 +234,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (1=1)
 group by
@@ -263,7 +270,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (1=1)
 order by num_rows desc limit 1000
@@ -295,7 +303,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (1=1)
 group by SUBSTRING(CAST(run_type AS CHAR), 1, 100)

--- a/metrics/ProfileColumns/oracle.snap
+++ b/metrics/ProfileColumns/oracle.snap
@@ -27,7 +27,8 @@ select
   CAST(STDDEV(run_status) AS BINARY_DOUBLE) as "run_status__stddev", 
   COUNT(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as "sku__num_not_null"
 from "default"."runs" 
 where (run_status > 0) and (run_type > 0)
 group by
@@ -62,7 +63,8 @@ select
   CAST(STDDEV(run_status) AS BINARY_DOUBLE) as "run_status__stddev", 
   COUNT(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as "sku__num_not_null"
 from "default"."runs" 
 where (run_status > 0) and (run_type > 0)
 order by "num_rows" desc FETCH FIRST 1000 ROWS ONLY
@@ -94,7 +96,8 @@ select
   CAST(STDDEV(run_status) AS BINARY_DOUBLE) as "run_status__stddev", 
   COUNT(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as "sku__num_not_null"
 from "default"."runs" 
 where (run_status > 0) and (run_type > 0)
 group by SUBSTR(TO_CHAR(run_type), 1, 100)
@@ -129,7 +132,8 @@ select
   CAST(STDDEV(run_status) AS BINARY_DOUBLE) as "run_status__stddev", 
   COUNT(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as "sku__num_not_null"
 from "default"."runs" 
 group by
   SUBSTR(TO_CHAR(workspace), 1, 100), 
@@ -163,7 +167,8 @@ select
   CAST(STDDEV(run_status) AS BINARY_DOUBLE) as "run_status__stddev", 
   COUNT(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as "sku__num_not_null"
 from "default"."runs" 
 order by "num_rows" desc FETCH FIRST 1000 ROWS ONLY
 ---
@@ -194,7 +199,8 @@ select
   CAST(STDDEV(run_status) AS BINARY_DOUBLE) as "run_status__stddev", 
   COUNT(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as "sku__num_not_null"
 from "default"."runs" 
 group by SUBSTR(TO_CHAR(run_type), 1, 100)
 order by "num_rows" desc FETCH FIRST 1000 ROWS ONLY
@@ -228,7 +234,8 @@ select
   CAST(STDDEV(run_status) AS BINARY_DOUBLE) as "run_status__stddev", 
   COUNT(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as "sku__num_not_null"
 from "default"."runs" 
 where (1=1)
 group by
@@ -263,7 +270,8 @@ select
   CAST(STDDEV(run_status) AS BINARY_DOUBLE) as "run_status__stddev", 
   COUNT(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as "sku__num_not_null"
 from "default"."runs" 
 where (1=1)
 order by "num_rows" desc FETCH FIRST 1000 ROWS ONLY
@@ -295,7 +303,8 @@ select
   CAST(STDDEV(run_status) AS BINARY_DOUBLE) as "run_status__stddev", 
   COUNT(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as "sku__num_not_null"
 from "default"."runs" 
 where (1=1)
 group by SUBSTR(TO_CHAR(run_type), 1, 100)

--- a/metrics/ProfileColumns/postgres.snap
+++ b/metrics/ProfileColumns/postgres.snap
@@ -27,7 +27,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (run_status > 0) and (run_type > 0)
 group by
@@ -62,7 +63,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (run_status > 0) and (run_type > 0)
 order by num_rows desc limit 1000
@@ -94,7 +96,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (run_status > 0) and (run_type > 0)
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)
@@ -129,7 +132,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 group by
   SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), 
@@ -163,7 +167,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 order by num_rows desc limit 1000
 ---
@@ -194,7 +199,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)
 order by num_rows desc limit 1000
@@ -228,7 +234,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (1=1)
 group by
@@ -263,7 +270,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (1=1)
 order by num_rows desc limit 1000
@@ -295,7 +303,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from default.runs 
 where (1=1)
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)

--- a/metrics/ProfileColumns/redshift.snap
+++ b/metrics/ProfileColumns/redshift.snap
@@ -26,7 +26,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from "db"."default"."runs" 
 where (run_status > 0) and (run_type > 0)
 group by
@@ -60,7 +61,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from "db"."default"."runs" 
 where (run_status > 0) and (run_type > 0)
 order by num_rows desc limit 1000
@@ -91,7 +93,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from "db"."default"."runs" 
 where (run_status > 0) and (run_type > 0)
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)
@@ -125,7 +128,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from "db"."default"."runs" 
 group by
   SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), 
@@ -158,7 +162,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from "db"."default"."runs" 
 order by num_rows desc limit 1000
 ---
@@ -188,7 +193,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from "db"."default"."runs" 
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)
 order by num_rows desc limit 1000
@@ -221,7 +227,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from "db"."default"."runs" 
 where (1=1)
 group by
@@ -255,7 +262,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from "db"."default"."runs" 
 where (1=1)
 order by num_rows desc limit 1000
@@ -286,7 +294,8 @@ select
   CAST(STDDEV(run_status) AS FLOAT) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as sku__num_not_null
 from "db"."default"."runs" 
 where (1=1)
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)

--- a/metrics/ProfileColumns/snowflake.snap
+++ b/metrics/ProfileColumns/snowflake.snap
@@ -27,7 +27,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as "run_status__stddev", 
   count(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  count_if(sku is not null) as "sku__num_not_null"
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
 group by
@@ -62,7 +63,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as "run_status__stddev", 
   count(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  count_if(sku is not null) as "sku__num_not_null"
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
 order by "num_rows" desc limit 1000
@@ -94,7 +96,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as "run_status__stddev", 
   count(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  count_if(sku is not null) as "sku__num_not_null"
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
 group by "segment"
@@ -129,7 +132,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as "run_status__stddev", 
   count(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  count_if(sku is not null) as "sku__num_not_null"
 from db.default.runs 
 group by
   "segment", 
@@ -163,7 +167,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as "run_status__stddev", 
   count(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  count_if(sku is not null) as "sku__num_not_null"
 from db.default.runs 
 order by "num_rows" desc limit 1000
 ---
@@ -194,7 +199,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as "run_status__stddev", 
   count(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  count_if(sku is not null) as "sku__num_not_null"
 from db.default.runs 
 group by "segment"
 order by "num_rows" desc limit 1000
@@ -228,7 +234,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as "run_status__stddev", 
   count(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  count_if(sku is not null) as "sku__num_not_null"
 from db.default.runs 
 where (1=1)
 group by
@@ -263,7 +270,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as "run_status__stddev", 
   count(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  count_if(sku is not null) as "sku__num_not_null"
 from db.default.runs 
 where (1=1)
 order by "num_rows" desc limit 1000
@@ -295,7 +303,8 @@ select
   CAST(stddev(run_status) AS FLOAT) as "run_status__stddev", 
   count(created_at) as "created_at__num_not_null", 
   min(created_at) as "created_at__min", 
-  max(created_at) as "created_at__max"
+  max(created_at) as "created_at__max", 
+  count_if(sku is not null) as "sku__num_not_null"
 from db.default.runs 
 where (1=1)
 group by "segment"

--- a/metrics/ProfileColumns/trino.snap
+++ b/metrics/ProfileColumns/trino.snap
@@ -27,7 +27,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  count_if(sku is not null) as sku__num_not_null
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
 group by
@@ -62,7 +63,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  count_if(sku is not null) as sku__num_not_null
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
 order by num_rows desc limit 1000
@@ -94,7 +96,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  count_if(sku is not null) as sku__num_not_null
 from db.default.runs 
 where (run_status > 0) and (run_type > 0)
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)
@@ -129,7 +132,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  count_if(sku is not null) as sku__num_not_null
 from db.default.runs 
 group by
   SUBSTRING(CAST(workspace AS VARCHAR), 1, 100), 
@@ -163,7 +167,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  count_if(sku is not null) as sku__num_not_null
 from db.default.runs 
 order by num_rows desc limit 1000
 ---
@@ -194,7 +199,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  count_if(sku is not null) as sku__num_not_null
 from db.default.runs 
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)
 order by num_rows desc limit 1000
@@ -228,7 +234,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  count_if(sku is not null) as sku__num_not_null
 from db.default.runs 
 where (1=1)
 group by
@@ -263,7 +270,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  count_if(sku is not null) as sku__num_not_null
 from db.default.runs 
 where (1=1)
 order by num_rows desc limit 1000
@@ -295,7 +303,8 @@ select
   CAST(STDDEV(run_status) AS DOUBLE) as run_status__stddev, 
   count(created_at) as created_at__num_not_null, 
   min(created_at) as created_at__min, 
-  max(created_at) as created_at__max
+  max(created_at) as created_at__max, 
+  count_if(sku is not null) as sku__num_not_null
 from db.default.runs 
 where (1=1)
 group by SUBSTRING(CAST(run_type AS VARCHAR), 1, 100)

--- a/metrics/profile_test.go
+++ b/metrics/profile_test.go
@@ -105,6 +105,14 @@ func (s *ProfileSuite) TestProfileColumns() {
 							Column:        "created_at",
 							ColumnProfile: ColumnProfileTime,
 						},
+						{
+							// STRUCT/RECORD and other unmapped types: the minimal
+							// profile must stay valid SQL (non-null count only) —
+							// no `= 0` or COUNT(DISTINCT) that warehouses reject on
+							// non-comparable types.
+							Column:        "sku",
+							ColumnProfile: ColumnProfileUnknown,
+						},
 					}
 
 					queryBuilder, err := ProfileColumns(dialect.Dialect, tableFqnExpr, columnsToProfile, monitorArgs, nil, 1000, 100)

--- a/metrics/queries.go
+++ b/metrics/queries.go
@@ -189,18 +189,22 @@ func (m *TableMetricExpr) OutColumnAlias() TextExpr {
 // Numeric Metric
 //
 
+// UnknownMetrics is the minimal profile emitted for columns whose type maps to
+// no string/numeric/time shape — STRUCT, ARRAY, JSON, BOOL, etc. Only a
+// non-null count is safe across all of them: numeric metrics like
+// COUNT(DISTINCT) and the `= 0` empty-check emit SQL the warehouse rejects on
+// non-comparable types (e.g. BigQuery refuses `STRUCT = INT64` and
+// `COUNT(DISTINCT struct)`).
 var UnknownMetrics = []MetricId{
 	METRIC_NUM_NOT_NULL,
-	METRIC_NUM_UNIQUE,
-	METRIC_NUM_EMPTY,
 }
 
 func UnknownMetricsValuesCols(field string, opts ...MetricConfOption) []Expr {
-	metricFieldCol := NumericCol(field)
+	col := TextCol(field)
 
 	var cols []Expr
 	for _, metricId := range UnknownMetrics {
-		metricExpr := NumericMetric(metricFieldCol, metricId)
+		metricExpr := &UnknownMetricExpr{MetricId: metricId, Column: col}
 		for _, opt := range opts {
 			opt(&metricExpr.MetricConf)
 		}
@@ -208,6 +212,28 @@ func UnknownMetricsValuesCols(field string, opts ...MetricConfOption) []Expr {
 	}
 
 	return cols
+}
+
+// UnknownMetricExpr renders the minimal, type-agnostic metrics for an
+// unmapped column type. Unlike NumericMetricExpr it never compares the column
+// to a literal or applies DISTINCT, so it stays valid for STRUCT/ARRAY/JSON.
+type UnknownMetricExpr struct {
+	MetricConf
+	MetricId MetricId
+	Column   Expr
+}
+
+func (m *UnknownMetricExpr) ToSql(dialect Dialect) (string, error) {
+	switch m.MetricId {
+	case METRIC_NUM_NOT_NULL:
+		return As(dialect.CountIf(IsNotNull(m.Column)), m.OutColumnAlias()).ToSql(dialect)
+	default:
+		return "", fmt.Errorf("unsupported UNKNOWN metric type: %s", m.MetricId)
+	}
+}
+
+func (m *UnknownMetricExpr) OutColumnAlias() TextExpr {
+	return m.PrefixedAliasForMetric(m.MetricId)
 }
 
 // Groupings


### PR DESCRIPTION
## Problem

Two related failures when profiling BigQuery tables with `RECORD`/STRUCT columns (Data Profile tab):

1. **Top-level STRUCT column** → `No matching signature for operator = for argument types: STRUCT<...>, INT64`. Columns that map to no string/numeric/time profile shape fell back to the "Unknown" minimal profile, which was built with `NumericCol` and emitted `COUNTIF(col = 0)` and `COUNT(DISTINCT col)` — both invalid on non-comparable types.

2. **Nested struct field** (e.g. `sku.description`) → `Invalid field name "sku.description__num_not_null"`. The column reference doubles as the metric's output-column alias prefix; a dotted path is a valid field reference but an invalid output-column name.

## Fix

- **Unknown/minimal profile** (`UnknownMetricsValuesCols`): emit only a type-agnostic non-null count via `COUNTIF(col IS NOT NULL)` (new `UnknownMetricExpr`), matching the documented "row count, non-null count" contract. Drops the `= 0` / `COUNT(DISTINCT)` expressions. Verified across all dialects via snapshots.

- **Alias sanitization** (`PrefixedAliasForMetric`): map every char outside `[A-Za-z0-9_]` to `_` in the alias prefix only, so a dotted nested-field path yields a legal output-column name (`sku.description` → `sku_description__num_not_null`). The column reference stays dotted (valid struct-field access). Readers (fe-app profile result parser) sanitize the same way to match.

Together these let the Data Profile tab profile STRUCT columns and their individual scalar leaf fields.