### PR TITLE
metrics: unique profile alias prefixes + explicit column→alias mapping

### DIFF
--- a/metrics/profile.go
+++ b/metrics/profile.go
@@ -22,6 +22,20 @@ type ColumnToProfile struct {
 	ColumnProfile ColumnProfile
 }
 
+// ProfiledColumn records the output-column alias prefix assigned to a profiled
+// column. The metric output columns for the column are named
+// "<AliasPrefix>__<metricId>". AliasPrefix is a valid SQL identifier, unique
+// within a single ProfileColumns call: collisions after sanitization (e.g. a
+// nested field "sku.id" and a literal column "sku_id" both sanitizing to
+// "sku_id") are disambiguated with an increasing numeric suffix. Callers map
+// result columns back to the requested column via this mapping instead of
+// replicating the sanitization rule.
+type ProfiledColumn struct {
+	Column        string
+	ColumnProfile ColumnProfile
+	AliasPrefix   string
+}
+
 func ProfileColumns(
 	dialect Dialect,
 	tableFqn TableExpr,
@@ -30,7 +44,7 @@ func ProfileColumns(
 	partition *Partition,
 	limit int64,
 	segmentLengthLimit int64,
-) (*querybuilder.QueryBuilder, error) {
+) (*querybuilder.QueryBuilder, []*ProfiledColumn, error) {
 
 	var expressions []Expr
 	var segmentColumns []string
@@ -49,17 +63,26 @@ func ProfileColumns(
 	countColExpr := Identifier(string(METRIC_NUM_ROWS))
 	expressions = append(expressions, As(CountAll(), countColExpr))
 
+	usedAliasPrefixes := map[string]struct{}{}
+	profiledColumns := make([]*ProfiledColumn, 0, len(columnsToProfile))
+
 	for _, toProfile := range columnsToProfile {
+		aliasPrefix := uniqueAliasPrefix(toProfile.Column, usedAliasPrefixes)
+		profiledColumns = append(profiledColumns, &ProfiledColumn{
+			Column:        toProfile.Column,
+			ColumnProfile: toProfile.ColumnProfile,
+			AliasPrefix:   aliasPrefix,
+		})
 		switch toProfile.ColumnProfile {
 		case ColumnProfileUnknown:
-			expressions = append(expressions, UnknownMetricsValuesCols(toProfile.Column, WithPrefixForColumn(toProfile.Column))...)
+			expressions = append(expressions, UnknownMetricsValuesCols(toProfile.Column, WithPrefixForColumn(aliasPrefix))...)
 		case ColumnProfileString:
-			expressions = append(expressions, TextMetricsValuesCols(toProfile.Column, WithPrefixForColumn(toProfile.Column))...)
-			expressions = append(expressions, TextMetricsLengthCols(toProfile.Column, WithPrefixForColumn(toProfile.Column))...)
+			expressions = append(expressions, TextMetricsValuesCols(toProfile.Column, WithPrefixForColumn(aliasPrefix))...)
+			expressions = append(expressions, TextMetricsLengthCols(toProfile.Column, WithPrefixForColumn(aliasPrefix))...)
 		case ColumnProfileNumeric:
-			expressions = append(expressions, NumericMetricsValuesCols(toProfile.Column, dialect, WithPrefixForColumn(toProfile.Column))...)
+			expressions = append(expressions, NumericMetricsValuesCols(toProfile.Column, dialect, WithPrefixForColumn(aliasPrefix))...)
 		case ColumnProfileTime:
-			expressions = append(expressions, TimeMetricsValuesCols(toProfile.Column, WithPrefixForColumn(toProfile.Column))...)
+			expressions = append(expressions, TimeMetricsValuesCols(toProfile.Column, WithPrefixForColumn(aliasPrefix))...)
 		}
 	}
 
@@ -78,5 +101,23 @@ func ProfileColumns(
 		query = query.WithFilter(condition)
 	}
 
-	return query, nil
+	return query, profiledColumns, nil
+}
+
+// uniqueAliasPrefix sanitizes column into a valid identifier and guarantees it
+// is unique among used: the first occurrence keeps the sanitized name, later
+// collisions get an increasing "_2", "_3", ... suffix. Readable aliases keep
+// the generated SQL legible in query logs while staying collision-free, so two
+// columns that sanitize to the same form (e.g. "sku.id" and "sku_id") never
+// share an output column. used is mutated to record every prefix returned.
+func uniqueAliasPrefix(column string, used map[string]struct{}) string {
+	base := sanitizeAliasPrefix(column)
+	candidate := base
+	for n := 2; ; n++ {
+		if _, taken := used[candidate]; !taken {
+			used[candidate] = struct{}{}
+			return candidate
+		}
+		candidate = fmt.Sprintf("%s_%d", base, n)
+	}
 }

--- a/metrics/profile_test.go
+++ b/metrics/profile_test.go
@@ -115,7 +115,7 @@ func (s *ProfileSuite) TestProfileColumns() {
 						},
 					}
 
-					queryBuilder, err := ProfileColumns(dialect.Dialect, tableFqnExpr, columnsToProfile, monitorArgs, nil, 1000, 100)
+					queryBuilder, _, err := ProfileColumns(dialect.Dialect, tableFqnExpr, columnsToProfile, monitorArgs, nil, 1000, 100)
 					s.Require().NoError(err)
 					s.Require().NotNil(queryBuilder)
 					sql, err := queryBuilder.ToSql(dialect.Dialect)
@@ -129,5 +129,41 @@ func (s *ProfileSuite) TestProfileColumns() {
 			}
 		}
 
