### PR TITLE
sqldialect: dialect-aware RowCompare for composite-key range scans

### DIFF
--- a/sqldialect/RowCompareCompositeGte/bigquery.snap
+++ b/sqldialect/RowCompareCompositeGte/bigquery.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeGte - 1]
+(workspace > 'ws' or (workspace = 'ws') and (path >= 'p'))
+---

--- a/sqldialect/RowCompareCompositeGte/clickhouse.snap
+++ b/sqldialect/RowCompareCompositeGte/clickhouse.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeGte - 1]
+(workspace > 'ws' or (workspace = 'ws') and (path >= 'p'))
+---

--- a/sqldialect/RowCompareCompositeGte/databricks.snap
+++ b/sqldialect/RowCompareCompositeGte/databricks.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeGte - 1]
+(workspace > 'ws' or (workspace = 'ws') and (path >= 'p'))
+---

--- a/sqldialect/RowCompareCompositeGte/duckdb.snap
+++ b/sqldialect/RowCompareCompositeGte/duckdb.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeGte - 1]
+(workspace > 'ws' or (workspace = 'ws') and (path >= 'p'))
+---

--- a/sqldialect/RowCompareCompositeGte/mssql.snap
+++ b/sqldialect/RowCompareCompositeGte/mssql.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeGte - 1]
+(workspace > 'ws' or (workspace = 'ws') and (path >= 'p'))
+---

--- a/sqldialect/RowCompareCompositeGte/mysql.snap
+++ b/sqldialect/RowCompareCompositeGte/mysql.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeGte - 1]
+(workspace, path) >= ('ws', 'p')
+---

--- a/sqldialect/RowCompareCompositeGte/oracle.snap
+++ b/sqldialect/RowCompareCompositeGte/oracle.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeGte - 1]
+(workspace > 'ws' or (workspace = 'ws') and (path >= 'p'))
+---

--- a/sqldialect/RowCompareCompositeGte/postgres.snap
+++ b/sqldialect/RowCompareCompositeGte/postgres.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeGte - 1]
+(workspace, path) >= ('ws', 'p')
+---

--- a/sqldialect/RowCompareCompositeGte/redshift.snap
+++ b/sqldialect/RowCompareCompositeGte/redshift.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeGte - 1]
+(workspace > 'ws' or (workspace = 'ws') and (path >= 'p'))
+---

--- a/sqldialect/RowCompareCompositeGte/snowflake.snap
+++ b/sqldialect/RowCompareCompositeGte/snowflake.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeGte - 1]
+(workspace > 'ws' or (workspace = 'ws') and (path >= 'p'))
+---

--- a/sqldialect/RowCompareCompositeGte/trino.snap
+++ b/sqldialect/RowCompareCompositeGte/trino.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeGte - 1]
+(workspace > 'ws' or (workspace = 'ws') and (path >= 'p'))
+---

--- a/sqldialect/RowCompareCompositeLt/bigquery.snap
+++ b/sqldialect/RowCompareCompositeLt/bigquery.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeLt - 1]
+(workspace < 'ws' or (workspace = 'ws') and (path < 'p'))
+---

--- a/sqldialect/RowCompareCompositeLt/clickhouse.snap
+++ b/sqldialect/RowCompareCompositeLt/clickhouse.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeLt - 1]
+(workspace < 'ws' or (workspace = 'ws') and (path < 'p'))
+---

--- a/sqldialect/RowCompareCompositeLt/databricks.snap
+++ b/sqldialect/RowCompareCompositeLt/databricks.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeLt - 1]
+(workspace < 'ws' or (workspace = 'ws') and (path < 'p'))
+---

--- a/sqldialect/RowCompareCompositeLt/duckdb.snap
+++ b/sqldialect/RowCompareCompositeLt/duckdb.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeLt - 1]
+(workspace < 'ws' or (workspace = 'ws') and (path < 'p'))
+---

--- a/sqldialect/RowCompareCompositeLt/mssql.snap
+++ b/sqldialect/RowCompareCompositeLt/mssql.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeLt - 1]
+(workspace < 'ws' or (workspace = 'ws') and (path < 'p'))
+---

--- a/sqldialect/RowCompareCompositeLt/mysql.snap
+++ b/sqldialect/RowCompareCompositeLt/mysql.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeLt - 1]
+(workspace, path) < ('ws', 'p')
+---

