### PR TITLE
fix(snowflake): treat 090073 warehouse-resume quota error as non-retryable [QUA-602]

### DIFF
--- a/scrapper/snowflake/permission_error_test.go
+++ b/scrapper/snowflake/permission_error_test.go
@@ -29,6 +29,20 @@ func TestIsPermissionError(t *testing.T) {
 		assert.True(t, IsPermissionError(err))
 	})
 
+	t.Run("warehouse cannot be resumed — resource monitor quota (typed 90073)", func(t *testing.T) {
+		err := &gosnowflake.SnowflakeError{
+			Number:  90073,
+			Message: "Warehouse 'WH_DATA_GOVERNANCE' cannot be resumed because resource monitor 'GOVERNANCE_RM' has exceeded its quota.",
+		}
+		assert.True(t, IsPermissionError(err))
+	})
+
+	t.Run("warehouse cannot be resumed — resource monitor quota (string, wrapped)", func(t *testing.T) {
+		inner := errors.New("090073 (22000): Warehouse 'WH_DATA_GOVERNANCE' cannot be resumed because resource monitor 'GOVERNANCE_RM' has exceeded its quota.")
+		err := errors.Wrap(inner, "failed to fetch query logs")
+		assert.True(t, IsPermissionError(err))
+	})
+
 	t.Run("unrelated SnowflakeError", func(t *testing.T) {
 		err := &gosnowflake.SnowflakeError{Number: 1234, Message: "syntax error"}
 		assert.False(t, IsPermissionError(err))

--- a/scrapper/snowflake/snowflake.go
+++ b/scrapper/snowflake/snowflake.go
@@ -111,23 +111,29 @@ func (e *SnowflakeScrapper) IsPermissionError(err error) bool {
 	return IsPermissionError(err)
 }
 
-// IsPermissionError reports whether err is a Snowflake permission/authorization failure.
+// IsPermissionError reports whether err is a Snowflake failure that is
+// user-actionable and NOT worth retrying — callers use it to finish the job and
+// surface the cause to the customer instead of looping with backoff.
 // Recognises:
 //   - SQL compilation error 002003 with the canonical "does not exist or not authorized"
 //     message (most common shape — Snowflake intentionally conflates "no privilege" and
 //     "no such object" to prevent object-existence probing).
 //   - Error 003001 "Insufficient privileges to operate on ...".
+//   - Error 090073 "Warehouse '%s' cannot be resumed because resource monitor '%s'
+//     has exceeded its quota." — the customer's compute is capped/suspended; retrying
+//     just builds a multi-day job backlog (QUA-602). Only the customer can lift it.
 func IsPermissionError(err error) bool {
 	if err == nil {
 		return false
 	}
 	var sfErr *gosnowflake.SnowflakeError
 	if errors.As(err, &sfErr) {
-		if sfErr.Number == 3001 {
+		if sfErr.Number == 3001 || sfErr.Number == 90073 {
 			return true
 		}
 	}
-	return strings.Contains(err.Error(), "does not exist or not authorized")
+	return strings.Contains(err.Error(), "does not exist or not authorized") ||
+		strings.Contains(err.Error(), "cannot be resumed because resource monitor")
 }
 
 func (e *SnowflakeScrapper) Capabilities() scrapper.Capabilities { return scrapper.Capabilities{} }


### PR DESCRIPTION
## Summary

Snowflake error `090073` (`Warehouse '%s' cannot be resumed because resource monitor '%s' has exceeded its quota`) was classified as an infra error and retried with backoff. For query-log fetching in `kernel-ext-dwh-metrics` this builds a multi-day backlog of never-completing jobs (`job_done_at` stays NULL), driving `jobqueue.run_delay_seconds` past the alert threshold **indefinitely** — until the customer lifts their Snowflake quota.

This makes `IsPermissionError` recognise `090073` so the consumer finishes the job and surfaces the cause to the customer instead of looping. Semantically `IsPermissionError` is the "user-actionable, not worth retrying" seam at the job layer (kernel `fetch_query_logs_job.go:174` finishes + heartbeats on it), and a quota-capped/suspended warehouse fits: only the customer can lift it.

## Root cause (EU prod, 2026-06-28)

- Alert `kernel-ext-dwh-metrics # query_logs_jobs jobqueue is delayed` firing at **~176,217s (≈2.04 days)** vs **3600s** threshold.
- Isolated to one integration — every other integration 0 errors:
  - ws **CivicaDEMO**, integration `956f54ca-7205-43fc-ae6f-f4749c72eab2` — 108/108 spans errored in 6h with `090073`.
- `090073` not matched by Snowflake `IsPermissionError` → infra-error retry path → `done_at` NULL → window ages at real time → permanent alert.

## Changes

- `scrapper/snowflake/snowflake.go` — `IsPermissionError` matches `090073` (typed `SnowflakeError.Number == 90073` + `"cannot be resumed because resource monitor"` string fallback); doc comment reframed to "user-actionable, non-retryable".
- `scrapper/snowflake/permission_error_test.go` — 2 new cases (typed + wrapped string). TDD red→green; full package: 53 passing.

## Rollout

Fix is live only after a `dwhsupport` release is tagged and `cloud` bumps the `dwhsupport` dep in `kernel-ext-dwh-metrics/go.mod`, then kernel-ext-dwh-metrics deploys.

## Out of scope (tracked in QUA-602)

- Customer heartbeat for this path still reads "invalid permissions…" (misleading for a quota error; real Snowflake text is appended). Accurate wording needs a new `Scrapper` interface method across all platforms.
- `query_logs_job_manager` shows ~1061d (EU) / ~312d (US) `run_delay_seconds` — ancient never-succeeded row, unmonitored; separate cleanup.

Linear: QUA-602