+	}
+}
+
+// TestProfileColumnsAliasMapping asserts ProfileColumns reports a unique, valid
+// alias prefix per requested column and disambiguates columns that sanitize to
+// the same identifier with an increasing numeric suffix — so callers can map
+// "<prefix>__<metric>" result columns back to the original column.
+func (s *ProfileSuite) TestProfileColumnsAliasMapping() {
+	dialect := dwhsql.NewBigQueryDialect()
+	tableFqnExpr := dwhsql.TableFqn("db", "default", "runs")
+
+	columnsToProfile := []*ColumnToProfile{
+		{Column: "amount", ColumnProfile: ColumnProfileNumeric},
+		// Nested struct field arrives as a dotted path...
+		{Column: "sku.id", ColumnProfile: ColumnProfileString},
+		// ...and collides after sanitization with a literal "sku_id" column.
+		{Column: "sku_id", ColumnProfile: ColumnProfileString},
+		// A third collision exercises the "_3" suffix.
+		{Column: "sku-id", ColumnProfile: ColumnProfileString},
+	}
+
+	_, profiled, err := ProfileColumns(dialect, tableFqnExpr, columnsToProfile, &MonitorArgs{}, nil, 1000, 100)
+	s.Require().NoError(err)
+	s.Require().Len(profiled, len(columnsToProfile))
+
+	s.Equal("amount", profiled[0].AliasPrefix)
+	s.Equal("sku_id", profiled[1].AliasPrefix)
+	s.Equal("sku_id_2", profiled[2].AliasPrefix)
+	s.Equal("sku_id_3", profiled[3].AliasPrefix)
+
+	seen := map[string]struct{}{}
+	for i, pc := range profiled {
+		s.Equal(columnsToProfile[i].Column, pc.Column, "original column preserved in mapping")
+		_, dup := seen[pc.AliasPrefix]
+		s.Falsef(dup, "alias prefix %q repeated", pc.AliasPrefix)
+		seen[pc.AliasPrefix] = struct{}{}
 	}
 }

--- a/metrics/profile_test.go
+++ b/metrics/profile_test.go
@@ -150,7 +150,7 @@ func (s *ProfileSuite) TestProfileColumnsAliasMapping() {
 		{Column: "sku-id", ColumnProfile: ColumnProfileString},
 	}
 
-	_, profiled, err := ProfileColumns(dialect, tableFqnExpr, columnsToProfile, &MonitorArgs{}, nil, 1000, 100)
+	qb, profiled, err := ProfileColumns(dialect, tableFqnExpr, columnsToProfile, &MonitorArgs{}, nil, 1000, 100)
 	s.Require().NoError(err)
 	s.Require().Len(profiled, len(columnsToProfile))
 
@@ -166,4 +166,14 @@ func (s *ProfileSuite) TestProfileColumnsAliasMapping() {
 		s.Falsef(dup, "alias prefix %q repeated", pc.AliasPrefix)
 		seen[pc.AliasPrefix] = struct{}{}
 	}