--- a/sqldialect/RowCompareCompositeLt/oracle.snap
+++ b/sqldialect/RowCompareCompositeLt/oracle.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeLt - 1]
+(workspace < 'ws' or (workspace = 'ws') and (path < 'p'))
+---

--- a/sqldialect/RowCompareCompositeLt/postgres.snap
+++ b/sqldialect/RowCompareCompositeLt/postgres.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeLt - 1]
+(workspace, path) < ('ws', 'p')
+---

--- a/sqldialect/RowCompareCompositeLt/redshift.snap
+++ b/sqldialect/RowCompareCompositeLt/redshift.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeLt - 1]
+(workspace < 'ws' or (workspace = 'ws') and (path < 'p'))
+---

--- a/sqldialect/RowCompareCompositeLt/snowflake.snap
+++ b/sqldialect/RowCompareCompositeLt/snowflake.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeLt - 1]
+(workspace < 'ws' or (workspace = 'ws') and (path < 'p'))
+---

--- a/sqldialect/RowCompareCompositeLt/trino.snap
+++ b/sqldialect/RowCompareCompositeLt/trino.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestCompositeLt - 1]
+(workspace < 'ws' or (workspace = 'ws') and (path < 'p'))
+---

--- a/sqldialect/RowCompareThreeColumnGt/bigquery.snap
+++ b/sqldialect/RowCompareThreeColumnGt/bigquery.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestThreeColumnGt - 1]
+(a > 1 or (a = 1) and (b > 2) or (a = 1) and (b = 2) and (c > 3))
+---

--- a/sqldialect/RowCompareThreeColumnGt/clickhouse.snap
+++ b/sqldialect/RowCompareThreeColumnGt/clickhouse.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestThreeColumnGt - 1]
+(a > 1 or (a = 1) and (b > 2) or (a = 1) and (b = 2) and (c > 3))
+---

--- a/sqldialect/RowCompareThreeColumnGt/databricks.snap
+++ b/sqldialect/RowCompareThreeColumnGt/databricks.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestThreeColumnGt - 1]
+(a > 1 or (a = 1) and (b > 2) or (a = 1) and (b = 2) and (c > 3))
+---

--- a/sqldialect/RowCompareThreeColumnGt/duckdb.snap
+++ b/sqldialect/RowCompareThreeColumnGt/duckdb.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestThreeColumnGt - 1]
+(a > 1 or (a = 1) and (b > 2) or (a = 1) and (b = 2) and (c > 3))
+---

--- a/sqldialect/RowCompareThreeColumnGt/mssql.snap
+++ b/sqldialect/RowCompareThreeColumnGt/mssql.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestThreeColumnGt - 1]
+(a > 1 or (a = 1) and (b > 2) or (a = 1) and (b = 2) and (c > 3))
+---

--- a/sqldialect/RowCompareThreeColumnGt/mysql.snap
+++ b/sqldialect/RowCompareThreeColumnGt/mysql.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestThreeColumnGt - 1]
+(a, b, c) > (1, 2, 3)
+---

--- a/sqldialect/RowCompareThreeColumnGt/oracle.snap
+++ b/sqldialect/RowCompareThreeColumnGt/oracle.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestThreeColumnGt - 1]
+(a > 1 or (a = 1) and (b > 2) or (a = 1) and (b = 2) and (c > 3))
+---

--- a/sqldialect/RowCompareThreeColumnGt/postgres.snap
+++ b/sqldialect/RowCompareThreeColumnGt/postgres.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestThreeColumnGt - 1]
+(a, b, c) > (1, 2, 3)
+---

--- a/sqldialect/RowCompareThreeColumnGt/redshift.snap
+++ b/sqldialect/RowCompareThreeColumnGt/redshift.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestThreeColumnGt - 1]
+(a > 1 or (a = 1) and (b > 2) or (a = 1) and (b = 2) and (c > 3))
+---

--- a/sqldialect/RowCompareThreeColumnGt/snowflake.snap
+++ b/sqldialect/RowCompareThreeColumnGt/snowflake.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestThreeColumnGt - 1]
+(a > 1 or (a = 1) and (b > 2) or (a = 1) and (b = 2) and (c > 3))
+---

--- a/sqldialect/RowCompareThreeColumnGt/trino.snap
+++ b/sqldialect/RowCompareThreeColumnGt/trino.snap
@@ -1,0 +1,4 @@
+
+[TestRowCompareSuite/TestThreeColumnGt - 1]
+(a > 1 or (a = 1) and (b > 2) or (a = 1) and (b = 2) and (c > 3))
+---

