### PR TITLE
scrapper: add per-dialect EstimateQuery cost/scale estimation API [QUA-776]

### DIFF
--- a/pool/scrapper.go
+++ b/pool/scrapper.go
@@ -198,6 +198,15 @@ func (s *scrapperWrapper[K]) RunRawQuery(ctx context.Context, sql string) (scrap
 	return s.lease.Value().RunRawQuery(ctx, sql)
 }
 
+func (s *scrapperWrapper[K]) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.lease == nil || s.lease.Released() {
+		return nil, nil
+	}
+	return s.lease.Value().EstimateQuery(ctx, sql)
+}
+
 func (s *scrapperWrapper[K]) QueryTableConstraints(ctx context.Context) ([]*scrapper.TableConstraintRow, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pool/scrapper_test.go
+++ b/pool/scrapper_test.go
@@ -75,6 +75,9 @@ func (m *mockScrapper) QueryShape(ctx context.Context, sql string) ([]*scrapper.
 func (m *mockScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.RawQueryRowIterator, error) {
 	return nil, nil
 }
+func (m *mockScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	return nil, nil
+}
 
 func (m *mockScrapper) QueryTableConstraints(ctx context.Context) ([]*scrapper.TableConstraintRow, error) {
 	return nil, nil

--- a/scrapper/athena/query_estimate.go
+++ b/scrapper/athena/query_estimate.go
@@ -1,0 +1,16 @@
+package athena
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+)
+
+// EstimateQuery is unsupported for now. Athena is Presto-derived and its
+// EXPLAIN surface mirrors Trino's; a pre-run bytes estimate depends on the Glue
+// table statistics being populated, which is not guaranteed. Athena does bill
+// on bytes scanned, so a reliable estimate is valuable — but it needs a
+// validation spike before we advertise it. Returning ErrUnsupported until then.
+func (e *AthenaScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	return nil, scrapper.ErrUnsupported
+}

--- a/scrapper/bigquery/bigquery.go
+++ b/scrapper/bigquery/bigquery.go
@@ -61,6 +61,11 @@ func (e *BigQueryScrapper) IsPermissionError(err error) bool {
 func (e *BigQueryScrapper) Capabilities() scrapper.Capabilities {
 	return scrapper.Capabilities{
 		ConstraintsViaQueryTables: true,
+		EstimateQuery: scrapper.EstimateQueryCapability{
+			Supported: true,
+			Bytes:     true,
+			Exact:     true,
+		},
 	}
 }
 

--- a/scrapper/bigquery/bigquery.go
+++ b/scrapper/bigquery/bigquery.go
@@ -62,9 +62,9 @@ func (e *BigQueryScrapper) Capabilities() scrapper.Capabilities {
 	return scrapper.Capabilities{
 		ConstraintsViaQueryTables: true,
 		EstimateQuery: scrapper.EstimateQueryCapability{
-			Supported: true,
-			Bytes:     true,
-			Exact:     true,
+			Supported:    true,
+			ReportsBytes: true,
+			CanBeExact:   true,
 		},
 	}
 }

--- a/scrapper/bigquery/query_estimate.go
+++ b/scrapper/bigquery/query_estimate.go
@@ -1,0 +1,53 @@
+package bigquery
+
+import (
+	"context"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/getsynq/dwhsupport/scrapper"
+	"github.com/pkg/errors"
+)
+
+// EstimateQuery uses a BigQuery dry-run job to obtain an authoritative estimate
+// of the bytes the query would process. A dry run does not execute the query
+// and is not billed; BigQuery bills on TotalBytesProcessed, so this doubles as a
+// cost estimate.
+//
+// The dry-run job must be created with DryRun=true and read via query.Run only —
+// job.Read errors on a dry-run job, so this cannot reuse RunRawQuery/QueryShape.
+func (e *BigQueryScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	query := e.executor.GetBigQueryClient().Query(sql)
+	query.DryRun = true
+	// A dry run reports scan bytes independent of cache; disabling the cache
+	// keeps the estimate stable and avoids a 0-byte "cache hit" result.
+	query.DisableQueryCache = true
+
+	job, err := query.Run(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "bigquery dry-run failed")
+	}
+
+	status := job.LastStatus()
+	if status == nil || status.Statistics == nil {
+		return nil, errors.New("bigquery dry-run returned no statistics")
+	}
+
+	estimate := &scrapper.QueryEstimate{
+		BytesScanned: int64Ptr(status.Statistics.TotalBytesProcessed),
+		Exact:        true,
+	}
+
+	// TotalBytesProcessedAccuracy is "PRECISE" for the common case and only
+	// downgrades to a "LOWER_BOUND"/"UPPER_BOUND" estimate for queries the
+	// planner cannot cost exactly (e.g. some BI Engine / wildcard scans). Treat
+	// anything other than a precise value as a planner estimate.
+	if qs, ok := status.Statistics.Details.(*bigquery.QueryStatistics); ok {
+		if qs.TotalBytesProcessedAccuracy != "" && qs.TotalBytesProcessedAccuracy != "PRECISE" {
+			estimate.Exact = false
+		}
+	}
+
+	return estimate, nil
+}
+
+func int64Ptr(v int64) *int64 { return &v }

--- a/scrapper/clickhouse/clickhouse.go
+++ b/scrapper/clickhouse/clickhouse.go
@@ -36,7 +36,7 @@ func (e *ClickhouseScrapper) IsPermissionError(err error) bool {
 
 func (e *ClickhouseScrapper) Capabilities() scrapper.Capabilities {
 	return scrapper.Capabilities{
-		EstimateQuery: scrapper.EstimateQueryCapability{Supported: true, Rows: true},
+		EstimateQuery: scrapper.EstimateQueryCapability{Supported: true, ReportsRows: true},
 	}
 }
 

--- a/scrapper/clickhouse/clickhouse.go
+++ b/scrapper/clickhouse/clickhouse.go
@@ -34,7 +34,11 @@ func (e *ClickhouseScrapper) IsPermissionError(err error) bool {
 	return dwhexecclickhouse.IsPermissionError(err)
 }
 
-func (e *ClickhouseScrapper) Capabilities() scrapper.Capabilities { return scrapper.Capabilities{} }
+func (e *ClickhouseScrapper) Capabilities() scrapper.Capabilities {
+	return scrapper.Capabilities{
+		EstimateQuery: scrapper.EstimateQueryCapability{Supported: true, Rows: true},
+	}
+}
 
 func (e *ClickhouseScrapper) DialectType() string {
 	return "clickhouse"

--- a/scrapper/clickhouse/query_estimate.go
+++ b/scrapper/clickhouse/query_estimate.go
@@ -1,0 +1,49 @@
+package clickhouse
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+	"github.com/pkg/errors"
+)
+
+// EstimateQuery returns a row estimate via `EXPLAIN ESTIMATE`, which reports the
+// parts/rows/marks the planner expects to read per table without executing the
+// query. Bytes are not available from this plan, so only Rows is populated. The
+// estimate is planner-based and depends on up-to-date part metadata.
+func (e *ClickhouseScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	columns, rows, err := scrapperstdsql.ExplainRows(ctx, e.executor, "EXPLAIN ESTIMATE "+sql)
+	if err != nil {
+		return nil, err
+	}
+	return parseClickhouseEstimate(columns, rows)
+}
+
+// parseClickhouseEstimate sums the per-table `rows` column of an
+// `EXPLAIN ESTIMATE` result. Output columns are: database, table, parts, rows,
+// marks.
+func parseClickhouseEstimate(columns []string, rows [][]any) (*scrapper.QueryEstimate, error) {
+	rowsIdx := -1
+	for i, c := range columns {
+		if c == "rows" {
+			rowsIdx = i
+			break
+		}
+	}
+	if rowsIdx < 0 {
+		return nil, errors.Errorf("EXPLAIN ESTIMATE has no 'rows' column, got %v", columns)
+	}
+
+	var total int64
+	for _, r := range rows {
+		if rowsIdx >= len(r) {
+			continue
+		}
+		if n, ok := scrapperstdsql.CellInt64(r[rowsIdx]); ok {
+			total += n
+		}
+	}
+
+	return &scrapper.QueryEstimate{Rows: &total}, nil
+}

--- a/scrapper/clickhouse/query_estimate_test.go
+++ b/scrapper/clickhouse/query_estimate_test.go
@@ -1,0 +1,46 @@
+package clickhouse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseClickhouseEstimate(t *testing.T) {
+	columns := []string{"database", "table", "parts", "rows", "marks"}
+
+	t.Run("sums rows across parts", func(t *testing.T) {
+		// ClickHouse surfaces UInt64 columns as uint64 via the native driver.
+		rows := [][]any{
+			{"db", "t1", uint64(3), uint64(1000), uint64(4)},
+			{"db", "t2", uint64(1), uint64(250), uint64(1)},
+		}
+		est, err := parseClickhouseEstimate(columns, rows)
+		require.NoError(t, err)
+		require.NotNil(t, est.Rows)
+		assert.EqualValues(t, 1250, *est.Rows)
+		assert.Nil(t, est.BytesScanned)
+		assert.False(t, est.Exact)
+	})
+
+	t.Run("handles text-encoded numbers", func(t *testing.T) {
+		rows := [][]any{{"db", "t1", "2", []byte("500"), "3"}}
+		est, err := parseClickhouseEstimate(columns, rows)
+		require.NoError(t, err)
+		require.NotNil(t, est.Rows)
+		assert.EqualValues(t, 500, *est.Rows)
+	})
+
+	t.Run("empty estimate for constant select", func(t *testing.T) {
+		est, err := parseClickhouseEstimate(columns, nil)
+		require.NoError(t, err)
+		require.NotNil(t, est.Rows)
+		assert.EqualValues(t, 0, *est.Rows)
+	})
+
+	t.Run("errors when rows column absent", func(t *testing.T) {
+		_, err := parseClickhouseEstimate([]string{"database", "table"}, [][]any{{"db", "t"}})
+		assert.Error(t, err)
+	})
+}

--- a/scrapper/databricks/query_estimate.go
+++ b/scrapper/databricks/query_estimate.go
@@ -1,0 +1,16 @@
+package databricks
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+)
+
+// EstimateQuery is unsupported for now. Databricks/Spark EXPLAIN output is a
+// cost-based-optimizer plan whose byte/row estimates require CBO statistics
+// (ANALYZE TABLE ... COMPUTE STATISTICS) that are frequently absent, and the
+// plan text format is not stable enough to parse reliably. Returning
+// ErrUnsupported until a validation spike confirms a trustworthy estimate.
+func (e *DatabricksScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	return nil, scrapper.ErrUnsupported
+}

--- a/scrapper/duckdb/query_estimate.go
+++ b/scrapper/duckdb/query_estimate.go
@@ -1,0 +1,14 @@
+package duckdb
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+)
+
+// EstimateQuery is unsupported: DuckDB's EXPLAIN emits only planner cost and
+// cardinality estimates, with no bytes-scanned figure. (DuckDB is embedded and
+// local, so a pre-run scan estimate has little value anyway.)
+func (e *DuckDBScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	return nil, scrapper.ErrUnsupported
+}

--- a/scrapper/interface.go
+++ b/scrapper/interface.go
@@ -63,22 +63,27 @@ type Capabilities struct {
 	EstimateQuery EstimateQueryCapability
 }
 
-// EstimateQueryCapability advertises the granularity and reliability of a
-// dialect's EstimateQuery implementation. Granularity differs by engine: some
-// return bytes scanned (BigQuery, Snowflake), others only a planner row
-// estimate (ClickHouse, Postgres), and many cannot estimate reliably at all.
+// EstimateQueryCapability advertises what a dialect's EstimateQuery
+// implementation can do. It is a static description of the dialect, distinct
+// from the per-query QueryEstimate result: e.g. CanBeExact says a dialect is
+// capable of authoritative estimates, while QueryEstimate.Exact reports whether
+// a specific estimate actually was. Granularity differs by engine: some return
+// bytes scanned (BigQuery, Snowflake), others only a planner row estimate
+// (ClickHouse, Postgres), and many cannot estimate reliably at all.
 type EstimateQueryCapability struct {
 	// Supported is true when EstimateQuery may return a *QueryEstimate rather
 	// than ErrUnsupported.
 	Supported bool
-	// Bytes is true when the estimate can populate QueryEstimate.BytesScanned.
-	Bytes bool
-	// Rows is true when the estimate can populate QueryEstimate.Rows.
-	Rows bool
-	// Exact is true only when the estimate is authoritative rather than a
-	// planner guess (BigQuery dry-run). Planner-based estimates depend on fresh
-	// table statistics and can be off by orders of magnitude.
-	Exact bool
+	// ReportsBytes is true when the estimate can populate QueryEstimate.BytesScanned.
+	ReportsBytes bool
+	// ReportsRows is true when the estimate can populate QueryEstimate.Rows.
+	ReportsRows bool
+	// CanBeExact is true when the dialect is capable of authoritative estimates
+	// rather than planner guesses (BigQuery dry-run). Individual estimates may
+	// still come back with QueryEstimate.Exact=false (e.g. BigQuery non-PRECISE
+	// accuracy); planner-based dialects are never exact. Planner estimates
+	// depend on fresh table statistics and can be off by orders of magnitude.
+	CanBeExact bool
 }
 
 // QueryEstimate is a pre-execution estimate of what a SELECT will scan. It is
@@ -87,7 +92,10 @@ type EstimateQueryCapability struct {
 type QueryEstimate struct {
 	// BytesScanned is the estimated number of bytes the query would read/process.
 	BytesScanned *int64
-	// Rows is the estimated number of rows scanned/produced.
+	// Rows is a planner estimate of rows processed, intended as a scan-size
+	// proxy. Where the engine exposes a plan tree (Postgres) this is the
+	// largest per-node estimate — i.e. the heaviest scan — rather than the
+	// final result cardinality, which collapses to 1 for aggregates.
 	Rows *int64
 	// Exact is true only when authoritative rather than a planner estimate
 	// (BigQuery dry-run: TotalBytesProcessed, with TotalBytesProcessedAccuracy).

--- a/scrapper/interface.go
+++ b/scrapper/interface.go
@@ -56,6 +56,42 @@ type Capabilities struct {
 	// ConstraintsViaQueryTables indicates that QueryTables with WithConstraints()
 	// populates TableRow.Constraints, making a separate QueryTableConstraints call unnecessary.
 	ConstraintsViaQueryTables bool
+	// EstimateQuery describes EstimateQuery support for this dialect. Its zero
+	// value means EstimateQuery returns ErrUnsupported. Callers should consult
+	// this before calling EstimateQuery so they can pick an appropriate UI
+	// ("this will scan ~X bytes" vs "~Y rows") or skip the call entirely.
+	EstimateQuery EstimateQueryCapability
+}
+
+// EstimateQueryCapability advertises the granularity and reliability of a
+// dialect's EstimateQuery implementation. Granularity differs by engine: some
+// return bytes scanned (BigQuery, Snowflake), others only a planner row
+// estimate (ClickHouse, Postgres), and many cannot estimate reliably at all.
+type EstimateQueryCapability struct {
+	// Supported is true when EstimateQuery may return a *QueryEstimate rather
+	// than ErrUnsupported.
+	Supported bool
+	// Bytes is true when the estimate can populate QueryEstimate.BytesScanned.
+	Bytes bool
+	// Rows is true when the estimate can populate QueryEstimate.Rows.
+	Rows bool
+	// Exact is true only when the estimate is authoritative rather than a
+	// planner guess (BigQuery dry-run). Planner-based estimates depend on fresh
+	// table statistics and can be off by orders of magnitude.
+	Exact bool
+}
+
+// QueryEstimate is a pre-execution estimate of what a SELECT will scan. It is
+// produced from engine metadata (dry-run / EXPLAIN) — the query itself is never
+// executed. Nil fields mean the engine could not estimate that dimension.
+type QueryEstimate struct {
+	// BytesScanned is the estimated number of bytes the query would read/process.
+	BytesScanned *int64
+	// Rows is the estimated number of rows scanned/produced.
+	Rows *int64
+	// Exact is true only when authoritative rather than a planner estimate
+	// (BigQuery dry-run: TotalBytesProcessed, with TotalBytesProcessedAccuracy).
+	Exact bool
 }
 
 // Unwrapper is implemented by Scrapper decorators (sanitize, reject, scope, ...)
@@ -114,6 +150,12 @@ type Scrapper interface {
 	// The caller must Close() the iterator. Callers that want a row cap
 	// should stop iteration after N calls to Next().
 	RunRawQuery(ctx context.Context, sql string) (RawQueryRowIterator, error)
+	// EstimateQuery returns a pre-execution scan estimate for an arbitrary
+	// SELECT, or ErrUnsupported when the dialect cannot estimate reliably.
+	// It must obtain the estimate from engine metadata (dry-run / EXPLAIN) and
+	// MUST NOT execute the query. Consult Capabilities().EstimateQuery to learn
+	// which dimensions (bytes vs rows) a given dialect can populate.
+	EstimateQuery(ctx context.Context, sql string) (*QueryEstimate, error)
 	QueryTableConstraints(ctx context.Context) ([]*TableConstraintRow, error)
 	// This will close underlying execer, such scrapper can't be used anymore
 	Close() error

--- a/scrapper/mocks.go
+++ b/scrapper/mocks.go
@@ -156,6 +156,45 @@ func (c *MockScrapperDialectTypeCall) DoAndReturn(f func() string) *MockScrapper
 	return c
 }
 
+// EstimateQuery mocks base method.
+func (m *MockScrapper) EstimateQuery(ctx context.Context, sql string) (*QueryEstimate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EstimateQuery", ctx, sql)
+	ret0, _ := ret[0].(*QueryEstimate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EstimateQuery indicates an expected call of EstimateQuery.
+func (mr *MockScrapperMockRecorder) EstimateQuery(ctx, sql any) *MockScrapperEstimateQueryCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateQuery", reflect.TypeOf((*MockScrapper)(nil).EstimateQuery), ctx, sql)
+	return &MockScrapperEstimateQueryCall{Call: call}
+}
+
+// MockScrapperEstimateQueryCall wrap *gomock.Call
+type MockScrapperEstimateQueryCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockScrapperEstimateQueryCall) Return(arg0 *QueryEstimate, arg1 error) *MockScrapperEstimateQueryCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockScrapperEstimateQueryCall) Do(f func(context.Context, string) (*QueryEstimate, error)) *MockScrapperEstimateQueryCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockScrapperEstimateQueryCall) DoAndReturn(f func(context.Context, string) (*QueryEstimate, error)) *MockScrapperEstimateQueryCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // IsPermissionError mocks base method.
 func (m *MockScrapper) IsPermissionError(err error) bool {
 	m.ctrl.T.Helper()

--- a/scrapper/mssql/query_estimate.go
+++ b/scrapper/mssql/query_estimate.go
@@ -1,0 +1,16 @@
+package mssql
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+)
+
+// EstimateQuery is unsupported for now. SQL Server's estimated plan comes from
+// `SET SHOWPLAN_XML ON`, a session-mode toggle that returns the plan as an XML
+// document rather than a queryable estimate, and the EstimateRows/
+// EstimatedDataSize attributes depend on current statistics. Returning
+// ErrUnsupported until a validation spike confirms a reliable parse.
+func (e *MSSQLScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	return nil, scrapper.ErrUnsupported
+}

--- a/scrapper/mysql/query_estimate.go
+++ b/scrapper/mysql/query_estimate.go
@@ -1,0 +1,16 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+)
+
+// EstimateQuery is unsupported for now. MySQL's `EXPLAIN FORMAT=JSON` exposes
+// per-table planner estimates (rows_examined_per_scan / rows_produced_per_join)
+// but no single authoritative row or byte total, and the JSON shape differs
+// between MySQL and MariaDB. Returning ErrUnsupported until a validation spike
+// settles a reliable aggregation across both.
+func (e *MySQLScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	return nil, scrapper.ErrUnsupported
+}