+
+	// Proof the reported mapping matches the SQL actually generated: every
+	// metric output column is named "<AliasPrefix>__<metric>", so each prefix
+	// must appear in the query, and the lossy dotted/literal collision must not.
+	sql, err := qb.ToSql(dialect)
+	s.Require().NoError(err)
+	for _, pc := range profiled {
+		s.Containsf(sql, pc.AliasPrefix+"__", "alias prefix %q for column %q missing from SQL", pc.AliasPrefix, pc.Column)
+	}
+	s.NotContains(sql, "sku.id__", "dotted path must not leak into an output column alias")
 }

--- a/metrics/queries.go
+++ b/metrics/queries.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/getsynq/dwhsupport/querybuilder"
@@ -144,7 +145,28 @@ func (c *MetricConf) PrefixedAliasForMetric(metricId MetricId) TextExpr {
 	if c.AliasPrefix == "" {
 		return Identifier(string(metricId))
 	}
-	return Identifier(fmt.Sprintf("%s__%s", c.AliasPrefix, string(metricId)))
+	return Identifier(fmt.Sprintf("%s__%s", sanitizeAliasPrefix(c.AliasPrefix), string(metricId)))
+}
+
+// sanitizeAliasPrefix maps a column reference to a valid output-column
+// identifier. The prefix doubles as the column being profiled, so a nested
+// struct field arrives as a dotted path (e.g. "sku.description") — valid as a
+// SQL field reference but rejected as an output column name by BigQuery and
+// others. Replace every char outside [A-Za-z0-9_] with '_' so the alias is
+// always a legal identifier; callers reading results must sanitize the same
+// way to match.
+func sanitizeAliasPrefix(prefix string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '_',
+			r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9':
+			return r
+		default:
+			return '_'
+		}
+	}, prefix)
 }
 
 type MetricConfOption func(*MetricConf)

--- a/metrics/queries.go
+++ b/metrics/queries.go
@@ -153,8 +153,10 @@ func (c *MetricConf) PrefixedAliasForMetric(metricId MetricId) TextExpr {
 // struct field arrives as a dotted path (e.g. "sku.description") — valid as a
 // SQL field reference but rejected as an output column name by BigQuery and
 // others. Replace every char outside [A-Za-z0-9_] with '_' so the alias is
-// always a legal identifier; callers reading results must sanitize the same
-// way to match.
+// always a legal identifier. ProfileColumns resolves collisions and reports the
+// final prefix per column via ProfiledColumn, so callers map results from that
+// mapping rather than re-deriving it; this stays as a defensive guarantee for
+// any direct WithPrefixForColumn user.
 func sanitizeAliasPrefix(prefix string) string {
 	return strings.Map(func(r rune) rune {
 		switch {

--- a/scrapper/scrappertest/metrics_execution_compliance.go
+++ b/scrapper/scrappertest/metrics_execution_compliance.go
@@ -225,7 +225,7 @@ func (s *MetricsExecutionSuite) TestMetricsExecution_ProfileColumns() {
 		}},
 	}
 
-	qb, err := metrics.ProfileColumns(dialect, s.Config.TableFqn, columnsToProfile, args, nil, 100, 150)
+	qb, _, err := metrics.ProfileColumns(dialect, s.Config.TableFqn, columnsToProfile, args, nil, 100, 150)
 	s.Require().NoError(err)
 
 	sql, err := qb.ToSql(dialect)


### PR DESCRIPTION
## Summary

Makes profile output-column aliases collision-free and self-describing, so consumers (kernel-ext-dwh-metrics, fe-app) map result columns back to the requested column without replicating any sanitization rule.

- `ProfileColumns` now returns a `[]*ProfiledColumn` mapping alongside the query builder, recording the alias prefix assigned to each requested column (`<prefix>__<metric>`).
- Alias prefixes stay readable (sanitized column name) and are made unique within a call: columns that sanitize to the same identifier (e.g. nested field `sku.id` vs literal `sku_id`) get an increasing numeric suffix (`sku_id`, `sku_id_2`, …) — they no longer silently merge into one output column.
- Sanitization (`[^A-Za-z0-9_] → _`) is retained as a defensive guarantee for direct `WithPrefixForColumn` users.

## Why

A nested-struct profile aliased `sku.description__num_not_null`, which BigQuery rejects as an output column name. Sanitizing fixes validity but is lossy (two columns can collapse to the same alias), and forced the FE to re-implement the exact rule to read results. Returning the explicit mapping + unique prefixes removes both the collision and the cross-repo guessing.