--- a/sqldialect/dialect_mysql.go
+++ b/sqldialect/dialect_mysql.go
@@ -150,3 +150,7 @@ func (d *MySQLDialect) FormatLimit(rowsSql string) string {
 }
 
 func (d *MySQLDialect) SupportsCrossDatabaseQueries() bool { return false }
+
+// prefersRowValueComparison: MySQL supports row constructor comparison and uses
+// a composite index range scan for `(a, b) >= (x, y)`. See RowCompare.
+func (d *MySQLDialect) prefersRowValueComparison() bool { return true }

--- a/sqldialect/dialect_postgres.go
+++ b/sqldialect/dialect_postgres.go
@@ -134,3 +134,9 @@ func (d *PostgresDialect) FormatLimit(rowsSql string) string {
 }
 
 func (d *PostgresDialect) SupportsCrossDatabaseQueries() bool { return false }
+
+// prefersRowValueComparison: Postgres decomposes a native row-value comparison
+// `(a, b) >= (x, y)` into a leading-column index range scan, so it is the
+// index-friendly form (verified against a (workspace, path) btree). See
+// RowCompare.
+func (d *PostgresDialect) prefersRowValueComparison() bool { return true }

--- a/sqldialect/row_compare.go
+++ b/sqldialect/row_compare.go
@@ -1,0 +1,143 @@
+package sqldialect
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RowCompare builds a lexicographic comparison of a column tuple against a
+// value tuple: `(cols...) <fn> (vals...)`, where fn is one of <, <=, >, >=
+// (equality should use per-column Eq). It is the dialect-aware way to express a
+// half-open key-range scan `(a, b) >= (lo0, lo1) AND (a, b) < (hi0, hi1)` for a
+// composite key.
+//
+// The two equivalent renderings differ wildly in how engines optimise them, and
+// the better one is engine-specific, so RowCompare lets each dialect pick:
+//
+//   - Native row-value constructor `(a, b) >= (x, y)` — Postgres and MySQL
+//     decompose this into a leading-column index range scan (sargable). The
+//     lexicographic OR-expansion, by contrast, confuses their planners into a
+//     bitmap union that over-scans.
+//   - Lexicographic OR-expansion `(a > x) OR (a = x AND b >= y)` — ClickHouse
+//     prunes its primary-key granules from this form, but does NOT prune from a
+//     native tuple comparison (it scans every granule). BigQuery / Snowflake /
+//     Redshift / MSSQL don't support `<`/`>` on row constructors at all, so the
+//     expansion is also their only valid form.
+//
+// Both renderings are semantically identical (same total order, NULLs aside).
+// A dialect opts into the native form by implementing rowValueComparer; every
+// other dialect falls back to the portable expansion, which is valid SQL
+// everywhere.
+func RowCompare(cols []Expr, fn CompareFn, vals []Expr) CondExpr {
+	return &RowCompareExpr{cols: cols, vals: vals, fn: fn}
+}
+
+type RowCompareExpr struct {
+	cols []Expr
+	vals []Expr
+	fn   CompareFn
+}
+
+var _ CondExpr = (*RowCompareExpr)(nil)
+
+// rowValueComparer is the optional interface a dialect implements to declare
+// that a native row-value constructor comparison is both supported and the
+// index-friendly form for it. Dialects that don't implement it get the
+// lexicographic expansion. Kept unexported: opting in is a property of the
+// concrete dialect, not something callers toggle.
+type rowValueComparer interface {
+	prefersRowValueComparison() bool
+}
+
+func (e *RowCompareExpr) ToSql(dialect Dialect) (string, error) {
+	n := min(len(e.cols), len(e.vals))
+	if n == 0 {
+		return "", fmt.Errorf("RowCompare: empty column or value tuple")
+	}
+	// A single component is a plain scalar comparison in every dialect — no
+	// tuple machinery, no divergent planning, so emit it directly.
+	if n == 1 {
+		return compare(e.cols[0], e.fn, e.vals[0]).ToSql(dialect)
+	}
+
+	if rv, ok := dialect.(rowValueComparer); ok && rv.prefersRowValueComparison() {
+		return e.nativeRowValue(dialect, n)
+	}
+	return e.expand(n).ToSql(dialect)
+}
+
+func (e *RowCompareExpr) IsCondExpr() {}
+
+// nativeRowValue renders `(c0, c1, ...) fn (v0, v1, ...)`.
+func (e *RowCompareExpr) nativeRowValue(dialect Dialect, n int) (string, error) {
+	colsSql := make([]string, n)
+	valsSql := make([]string, n)
+	for i := 0; i < n; i++ {
+		c, err := e.cols[i].ToSql(dialect)
+		if err != nil {
+			return "", err
+		}
+		v, err := e.vals[i].ToSql(dialect)
+		if err != nil {
+			return "", err
+		}
+		colsSql[i] = c
+		valsSql[i] = v
+	}
+	return fmt.Sprintf("(%s) %s (%s)",
+		strings.Join(colsSql, ", "), e.fn, strings.Join(valsSql, ", ")), nil
+}
+
+// expand builds the portable lexicographic OR-expansion. For `(c) fn (v)` with
+// fn ∈ {<, <=, >, >=} it emits, for each level i:
+//
+//	(c0 = v0 AND ... AND c_{i-1} = v_{i-1} AND c_i <step> v_i)
+//
+// OR-joined across levels, where <step> is the strict operator (< or >) at every
+// non-final level and the requested (possibly non-strict) operator at the final
+// level. That is exactly the standard total-order definition of a tuple
+// comparison.
+func (e *RowCompareExpr) expand(n int) CondExpr {
+	nonFinal, final := stepOps(e.fn)
+
+	groups := make([]CondExpr, 0, n)
+	for i := 0; i < n; i++ {
+		level := make([]CondExpr, 0, i+1)
+		for j := 0; j < i; j++ {
+			level = append(level, Eq(e.cols[j], e.vals[j]))
+		}
+		if i == n-1 {
+			level = append(level, compare(e.cols[i], final, e.vals[i]))
+		} else {
+			level = append(level, compare(e.cols[i], nonFinal, e.vals[i]))
+		}
+		if len(level) == 1 {
+			groups = append(groups, level[0])
+		} else {
+			groups = append(groups, AndGroups(level...))
+		}
+	}
+	if len(groups) == 1 {
+		return groups[0]
+	}
+	return Or(groups...)
+}
+
+// stepOps maps a tuple comparison operator to (non-final-level op, final-level
+// op): non-final levels are always strict in the comparison direction; only the
+// final level carries the inclusive/exclusive distinction.
+func stepOps(fn CompareFn) (nonFinal, final CompareFn) {
+	switch fn {
+	case COMPARE_LT:
+		return COMPARE_LT, COMPARE_LT
+	case COMPARE_LTE:
+		return COMPARE_LT, COMPARE_LTE
+	case COMPARE_GT:
+		return COMPARE_GT, COMPARE_GT
+	case COMPARE_GTE:
+		return COMPARE_GT, COMPARE_GTE
+	default:
+		// Defensive: only ordering operators define a lexicographic expansion.
+		return fn, fn
+	}
+}