--- a/scrapper/oracle/query_estimate.go
+++ b/scrapper/oracle/query_estimate.go
@@ -1,0 +1,16 @@
+package oracle
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+)
+
+// EstimateQuery is unsupported for now. Oracle has no single-statement EXPLAIN
+// that returns an estimate as a result set: `EXPLAIN PLAN FOR` writes to
+// PLAN_TABLE and requires a follow-up read, and the Cardinality/Bytes columns
+// depend on gathered optimizer statistics. Returning ErrUnsupported until a
+// validation spike confirms a trustworthy, side-effect-free path.
+func (e *OracleScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	return nil, scrapper.ErrUnsupported
+}

--- a/scrapper/postgres/postgres.go
+++ b/scrapper/postgres/postgres.go
@@ -42,7 +42,7 @@ func (e *PostgresScrapper) IsPermissionError(err error) bool {
 
 func (e *PostgresScrapper) Capabilities() scrapper.Capabilities {
 	return scrapper.Capabilities{
-		EstimateQuery: scrapper.EstimateQueryCapability{Supported: true, Rows: true},
+		EstimateQuery: scrapper.EstimateQueryCapability{Supported: true, ReportsRows: true},
 	}
 }
 

--- a/scrapper/postgres/postgres.go
+++ b/scrapper/postgres/postgres.go
@@ -40,7 +40,11 @@ func (e *PostgresScrapper) IsPermissionError(err error) bool {
 	return dwhexecpostgres.IsPermissionError(err)
 }
 
-func (e *PostgresScrapper) Capabilities() scrapper.Capabilities { return scrapper.Capabilities{} }
+func (e *PostgresScrapper) Capabilities() scrapper.Capabilities {
+	return scrapper.Capabilities{
+		EstimateQuery: scrapper.EstimateQueryCapability{Supported: true, Rows: true},
+	}
+}
 
 func (e *PostgresScrapper) DialectType() string {
 	return "postgres"

--- a/scrapper/postgres/query_estimate.go
+++ b/scrapper/postgres/query_estimate.go
@@ -1,0 +1,50 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+	"github.com/pkg/errors"
+)
+
+// EstimateQuery returns a row estimate via `EXPLAIN (FORMAT JSON)`, which plans
+// the query without executing it (no ANALYZE). Postgres reports a planner row
+// estimate but no scan-bytes figure, so only Rows is populated. The estimate is
+// only as good as the table's last ANALYZE and can be off by orders of
+// magnitude on stale statistics.
+func (e *PostgresScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	_, rows, err := scrapperstdsql.ExplainRows(ctx, e.executor, "EXPLAIN (FORMAT JSON) "+sql)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 || len(rows[0]) == 0 {
+		return nil, errors.New("EXPLAIN (FORMAT JSON) returned no rows")
+	}
+	jsonText, ok := scrapperstdsql.CellString(rows[0][0])
+	if !ok {
+		return nil, errors.New("EXPLAIN (FORMAT JSON) returned a null plan")
+	}
+	return parsePostgresEstimate(jsonText)
+}
+
+// pgExplainNode mirrors the top-level plan node of `EXPLAIN (FORMAT JSON)`.
+// "Plan Rows" is the estimated number of rows the top node emits.
+type pgExplainNode struct {
+	Plan struct {
+		PlanRows float64 `json:"Plan Rows"`
+	} `json:"Plan"`
+}
+
+func parsePostgresEstimate(jsonText string) (*scrapper.QueryEstimate, error) {
+	var nodes []pgExplainNode
+	if err := json.Unmarshal([]byte(jsonText), &nodes); err != nil {
+		return nil, errors.Wrap(err, "parsing EXPLAIN (FORMAT JSON) output")
+	}
+	if len(nodes) == 0 {
+		return nil, errors.New("EXPLAIN (FORMAT JSON) output had no plan")
+	}
+	rows := int64(nodes[0].Plan.PlanRows)
+	return &scrapper.QueryEstimate{Rows: &rows}, nil
+}

--- a/scrapper/postgres/query_estimate.go
+++ b/scrapper/postgres/query_estimate.go
@@ -14,6 +14,11 @@ import (
 // estimate but no scan-bytes figure, so only Rows is populated. The estimate is
 // only as good as the table's last ANALYZE and can be off by orders of
 // magnitude on stale statistics.
+//
+// Rows is the largest per-node "Plan Rows" across the whole plan tree, not the
+// top node's output. The top node emits post-aggregation cardinality — 1 for
+// `SELECT count(*) FROM big_table` — which is useless as a scan-size warning;
+// the deepest scan node carries the figure a caller actually wants to warn on.
 func (e *PostgresScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
 	_, rows, err := scrapperstdsql.ExplainRows(ctx, e.executor, "EXPLAIN (FORMAT JSON) "+sql)
 	if err != nil {
@@ -29,22 +34,39 @@ func (e *PostgresScrapper) EstimateQuery(ctx context.Context, sql string) (*scra
 	return parsePostgresEstimate(jsonText)
 }
 
-// pgExplainNode mirrors the top-level plan node of `EXPLAIN (FORMAT JSON)`.
-// "Plan Rows" is the estimated number of rows the top node emits.
-type pgExplainNode struct {
-	Plan struct {
-		PlanRows float64 `json:"Plan Rows"`
-	} `json:"Plan"`
+// pgExplainRoot mirrors one element of the `EXPLAIN (FORMAT JSON)` array.
+type pgExplainRoot struct {
+	Plan pgPlanNode `json:"Plan"`
+}
+
+// pgPlanNode is a plan node; "Plan Rows" is the estimated rows the node emits
+// (post-filter, post-aggregation) and "Plans" holds its children.
+type pgPlanNode struct {
+	PlanRows float64      `json:"Plan Rows"`
+	Plans    []pgPlanNode `json:"Plans"`
 }
 
 func parsePostgresEstimate(jsonText string) (*scrapper.QueryEstimate, error) {
-	var nodes []pgExplainNode
-	if err := json.Unmarshal([]byte(jsonText), &nodes); err != nil {
+	var roots []pgExplainRoot
+	if err := json.Unmarshal([]byte(jsonText), &roots); err != nil {
 		return nil, errors.Wrap(err, "parsing EXPLAIN (FORMAT JSON) output")
 	}
-	if len(nodes) == 0 {
+	if len(roots) == 0 {
 		return nil, errors.New("EXPLAIN (FORMAT JSON) output had no plan")
 	}
-	rows := int64(nodes[0].Plan.PlanRows)
+	rows := int64(maxPlanRows(roots[0].Plan))
 	return &scrapper.QueryEstimate{Rows: &rows}, nil
+}
+
+// maxPlanRows returns the largest "Plan Rows" in the subtree rooted at n. The
+// deepest scan node's estimate is a better scan-size proxy than the top node's
+// output cardinality, which collapses to 1 for aggregates.
+func maxPlanRows(n pgPlanNode) float64 {
+	max := n.PlanRows
+	for _, child := range n.Plans {
+		if m := maxPlanRows(child); m > max {
+			max = m
+		}
+	}
+	return max
 }

--- a/scrapper/postgres/query_estimate_test.go
+++ b/scrapper/postgres/query_estimate_test.go
@@ -1,0 +1,48 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePostgresEstimate(t *testing.T) {
+	t.Run("reads top-level Plan Rows", func(t *testing.T) {
+		// Representative `EXPLAIN (FORMAT JSON) SELECT ...` output.
+		jsonText := `[
+		  {
+		    "Plan": {
+		      "Node Type": "Seq Scan",
+		      "Relation Name": "orders",
+		      "Plan Rows": 12345,
+		      "Plan Width": 64
+		    }
+		  }
+		]`
+		est, err := parsePostgresEstimate(jsonText)
+		require.NoError(t, err)
+		require.NotNil(t, est.Rows)
+		assert.EqualValues(t, 12345, *est.Rows)
+		assert.Nil(t, est.BytesScanned)
+		assert.False(t, est.Exact)
+	})
+
+	t.Run("nested plan uses top node estimate", func(t *testing.T) {
+		jsonText := `[{"Plan":{"Node Type":"Aggregate","Plan Rows":1,"Plan Width":8,"Plans":[{"Node Type":"Seq Scan","Plan Rows":1000000,"Plan Width":4}]}}]`
+		est, err := parsePostgresEstimate(jsonText)
+		require.NoError(t, err)
+		require.NotNil(t, est.Rows)
+		assert.EqualValues(t, 1, *est.Rows)
+	})
+
+	t.Run("errors on malformed json", func(t *testing.T) {
+		_, err := parsePostgresEstimate("not json")
+		assert.Error(t, err)
+	})
+
+	t.Run("errors on empty array", func(t *testing.T) {
+		_, err := parsePostgresEstimate("[]")
+		assert.Error(t, err)
+	})
+}

--- a/scrapper/postgres/query_estimate_test.go
+++ b/scrapper/postgres/query_estimate_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestParsePostgresEstimate(t *testing.T) {
-	t.Run("reads top-level Plan Rows", func(t *testing.T) {
+	t.Run("single scan node", func(t *testing.T) {
 		// Representative `EXPLAIN (FORMAT JSON) SELECT ...` output.
 		jsonText := `[
 		  {
@@ -28,12 +28,14 @@ func TestParsePostgresEstimate(t *testing.T) {
 		assert.False(t, est.Exact)
 	})
 
-	t.Run("nested plan uses top node estimate", func(t *testing.T) {
+	t.Run("aggregate uses deepest scan estimate, not top output", func(t *testing.T) {
+		// SELECT count(*) FROM big_table: top Aggregate emits 1 row while the
+		// underlying Seq Scan reads 1,000,000 — the scan figure is what matters.
 		jsonText := `[{"Plan":{"Node Type":"Aggregate","Plan Rows":1,"Plan Width":8,"Plans":[{"Node Type":"Seq Scan","Plan Rows":1000000,"Plan Width":4}]}}]`
 		est, err := parsePostgresEstimate(jsonText)
 		require.NoError(t, err)
 		require.NotNil(t, est.Rows)
-		assert.EqualValues(t, 1, *est.Rows)
+		assert.EqualValues(t, 1000000, *est.Rows)
 	})
 
 	t.Run("errors on malformed json", func(t *testing.T) {

--- a/scrapper/redshift/query_estimate.go
+++ b/scrapper/redshift/query_estimate.go
@@ -1,0 +1,14 @@
+package redshift
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+)
+
+// EstimateQuery is unsupported: Redshift's EXPLAIN reports only abstract planner
+// cost units and cardinality, with no bytes-scanned figure to translate into a
+// scan/cost estimate.
+func (e *RedshiftScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	return nil, scrapper.ErrUnsupported
+}

--- a/scrapper/reject/rejecting_scrapper.go
+++ b/scrapper/reject/rejecting_scrapper.go
@@ -161,6 +161,12 @@ func (s *RejectingScrapper) RunRawQuery(ctx context.Context, sql string) (scrapp
 	return s.inner.RunRawQuery(ctx, sql)
 }
 
+// EstimateQuery returns a numeric estimate with no identity fields, so there is
+// nothing to reject — pass through.
+func (s *RejectingScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	return s.inner.EstimateQuery(ctx, sql)
+}
+
 func (s *RejectingScrapper) QueryTableConstraints(ctx context.Context) ([]*scrapper.TableConstraintRow, error) {
 	rows, err := s.inner.QueryTableConstraints(ctx)
 	if err != nil {

--- a/scrapper/reject/rejecting_scrapper_test.go
+++ b/scrapper/reject/rejecting_scrapper_test.go
@@ -72,6 +72,9 @@ func (s *stubScrapper) QueryShape(context.Context, string) ([]*scrapper.QuerySha
 func (s *stubScrapper) RunRawQuery(context.Context, string) (scrapper.RawQueryRowIterator, error) {
 	return nil, nil
 }
+func (s *stubScrapper) EstimateQuery(context.Context, string) (*scrapper.QueryEstimate, error) {
+	return nil, nil
+}
 
 func (s *stubScrapper) QueryTableConstraints(context.Context) ([]*scrapper.TableConstraintRow, error) {
 	return s.constraints, nil

--- a/scrapper/sanitize/sanitizing_scrapper.go
+++ b/scrapper/sanitize/sanitizing_scrapper.go
@@ -152,6 +152,12 @@ func (s *SanitizingScrapper) RunRawQuery(ctx context.Context, sql string) (scrap
 	return &sanitizingRawQueryRows{inner: iter}, nil
 }
 
+// EstimateQuery returns a numeric estimate with no string fields, so there is
+// nothing to sanitize — pass through.
+func (s *SanitizingScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	return s.inner.EstimateQuery(ctx, sql)
+}
+
 type sanitizingRawQueryRows struct {
 	inner scrapper.RawQueryRowIterator
 }

--- a/scrapper/sanitize/sanitizing_scrapper_test.go
+++ b/scrapper/sanitize/sanitizing_scrapper_test.go
@@ -74,6 +74,9 @@ func (s *stubScrapper) QueryShape(context.Context, string) ([]*scrapper.QuerySha
 func (s *stubScrapper) RunRawQuery(context.Context, string) (scrapper.RawQueryRowIterator, error) {
 	return nil, nil
 }
+func (s *stubScrapper) EstimateQuery(context.Context, string) (*scrapper.QueryEstimate, error) {
+	return nil, nil
+}
 
 func (s *stubScrapper) QueryTableConstraints(context.Context) ([]*scrapper.TableConstraintRow, error) {
 	return s.constraints, nil

--- a/scrapper/scope/scoped_scrapper.go
+++ b/scrapper/scope/scoped_scrapper.go
@@ -71,6 +71,10 @@ func (s *ScopedScrapper) RunRawQuery(ctx context.Context, sql string) (scrapper.
 	return s.inner.RunRawQuery(ctx, sql)
 }
 
+func (s *ScopedScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	return s.inner.EstimateQuery(ctx, sql)
+}
+
 // Scrapper interface — filtered methods.
 // These inject the base scope into the context (enabling SQL push-down in the inner scrapper)
 // and post-filter returned rows to guarantee scope compliance even when the inner scrapper

--- a/scrapper/scope/scoped_scrapper_test.go
+++ b/scrapper/scope/scoped_scrapper_test.go
@@ -71,6 +71,9 @@ func (m *mockScrapper) QueryShape(context.Context, string) ([]*scrapper.QuerySha
 func (m *mockScrapper) RunRawQuery(context.Context, string) (scrapper.RawQueryRowIterator, error) {
 	return nil, nil
 }
+func (m *mockScrapper) EstimateQuery(context.Context, string) (*scrapper.QueryEstimate, error) {
+	return nil, nil
+}
 
 func (m *mockScrapper) QueryTableConstraints(context.Context) ([]*scrapper.TableConstraintRow, error) {
 	return m.constraintRows, nil

--- a/scrapper/scrappertest/compliance.go
+++ b/scrapper/scrappertest/compliance.go
@@ -273,13 +273,20 @@ func (s *ComplianceSuite) TestCompliance_MethodsDoNotError() {
 		s.NotNil(estimate, "EstimateQuery returned nil estimate without an error")
 		if estimate != nil {
 			// Advertised granularity must line up with what came back.
-			if !caps.Bytes {
-				s.Nil(estimate.BytesScanned, "EstimateQuery returned bytes but Capabilities.EstimateQuery.Bytes is false")
+			if !caps.ReportsBytes {
+				s.Nil(estimate.BytesScanned, "EstimateQuery returned bytes but Capabilities.EstimateQuery.ReportsBytes is false")
 			}
-			if !caps.Rows {
-				s.Nil(estimate.Rows, "EstimateQuery returned rows but Capabilities.EstimateQuery.Rows is false")
+			if !caps.ReportsRows {
+				s.Nil(estimate.Rows, "EstimateQuery returned rows but Capabilities.EstimateQuery.ReportsRows is false")
 			}
-			s.Equal(caps.Exact, estimate.Exact, "QueryEstimate.Exact must match Capabilities.EstimateQuery.Exact")
+			// CanBeExact statically advertises that a dialect *can* be
+			// authoritative; estimate.Exact is the per-query result and may be
+			// downgraded (e.g. BigQuery non-PRECISE accuracy). Only the negative
+			// direction is an invariant: a dialect that can never be exact must
+			// never return an exact estimate.
+			if !caps.CanBeExact {
+				s.False(estimate.Exact, "dialect advertises no exact estimates but EstimateQuery returned Exact=true")
+			}
 		}
 	} else if errors.Is(err, scrapper.ErrUnsupported) {
 		s.False(caps.Supported, "Capabilities advertises EstimateQuery support but it returned ErrUnsupported")

--- a/scrapper/scrappertest/compliance.go
+++ b/scrapper/scrappertest/compliance.go
@@ -261,6 +261,30 @@ func (s *ComplianceSuite) TestCompliance_MethodsDoNotError() {
 		}
 	}
 
+	// --- EstimateQuery ---
+	// SELECT 1 is valid and plannable on every dialect; the estimate may be
+	// zero bytes/rows but must never execute a real scan.
+	estimate, err := s.Scrapper.EstimateQuery(ctx, "SELECT 1")
+	if !s.True(isAcceptableError(err), "EstimateQuery error: %v", err) {
+		s.T().FailNow()
+	}
+	caps := s.Scrapper.Capabilities().EstimateQuery
+	if err == nil {
+		s.NotNil(estimate, "EstimateQuery returned nil estimate without an error")
+		if estimate != nil {
+			// Advertised granularity must line up with what came back.
+			if !caps.Bytes {
+				s.Nil(estimate.BytesScanned, "EstimateQuery returned bytes but Capabilities.EstimateQuery.Bytes is false")
+			}
+			if !caps.Rows {
+				s.Nil(estimate.Rows, "EstimateQuery returned rows but Capabilities.EstimateQuery.Rows is false")
+			}
+			s.Equal(caps.Exact, estimate.Exact, "QueryEstimate.Exact must match Capabilities.EstimateQuery.Exact")
+		}
+	} else if errors.Is(err, scrapper.ErrUnsupported) {
+		s.False(caps.Supported, "Capabilities advertises EstimateQuery support but it returned ErrUnsupported")
+	}
+
 	// --- Cross-method consistency: all non-empty Instance values must be equal ---
 	if len(allInstances) > 1 {
 		first := allInstances[0]

--- a/scrapper/snowflake/query_estimate.go
+++ b/scrapper/snowflake/query_estimate.go
@@ -1,0 +1,48 @@
+package snowflake
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	scrapperstdsql "github.com/getsynq/dwhsupport/scrapper/stdsql"
+	"github.com/pkg/errors"
+)
+
+// EstimateQuery returns a bytes estimate via `EXPLAIN USING JSON`, which
+// compiles the query and reports the partitions/bytes the optimizer expects to
+// scan without executing it. The GlobalStats.bytesAssigned figure is a
+// planner estimate derived from micro-partition metadata, not an authoritative
+// scan count, so Exact stays false. Row counts are not reported.
+func (e *SnowflakeScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	_, rows, err := scrapperstdsql.ExplainRows(ctx, e.executor, "EXPLAIN USING JSON "+sql)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 || len(rows[0]) == 0 {
+		return nil, errors.New("EXPLAIN USING JSON returned no rows")
+	}
+	jsonText, ok := scrapperstdsql.CellString(rows[0][0])
+	if !ok {
+		return nil, errors.New("EXPLAIN USING JSON returned a null plan")
+	}
+	return parseSnowflakeEstimate(jsonText)
+}
+
+// sfExplainPlan mirrors the JSON document returned by `EXPLAIN USING JSON`. Only
+// GlobalStats.bytesAssigned is needed: it is the total bytes the optimizer
+// assigned across all scanned micro-partitions.
+type sfExplainPlan struct {
+	GlobalStats struct {
+		BytesAssigned int64 `json:"bytesAssigned"`
+	} `json:"GlobalStats"`
+}
+
+func parseSnowflakeEstimate(jsonText string) (*scrapper.QueryEstimate, error) {
+	var plan sfExplainPlan
+	if err := json.Unmarshal([]byte(jsonText), &plan); err != nil {
+		return nil, errors.Wrap(err, "parsing EXPLAIN USING JSON output")
+	}
+	bytes := plan.GlobalStats.BytesAssigned
+	return &scrapper.QueryEstimate{BytesScanned: &bytes}, nil
+}

--- a/scrapper/snowflake/query_estimate_test.go
+++ b/scrapper/snowflake/query_estimate_test.go
@@ -1,0 +1,41 @@
+package snowflake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSnowflakeEstimate(t *testing.T) {
+	t.Run("reads GlobalStats.bytesAssigned", func(t *testing.T) {
+		// Representative `EXPLAIN USING JSON SELECT ...` output.
+		jsonText := `{
+		  "GlobalStats": {
+		    "partitionsTotal": 10,
+		    "partitionsAssigned": 4,
+		    "bytesAssigned": 8388608
+		  },
+		  "Operations": [[{"id":0,"operation":"TableScan"}]]
+		}`
+		est, err := parseSnowflakeEstimate(jsonText)
+		require.NoError(t, err)
+		require.NotNil(t, est.BytesScanned)
+		assert.EqualValues(t, 8388608, *est.BytesScanned)
+		assert.Nil(t, est.Rows)
+		assert.False(t, est.Exact)
+	})
+
+	t.Run("zero bytes for constant select", func(t *testing.T) {
+		jsonText := `{"GlobalStats":{"partitionsTotal":0,"partitionsAssigned":0,"bytesAssigned":0}}`
+		est, err := parseSnowflakeEstimate(jsonText)
+		require.NoError(t, err)
+		require.NotNil(t, est.BytesScanned)
+		assert.EqualValues(t, 0, *est.BytesScanned)
+	})
+
+	t.Run("errors on malformed json", func(t *testing.T) {
+		_, err := parseSnowflakeEstimate("<xml/>")
+		assert.Error(t, err)
+	})
+}

--- a/scrapper/snowflake/snowflake.go
+++ b/scrapper/snowflake/snowflake.go
@@ -118,7 +118,11 @@ func IsPermissionError(err error) bool {
 	return dwhexecsnowflake.IsPermissionError(err)
 }
 
-func (e *SnowflakeScrapper) Capabilities() scrapper.Capabilities { return scrapper.Capabilities{} }
+func (e *SnowflakeScrapper) Capabilities() scrapper.Capabilities {
+	return scrapper.Capabilities{
+		EstimateQuery: scrapper.EstimateQueryCapability{Supported: true, Bytes: true},
+	}
+}
 
 func (e *SnowflakeScrapper) DialectType() string {
 	return "snowflake"

--- a/scrapper/snowflake/snowflake.go
+++ b/scrapper/snowflake/snowflake.go
@@ -120,7 +120,7 @@ func IsPermissionError(err error) bool {
 
 func (e *SnowflakeScrapper) Capabilities() scrapper.Capabilities {
 	return scrapper.Capabilities{
-		EstimateQuery: scrapper.EstimateQueryCapability{Supported: true, Bytes: true},
+		EstimateQuery: scrapper.EstimateQueryCapability{Supported: true, ReportsBytes: true},
 	}
 }
 

--- a/scrapper/stdsql/explain.go
+++ b/scrapper/stdsql/explain.go
@@ -1,0 +1,101 @@
+package stdsql
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/getsynq/dwhsupport/exec/querystats"
+)
+
+// ExplainRows runs an EXPLAIN-style statement and returns the result column
+// names plus every row as a slice of raw driver values. It is the shared
+// plumbing behind the per-dialect EstimateQuery implementations that read an
+// EXPLAIN result set.
+//
+// The caller is responsible for passing a statement that only plans the query
+// (EXPLAIN / EXPLAIN ESTIMATE / EXPLAIN USING JSON) and never one that executes
+// it (no EXPLAIN ANALYZE) — EstimateQuery must not run the user's query.
+func ExplainRows(ctx context.Context, db RowQuerier, sql string) (columns []string, rows [][]any, err error) {
+	collector, ctx := querystats.Start(ctx)
+	defer collector.Finish()
+
+	sqlRows, err := db.QueryRows(ctx, sql)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer sqlRows.Close()
+
+	columns, err = sqlRows.Columns()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for sqlRows.Next() {
+		cells, err := sqlRows.SliceScan()
+		if err != nil {
+			return nil, nil, err
+		}
+		rows = append(rows, cells)
+	}
+	if err := sqlRows.Err(); err != nil {
+		return nil, nil, err
+	}
+	return columns, rows, nil
+}
+
+// CellString renders a raw driver cell (string, []byte, fmt.Stringer, ...) as a
+// string. Used to pull JSON text out of a single EXPLAIN result cell.
+func CellString(v any) (string, bool) {
+	switch val := v.(type) {
+	case nil:
+		return "", false
+	case string:
+		return val, true
+	case []byte:
+		return string(val), true
+	case fmt.Stringer:
+		return val.String(), true
+	default:
+		return fmt.Sprint(v), true
+	}
+}
+
+// CellInt64 coerces a raw driver cell to int64, handling the signed/unsigned/
+// float/text shapes different drivers use for EXPLAIN numeric columns.
+func CellInt64(v any) (int64, bool) {
+	switch val := v.(type) {
+	case int64:
+		return val, true
+	case int32:
+		return int64(val), true
+	case int:
+		return int64(val), true
+	case uint64:
+		return int64(val), true
+	case uint32:
+		return int64(val), true
+	case uint:
+		return int64(val), true
+	case float64:
+		return int64(val), true
+	case float32:
+		return int64(val), true
+	case []byte:
+		return parseInt64(string(val))
+	case string:
+		return parseInt64(val)
+	default:
+		return 0, false
+	}
+}
+
+func parseInt64(s string) (int64, bool) {
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return n, true
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return int64(f), true
+	}
+	return 0, false
+}

--- a/scrapper/stdsql/explain_test.go
+++ b/scrapper/stdsql/explain_test.go
@@ -1,0 +1,48 @@
+package stdsql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCellInt64(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want int64
+		ok   bool
+	}{
+		{"int64", int64(42), 42, true},
+		{"uint64", uint64(42), 42, true},
+		{"int", 42, 42, true},
+		{"float64", float64(42.9), 42, true},
+		{"string int", "1000", 1000, true},
+		{"string float", "1000.5", 1000, true},
+		{"bytes", []byte("250"), 250, true},
+		{"nil", nil, 0, false},
+		{"non-numeric string", "abc", 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := CellInt64(c.in)
+			assert.Equal(t, c.ok, ok)
+			if c.ok {
+				assert.Equal(t, c.want, got)
+			}
+		})
+	}
+}
+
+func TestCellString(t *testing.T) {
+	got, ok := CellString([]byte(`{"a":1}`))
+	assert.True(t, ok)
+	assert.Equal(t, `{"a":1}`, got)
+
+	got, ok = CellString("plain")
+	assert.True(t, ok)
+	assert.Equal(t, "plain", got)
+
+	_, ok = CellString(nil)
+	assert.False(t, ok)
+}

--- a/scrapper/trino/query_estimate.go
+++ b/scrapper/trino/query_estimate.go
@@ -1,0 +1,17 @@
+package trino
+
+import (
+	"context"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+)
+
+// EstimateQuery is unsupported for now. Trino's `EXPLAIN (TYPE IO)` /
+// `EXPLAIN (TYPE DISTRIBUTED)` can surface an estimate, but whether a reliable
+// pre-run bytes figure is available depends heavily on the backing connector's
+// statistics (Hive/Iceberg with fresh stats vs none), and it has not been
+// validated against our pinned driver and typical connectors. Returning
+// ErrUnsupported until a validation spike confirms a trustworthy estimate.
+func (e *TrinoScrapper) EstimateQuery(ctx context.Context, sql string) (*scrapper.QueryEstimate, error) {
+	return nil, scrapper.ErrUnsupported
+}

--- a/scrapper/unwrap_test.go
+++ b/scrapper/unwrap_test.go
@@ -52,6 +52,9 @@ func (stubLeaf) QueryShape(context.Context, string) ([]*scrapper.QueryShapeColum
 func (stubLeaf) RunRawQuery(context.Context, string) (scrapper.RawQueryRowIterator, error) {
 	return nil, nil
 }
+func (stubLeaf) EstimateQuery(context.Context, string) (*scrapper.QueryEstimate, error) {
+	return nil, nil
+}
 func (stubLeaf) QueryTableConstraints(context.Context) ([]*scrapper.TableConstraintRow, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

Spun out of QUA-70. Adds a **pre-execution scan-estimate** method to the `Scrapper` interface so consumers (synq-recon preflight, FE reconciliation setup) can warn "this query will scan ~X bytes / ~Y rows" before running arbitrary `query:` SQL. Estimates are obtained from **dry-run / EXPLAIN metadata only — the user's query is never executed**.

## API

```go
type QueryEstimate struct {
    BytesScanned *int64
    Rows         *int64
    Exact        bool // authoritative (BigQuery dry-run) vs planner guess
}
EstimateQuery(ctx, sql) (*QueryEstimate, error) // or ErrUnsupported
```

`Capabilities.EstimateQuery` advertises granularity (bytes vs rows) and whether the estimate is authoritative, so callers can pick the right UI or skip the call.

## Per-engine matrix shipped

| Engine | Mechanism | Captures | Notes |
| -- | -- | -- | -- |
| BigQuery | `DryRun=true` → `TotalBytesProcessed` | bytes | authoritative, `Exact=true` |
| ClickHouse | `EXPLAIN ESTIMATE` | rows | planner-based |
| Postgres | `EXPLAIN (FORMAT JSON)` | rows | planner-based |
| Snowflake | `EXPLAIN USING JSON` → `GlobalStats.bytesAssigned` | bytes | planner-based |
| Redshift, DuckDB | — | — | `ErrUnsupported` (no bytes) |
| Trino, Athena, Databricks | — | — | `ErrUnsupported` (pre-run bytes unconfirmed — needs a validation spike against live warehouses/connectors) |
| MySQL, Oracle, MSSQL | — | — | `ErrUnsupported` (no single authoritative figure / side-effect-free path — needs a validation spike) |

Rationale for each `ErrUnsupported` engine is documented in its `query_estimate.go`. Only BigQuery is code-verified end-to-end; the four EXPLAIN parsers are unit-tested against representative output and should be confirmed against staging via the compliance suite before consumers rely on the non-BigQuery numbers.

## Fan-out

Shared `stdsql.ExplainRows`/`CellInt64`/`CellString` helper for the EXPLAIN path; wired through the scope/reject/sanitize/pool decorators, regenerated mocks, updated test stubs, and added an `EstimateQuery` check to the compliance suite. Unit tests cover each parser.

https://claude.ai/code/session_017Z9n4aBDRyEGsmSjDrztrF