--- a/sqldialect/row_compare_test.go
+++ b/sqldialect/row_compare_test.go
@@ -1,0 +1,91 @@
+package sqldialect
+
+import (
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/stretchr/testify/suite"
+)
+
+type RowCompareSuite struct {
+	suite.Suite
+}
+
+func TestRowCompareSuite(t *testing.T) {
+	suite.Run(t, new(RowCompareSuite))
+}
+
+// Composite half-open lower bound: (workspace, path) >= ('ws', 'p').
+func (s *RowCompareSuite) TestCompositeGte() {
+	for _, dialect := range DialectsToTest() {
+		expr := RowCompare(
+			[]Expr{Sql("workspace"), Sql("path")},
+			COMPARE_GTE,
+			[]Expr{String("ws"), String("p")},
+		)
+		sql, err := expr.ToSql(dialect.Dialect)
+		s.Require().NoError(err)
+		s.Require().NotEmpty(sql)
+		s.T().Log(dialect.Name, "=>", sql)
+		snaps.WithConfig(snaps.Dir("RowCompareCompositeGte"), snaps.Filename(dialect.Name)).MatchSnapshot(s.T(), sql)
+	}
+}
+
+// Composite exclusive upper bound: (workspace, path) < ('ws', 'p').
+func (s *RowCompareSuite) TestCompositeLt() {
+	for _, dialect := range DialectsToTest() {
+		expr := RowCompare(
+			[]Expr{Sql("workspace"), Sql("path")},
+			COMPARE_LT,
+			[]Expr{String("ws"), String("p")},
+		)
+		sql, err := expr.ToSql(dialect.Dialect)
+		s.Require().NoError(err)
+		s.Require().NotEmpty(sql)
+		snaps.WithConfig(snaps.Dir("RowCompareCompositeLt"), snaps.Filename(dialect.Name)).MatchSnapshot(s.T(), sql)
+	}
+}
+
+// Three-column key exercises the multi-level equality prefixes in the expansion.
+func (s *RowCompareSuite) TestThreeColumnGt() {
+	for _, dialect := range DialectsToTest() {
+		expr := RowCompare(
+			[]Expr{Sql("a"), Sql("b"), Sql("c")},
+			COMPARE_GT,
+			[]Expr{Int64(1), Int64(2), Int64(3)},
+		)
+		sql, err := expr.ToSql(dialect.Dialect)
+		s.Require().NoError(err)
+		snaps.WithConfig(snaps.Dir("RowCompareThreeColumnGt"), snaps.Filename(dialect.Name)).MatchSnapshot(s.T(), sql)
+	}
+}
+
+// A single-column key must collapse to a plain scalar comparison in every
+// dialect — no tuple syntax, no expansion.
+func (s *RowCompareSuite) TestSingleColumnIsScalar() {
+	for _, dialect := range DialectsToTest() {
+		expr := RowCompare([]Expr{Sql("id")}, COMPARE_GTE, []Expr{Int64(42)})
+		sql, err := expr.ToSql(dialect.Dialect)
+		s.Require().NoError(err)
+		s.Require().Equal("id >= 42", sql)
+	}
+}
+
+// Postgres opts into the native row-value form; ClickHouse keeps the expansion
+// (it prunes its primary key from the OR form, not from a native tuple).
+func (s *RowCompareSuite) TestNativeVsExpansionSelection() {
+	expr := RowCompare(
+		[]Expr{Sql("workspace"), Sql("path")},
+		COMPARE_GTE,
+		[]Expr{String("ws"), String("p")},
+	)
+
+	pg, err := expr.ToSql(NewPostgresDialect())
+	s.Require().NoError(err)
+	s.Require().Equal(`(workspace, path) >= ('ws', 'p')`, pg)
+
+	ch, err := expr.ToSql(NewClickHouseDialect())
+	s.Require().NoError(err)
+	s.Require().Contains(ch, " or ")
+	s.Require().NotContains(ch, `(workspace, path) >=`)
+}


### PR DESCRIPTION
## Summary

Adds `sqldialect.RowCompare(cols []Expr, fn CompareFn, vals []Expr) CondExpr` — a lexicographic tuple comparison `(a, b) >= (x, y)` that renders the form each engine's planner can actually optimise.

The motivation: the index-optimal rendering is **engine-specific and opposite** for the two engines we measured (on a real 1.5M-row `(workspace, path)` table):

| Form | Postgres | ClickHouse |
|---|---|---|
| Native `(a,b) >= (x,y)` | Index Only Scan (leading-col range) | no pruning — 719/719 granules |
| Lexicographic OR-expansion | bitmap union, over-scans | prunes PK — 56/718 granules |

So the choice has to be a dialect property:

- **Postgres / MySQL** opt into the native row-value constructor (`(a, b) >= (x, y)`) via the unexported `rowValueComparer` interface — same pattern as `SupportsCrossDatabaseQueries()`.
- **Everyone else** (ClickHouse, BigQuery, Snowflake, Redshift, Databricks, DuckDB, Trino, Oracle, MSSQL) falls back to the portable lexicographic OR-expansion `(a > x or (a = x and b >= y))`. This is the form ClickHouse prunes from, and it's the only *valid* form for engines that don't support `<`/`>` on row constructors (BigQuery, Snowflake, Redshift, MSSQL).

A single-column key collapses to a plain scalar comparison in every dialect. All four ordering operators (`<`, `<=`, `>`, `>=`) get correct strict/inclusive boundary semantics. Snapshot tests cover all 11 dialects.

## Use cases

Keyset pagination, incremental high-watermark scans, and any composite-cursor range want this same index-friendly tuple comparison. First consumer will be `synq-recon`'s composite-key bisection (`pkg/checksum/tuplekey.go`), which currently hand-rolls the OR-expansion and can delete it in favour of this primitive.

## Note for reviewers

MySQL's native flag is enabled on the strength of documented behaviour (row constructor comparison uses range access on the leftmost index prefix); flag it if you'd rather gate to Postgres-only until verified on a live table. The expansion fallback is safe for everyone regardless.