### PR TITLE
dwhsupport: wire Fabric into connect + yaml config

### DIFF
--- a/connect/connect.go
+++ b/connect/connect.go
@@ -9,6 +9,7 @@ import (
 	dwhexecbigquery "github.com/getsynq/dwhsupport/exec/bigquery"
 	dwhexecclickhouse "github.com/getsynq/dwhsupport/exec/clickhouse"
 	dwhexecdatabricks "github.com/getsynq/dwhsupport/exec/databricks"
+	dwhexecfabric "github.com/getsynq/dwhsupport/exec/fabric"
 	dwhexecmssql "github.com/getsynq/dwhsupport/exec/mssql"
 	dwhexecmysql "github.com/getsynq/dwhsupport/exec/mysql"
 	dwhexecoracle "github.com/getsynq/dwhsupport/exec/oracle"
@@ -21,14 +22,15 @@ import (
 	scrapperbigquery "github.com/getsynq/dwhsupport/scrapper/bigquery"
 	scrapperclickhouse "github.com/getsynq/dwhsupport/scrapper/clickhouse"
 	scrapperdatabricks "github.com/getsynq/dwhsupport/scrapper/databricks"
+	scrapperfabric "github.com/getsynq/dwhsupport/scrapper/fabric"
 	scrappermssql "github.com/getsynq/dwhsupport/scrapper/mssql"
 	scrappermysql "github.com/getsynq/dwhsupport/scrapper/mysql"
 	scrapperoracle "github.com/getsynq/dwhsupport/scrapper/oracle"
 	scrapperpostgres "github.com/getsynq/dwhsupport/scrapper/postgres"
 	scrapperredshift "github.com/getsynq/dwhsupport/scrapper/redshift"
+	"github.com/getsynq/dwhsupport/scrapper/scope"
 	scrappersnowflake "github.com/getsynq/dwhsupport/scrapper/snowflake"
 	scrappertrino "github.com/getsynq/dwhsupport/scrapper/trino"
-	"github.com/getsynq/dwhsupport/scrapper/scope"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 )
@@ -173,6 +175,27 @@ func MSSQL(ctx context.Context, t *agentdwhv1.MSSQLConf) (*scrappermssql.MSSQLSc
 	})
 }
 
+// Fabric builds a FabricScrapper for a Microsoft Fabric Warehouse / Lakehouse
+// SQL analytics endpoint. Authentication, TLS and port are derived from the
+// simplified FabricConf surface (see exec/fabric); the ambient AuthType modes
+// (azure_cli / default / managed_identity) authenticate as the host's own Azure
+// identity and are intended for on-prem agents — a hosted caller leaving
+// AuthType empty with no credentials fails closed.
+func Fabric(ctx context.Context, t *agentdwhv1.FabricConf) (*scrapperfabric.FabricScrapper, error) {
+	return scrapperfabric.NewFabricScrapper(ctx, &scrapperfabric.FabricScrapperConf{
+		FabricConf: dwhexecfabric.FabricConf{
+			Host:         t.GetHost(),
+			Database:     t.GetDatabase(),
+			AuthType:     t.GetAuthType(),
+			ClientID:     t.GetClientId(),
+			ClientSecret: t.GetClientSecret(),
+			TenantID:     t.GetTenantId(),
+			AccessToken:  t.GetAccessToken(),
+		},
+		Scope: scopeFromProto(t.GetScope()),
+	})
+}
+
 func Oracle(ctx context.Context, t *agentdwhv1.OracleConf) (*scrapperoracle.OracleScrapper, error) {
 	return scrapperoracle.NewOracleScrapper(ctx, &scrapperoracle.OracleScrapperConf{
 		OracleConf: dwhexecoracle.OracleConf{
@@ -226,6 +249,8 @@ func Connect(ctx context.Context, conf *agentdwhv1.Connection) (scrapper.Scrappe
 		return DuckDB(ctx, t.Duckdb)
 	case *agentdwhv1.Connection_Athena:
 		return Athena(ctx, t.Athena)
+	case *agentdwhv1.Connection_Fabric:
+		return Fabric(ctx, t.Fabric)
 	default:
 		return nil, errors.New("unsupported database type")
 	}
@@ -254,20 +279,21 @@ func Athena(ctx context.Context, t *agentdwhv1.AthenaConf) (*scrapperathena.Athe
 		UseShowCreateView:     t.GetUseShowCreateView(),
 		UseShowCreateTable:    t.GetUseShowCreateTable(),
 		UseIcebergMetricsScan: t.GetUseIcebergMetricsScan(),
-		Scope:                 athenaScopeFromProto(t.GetScope()),
+		Scope:                 scopeFromProto(t.GetScope()),
 	})
 }
 
-// athenaScopeFromProto inlines the buf-generated ScopeFilter → runtime
-// scope.ScopeFilter conversion. Kept here (not in scrapper/scope) on purpose:
-// the same proto file is also generated under github.com/getsynq/api/common/v1
-// in the cloud workspace, and any binary that links BOTH Go packages panics on
-// init because protobuf's global registry rejects duplicate registrations of
-// the same .proto file path. By only importing the buf flavor in this package
-// (which is exclusive to agent callers anyway), the runtime scope.ScopeFilter
-// type stays free of any proto generated package and is safe to import from
-// cloud handlers that already use the workspace flavor.
-func athenaScopeFromProto(p *commonv1.ScopeFilter) *scope.ScopeFilter {
+// scopeFromProto inlines the buf-generated ScopeFilter → runtime
+// scope.ScopeFilter conversion (shared by the Athena and Fabric scrappers).
+// Kept here (not in scrapper/scope) on purpose: the same proto file is also
+// generated under github.com/getsynq/api/common/v1 in the cloud workspace, and
+// any binary that links BOTH Go packages panics on init because protobuf's
+// global registry rejects duplicate registrations of the same .proto file path.
+// By only importing the buf flavor in this package (which is exclusive to agent
+// callers anyway), the runtime scope.ScopeFilter type stays free of any proto
+// generated package and is safe to import from cloud handlers that already use
+// the workspace flavor.
+func scopeFromProto(p *commonv1.ScopeFilter) *scope.ScopeFilter {
 	if p == nil {
 		return nil
 	}

--- a/exec/fabric/fabric.go
+++ b/exec/fabric/fabric.go
@@ -47,10 +47,13 @@ type FabricConf struct {
 	// BigQueryScrapperConf.Datasets).
 	Database string
 
-	// AuthType selects the authentication method — one of the AuthType*
-	// constants below, matched case-insensitively. Empty defaults to a service
-	// principal (ClientID + ClientSecret), unless AccessToken is set (a
-	// non-empty AccessToken always wins). The ambient modes
+	// AuthType selects the authentication method. It accepts any of the
+	// spellings in authTypeAliases — dbt-fabric ("ServicePrincipal", "CLI",
+	// "auto"), Microsoft's ODBC "Authentication=" keyword
+	// ("ActiveDirectoryServicePrincipal", ...), the Azure SDK names, or our own
+	// AuthType* constants — collapsed to a canonical value via CanonicalAuthType.
+	// Empty defaults to a service principal (ClientID + ClientSecret), unless
+	// AccessToken is set (a non-empty AccessToken always wins). The ambient modes
 	// (AuthTypeAzureCLI/Default/ManagedIdentity) authenticate as the host's own
 	// Azure identity with no stored credential and are intended for on-prem
 	// agents. They are opt-in — engaged only when AuthType names one — so a
@@ -76,23 +79,84 @@ type FabricConf struct {
 	AccessToken string
 }
 
-// AuthType values for FabricConf.AuthType. Named after the Azure credential
-// types Fabric users configure elsewhere, so the choice reads the same here as
-// in Azure tooling.
+// Canonical AuthType values for FabricConf.AuthType. Each method is recognized
+// under several industry spellings (dbt-fabric, Microsoft's ODBC
+// `Authentication=` keyword, the Azure SDK credential names, and our own
+// snake_case) — see authTypeAliases — but these constants are the single
+// canonical names to use when generating or suggesting config, so our output
+// stays consistent. Matching is done via CanonicalAuthType (case- and
+// separator-insensitive).
 const (
 	// AuthTypeServicePrincipal authenticates with an Entra service principal
 	// (ClientID + ClientSecret). This is the default when AuthType is empty.
+	// Aliases: "ServicePrincipal" (dbt-fabric),
+	// "ActiveDirectoryServicePrincipal" (Microsoft ODBC).
 	AuthTypeServicePrincipal = "service_principal"
 	// AuthTypeAzureCLI reuses the host's interactive `az login` session — the
-	// local-execution / developer-machine case.
+	// local-execution / developer-machine case. Aliases: "CLI" (dbt-fabric),
+	// "ActiveDirectoryAzCli" (Microsoft ODBC), "az_cli".
 	AuthTypeAzureCLI = "azure_cli"
 	// AuthTypeDefault uses Azure's DefaultAzureCredential chain (managed
-	// identity → environment → workload identity → az CLI).
+	// identity → environment → workload identity → az CLI). Aliases: "auto"
+	// (dbt-fabric), "ActiveDirectoryDefault" (Microsoft ODBC),
+	// "DefaultAzureCredential" (Azure SDK).
 	AuthTypeDefault = "default"
 	// AuthTypeManagedIdentity authenticates with an Azure managed identity; set
 	// ClientID for a user-assigned identity, leave empty for system-assigned.
+	// Aliases: "MSI", "ActiveDirectoryManagedIdentity" / "ActiveDirectoryMSI"
+	// (Microsoft ODBC).
 	AuthTypeManagedIdentity = "managed_identity"
 )
+
+// authTypeAliases maps every accepted spelling (normalized by normalizeAuthType)
+// to its canonical AuthType* value. It deliberately spans four vocabularies so a
+// config copied from dbt-fabric, Microsoft's docs, or Azure tooling works
+// as-is, while CanonicalAuthType still collapses them to one name for our own
+// generated config.
+var authTypeAliases = map[string]string{
+	// Service principal.
+	"serviceprincipal":                AuthTypeServicePrincipal,
+	"activedirectoryserviceprincipal": AuthTypeServicePrincipal,
+	// Azure CLI (`az login`).
+	"cli":                  AuthTypeAzureCLI,
+	"azurecli":             AuthTypeAzureCLI,
+	"azcli":                AuthTypeAzureCLI,
+	"activedirectoryazcli": AuthTypeAzureCLI,
+	// DefaultAzureCredential chain.
+	"auto":                   AuthTypeDefault,
+	"default":                AuthTypeDefault,
+	"activedirectorydefault": AuthTypeDefault,
+	"defaultazurecredential": AuthTypeDefault,
+	// Managed identity.
+	"managedidentity":                AuthTypeManagedIdentity,
+	"msi":                            AuthTypeManagedIdentity,
+	"activedirectorymanagedidentity": AuthTypeManagedIdentity,
+	"activedirectorymsi":             AuthTypeManagedIdentity,
+}
+
+// normalizeAuthType lower-cases s and strips the separators that distinguish the
+// various spellings (`_`, `-`, spaces), so "ActiveDirectoryServicePrincipal",
+// "service_principal" and "Service Principal" all collapse to a common key.
+func normalizeAuthType(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	return strings.NewReplacer("_", "", "-", "", " ", "").Replace(s)
+}
+
+// CanonicalAuthType maps any accepted auth spelling (dbt-fabric, Microsoft ODBC,
+// Azure SDK, or our own snake_case) to the single canonical AuthType* value.
+// Empty input stays empty (interpreted as the service-principal default);
+// unrecognized non-empty input is returned unchanged so callers can surface it.
+// Use it whenever generating or suggesting config so the auth method reads the
+// same everywhere.
+func CanonicalAuthType(s string) string {
+	if s == "" {
+		return ""
+	}
+	if c, ok := authTypeAliases[normalizeAuthType(s)]; ok {
+		return c
+	}
+	return s
+}
 
 // ToMSSQLConf translates the simplified Fabric configuration into the MSSQL
 // executor configuration, fixing the settings Fabric always requires: TLS
@@ -121,7 +185,7 @@ func (c *FabricConf) ToMSSQLConf() *dwhexecmssql.MSSQLConf {
 		return conf
 	}
 
-	switch strings.ToLower(c.AuthType) {
+	switch CanonicalAuthType(c.AuthType) {
 	case AuthTypeAzureCLI:
 		conf.FedAuth = "ActiveDirectoryAzCli"
 	case AuthTypeDefault:
@@ -131,7 +195,7 @@ func (c *FabricConf) ToMSSQLConf() *dwhexecmssql.MSSQLConf {
 		// A non-empty ClientID selects a user-assigned identity; the azuread
 		// driver reads it from the "user id" parameter.
 		conf.User = c.ClientID
-	default: // "" or AuthTypeServicePrincipal
+	default: // "", AuthTypeServicePrincipal, or an unrecognized value
 		conf.FedAuth = "ActiveDirectoryServicePrincipal"
 		// The azuread driver reads the client id from "user id" and splits an
 		// optional "@tenant" suffix; the client secret goes in the password.

--- a/exec/fabric/fabric_test.go
+++ b/exec/fabric/fabric_test.go
@@ -2,6 +2,40 @@ package fabric
 
 import "testing"
 
+func TestCanonicalAuthType(t *testing.T) {
+	tests := map[string]string{
+		// Empty stays empty (service-principal default).
+		"": "",
+		// Canonical values pass through.
+		"service_principal": AuthTypeServicePrincipal,
+		"azure_cli":         AuthTypeAzureCLI,
+		"default":           AuthTypeDefault,
+		"managed_identity":  AuthTypeManagedIdentity,
+		// dbt-fabric spellings.
+		"ServicePrincipal": AuthTypeServicePrincipal,
+		"CLI":              AuthTypeAzureCLI,
+		"auto":             AuthTypeDefault,
+		// Microsoft ODBC "Authentication=" keyword spellings.
+		"ActiveDirectoryServicePrincipal": AuthTypeServicePrincipal,
+		"ActiveDirectoryAzCli":            AuthTypeAzureCLI,
+		"ActiveDirectoryDefault":          AuthTypeDefault,
+		"ActiveDirectoryManagedIdentity":  AuthTypeManagedIdentity,
+		"ActiveDirectoryMSI":              AuthTypeManagedIdentity,
+		// Azure SDK / shorthand spellings, mixed case and separators.
+		"DefaultAzureCredential": AuthTypeDefault,
+		"MSI":                    AuthTypeManagedIdentity,
+		"az-cli":                 AuthTypeAzureCLI,
+		"Managed Identity":       AuthTypeManagedIdentity,
+		// Unrecognized values are returned unchanged.
+		"nonsense": "nonsense",
+	}
+	for in, want := range tests {
+		if got := CanonicalAuthType(in); got != want {
+			t.Errorf("CanonicalAuthType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestParseHostIdentity(t *testing.T) {
 	const host = "lvmghcalzphu5hhdgghdffivni-6apfgq3vf4eexhtn4fl5xrwg7i.datawarehouse.fabric.microsoft.com"
 	got, err := ParseHostIdentity(host)
@@ -69,6 +103,27 @@ func TestToMSSQLConf(t *testing.T) {
 			wantPass:    "secret",
 		},
 		{
+			name:        "dbt-fabric ServicePrincipal alias",
+			conf:        FabricConf{Host: host, Database: db, AuthType: "ServicePrincipal", ClientID: "cid", ClientSecret: "secret"},
+			wantFedAuth: "ActiveDirectoryServicePrincipal",
+			wantUser:    "cid",
+			wantPass:    "secret",
+		},
+		{
+			name:        "Microsoft ODBC ActiveDirectoryServicePrincipal alias",
+			conf:        FabricConf{Host: host, Database: db, AuthType: "ActiveDirectoryServicePrincipal", ClientID: "cid", ClientSecret: "secret"},
+			wantFedAuth: "ActiveDirectoryServicePrincipal",
+			wantUser:    "cid",
+			wantPass:    "secret",
+		},
+		{
+			name:        "unrecognized AuthType falls back to service principal",
+			conf:        FabricConf{Host: host, Database: db, AuthType: "nonsense", ClientID: "cid", ClientSecret: "secret"},
+			wantFedAuth: "ActiveDirectoryServicePrincipal",
+			wantUser:    "cid",
+			wantPass:    "secret",
+		},
+		{
 			name:        "access token wins over everything",
 			conf:        FabricConf{Host: host, Database: db, AuthType: "azure_cli", ClientID: "cid", ClientSecret: "secret", AccessToken: "tok"},
 			wantFedAuth: "",
@@ -80,13 +135,35 @@ func TestToMSSQLConf(t *testing.T) {
 			wantFedAuth: "ActiveDirectoryAzCli",
 		},
 		{
+			name:        "dbt-fabric CLI alias",
+			conf:        FabricConf{Host: host, Database: db, AuthType: "CLI"},
+			wantFedAuth: "ActiveDirectoryAzCli",
+		},
+		{
 			name:        "default credential chain",
 			conf:        FabricConf{Host: host, Database: db, AuthType: "default"},
 			wantFedAuth: "ActiveDirectoryDefault",
 		},
 		{
+			name:        "dbt-fabric auto alias",
+			conf:        FabricConf{Host: host, Database: db, AuthType: "auto"},
+			wantFedAuth: "ActiveDirectoryDefault",
+		},
+		{
 			name:        "user-assigned managed identity",
 			conf:        FabricConf{Host: host, Database: db, AuthType: "managed_identity", ClientID: "uami-cid"},
+			wantFedAuth: "ActiveDirectoryManagedIdentity",
+			wantUser:    "uami-cid",
+		},
+		{
+			name:        "MSI alias for managed identity",
+			conf:        FabricConf{Host: host, Database: db, AuthType: "MSI", ClientID: "uami-cid"},
+			wantFedAuth: "ActiveDirectoryManagedIdentity",
+			wantUser:    "uami-cid",
+		},
+		{
+			name:        "Microsoft ODBC ActiveDirectoryManagedIdentity alias",
+			conf:        FabricConf{Host: host, Database: db, AuthType: "ActiveDirectoryManagedIdentity", ClientID: "uami-cid"},
 			wantFedAuth: "ActiveDirectoryManagedIdentity",
 			wantUser:    "uami-cid",
 		},

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/getsynq/dwhsupport
 go 1.25.5
 
 require (
-	buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260506084438-595c0ebf0bd4.1
+	buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260714162129-d61afe5c46b6.1
 	cloud.google.com/go v0.121.6
 	cloud.google.com/go/bigquery v1.69.0
 	github.com/ClickHouse/ch-go v0.68.0
@@ -37,6 +37,7 @@ require (
 	github.com/trinodb/trino-go-client v0.323.0
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
 	go.opentelemetry.io/otel v1.39.0
+	go.opentelemetry.io/otel/sdk v1.39.0
 	go.opentelemetry.io/otel/trace v1.39.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.48.0
@@ -181,8 +182,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.39.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.39.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/snowflakedb/gosnowflake v1.13.3
 	github.com/stretchr/testify v1.11.1
 	github.com/trinodb/trino-go-client v0.323.0
+	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
 	go.opentelemetry.io/otel v1.39.0
 	go.opentelemetry.io/otel/sdk v1.39.0
@@ -176,6 +177,8 @@ require (
 	github.com/twmb/murmur3 v1.1.8 // indirect
 	github.com/uber-go/tally/v4 v4.1.17 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -442,6 +443,7 @@ github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+x
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1 h1:PMmTMyvHScV9Mn8wc6ASge9uRcHy0jtqPd+fM35LmsQ=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
-buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260506084438-595c0ebf0bd4.1 h1:Dwy6qrydFUIzFfZbFH/GwZMtgGvRA5ax1F3Yj+ZwH3k=
-buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260506084438-595c0ebf0bd4.1/go.mod h1:TOEu9lrXJ0CuMq3lFyZRfqabnKBXTBkwpWebF6tli90=
+buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260714162129-d61afe5c46b6.1 h1:oqy/HIyqWN8KPJJP1QJJrxYi+YjPeRbVWqN75GBimNg=
+buf.build/gen/go/getsynq/api/protocolbuffers/go v1.36.11-20260714162129-d61afe5c46b6.1/go.mod h1:TOEu9lrXJ0CuMq3lFyZRfqabnKBXTBkwpWebF6tli90=
 cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
 cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 cloud.google.com/go v0.121.6 h1:waZiuajrI28iAf40cWgycWNgaXPO06dupuS+sgibK6c=

--- a/yamlconfig/convert.go
+++ b/yamlconfig/convert.go
@@ -87,6 +87,10 @@ func ToProtoConnection(id string, conn *Connection) (*agentdwhv1.Connection, err
 		proto.Config = &agentdwhv1.Connection_Athena{
 			Athena: athenaConfToProto(conn.Athena),
 		}
+	case conn.Fabric != nil:
+		proto.Config = &agentdwhv1.Connection_Fabric{
+			Fabric: fabricConfToProto(conn.Fabric),
+		}
 	default:
 		return nil, fmt.Errorf("no database type configured")
 	}
@@ -262,6 +266,19 @@ func athenaConfToProto(c *AthenaConf) *agentdwhv1.AthenaConf {
 		UseShowCreateTable:    c.UseShowCreateTable,
 		UseShowCreateView:     c.UseShowCreateView,
 		UseIcebergMetricsScan: c.UseIcebergMetricsScan,
+	}
+}
+
+func fabricConfToProto(c *FabricConf) *agentdwhv1.FabricConf {
+	return &agentdwhv1.FabricConf{
+		Host:         c.Host,
+		Database:     c.Database,
+		AuthType:     c.AuthType,
+		ClientId:     c.ClientId,
+		ClientSecret: c.ClientSecret,
+		TenantId:     c.TenantId,
+		AccessToken:  c.AccessToken,
+		Scope:        scopeConfToProto(c.Scope),
 	}
 }
 

--- a/yamlconfig/convert_reverse.go
+++ b/yamlconfig/convert_reverse.go
@@ -51,6 +51,8 @@ func FromProtoConnection(proto *agentdwhv1.Connection) *Connection {
 		conn.DuckDB = duckdbConfFromProto(t.Duckdb)
 	case *agentdwhv1.Connection_Athena:
 		conn.Athena = athenaConfFromProto(t.Athena)
+	case *agentdwhv1.Connection_Fabric:
+		conn.Fabric = fabricConfFromProto(t.Fabric)
 	}
 
 	return conn
@@ -254,6 +256,22 @@ func athenaConfFromProto(c *agentdwhv1.AthenaConf) *AthenaConf {
 		UseShowCreateTable:    c.GetUseShowCreateTable(),
 		UseShowCreateView:     c.GetUseShowCreateView(),
 		UseIcebergMetricsScan: c.GetUseIcebergMetricsScan(),
+	}
+}
+
+func fabricConfFromProto(c *agentdwhv1.FabricConf) *FabricConf {
+	if c == nil {
+		return nil
+	}
+	return &FabricConf{
+		Host:         c.GetHost(),
+		Database:     c.GetDatabase(),
+		AuthType:     c.GetAuthType(),
+		ClientId:     c.GetClientId(),
+		ClientSecret: c.GetClientSecret(),
+		TenantId:     c.GetTenantId(),
+		AccessToken:  c.GetAccessToken(),
+		Scope:        scopeConfFromProto(c.GetScope()),
 	}
 }
 

--- a/yamlconfig/convert_test.go
+++ b/yamlconfig/convert_test.go
@@ -1,4 +1,3 @@
-
 package yamlconfig
 
 import (
@@ -6,6 +5,7 @@ import (
 	"testing"
 
 	agentdwhv1 "buf.build/gen/go/getsynq/api/protocolbuffers/go/synq/agent/dwh/v1"
+	commonv1 "buf.build/gen/go/getsynq/api/protocolbuffers/go/synq/common/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +19,7 @@ func TestToProtoConnections_AllTypes(t *testing.T) {
 
 	protos, err := ToProtoConnections(conns)
 	require.NoError(t, err)
-	assert.Len(t, protos, 13)
+	assert.Len(t, protos, 14)
 
 	// Verify Postgres
 	pg := protos["pg-local"]
@@ -112,6 +112,22 @@ func TestToProtoConnections_AllTypes(t *testing.T) {
 	require.NotNil(t, rsConf)
 	assert.Equal(t, int32(5439), rsConf.GetPort())
 	assert.True(t, rsConf.GetFreshnessFromQueryLogs())
+
+	// Verify Fabric
+	fabric := protos["fabric-prod"]
+	require.NotNil(t, fabric)
+	assert.Equal(t, "Fabric Warehouse", fabric.GetName())
+	fabricConf := fabric.GetFabric()
+	require.NotNil(t, fabricConf)
+	assert.Equal(t, "my-workspace.datawarehouse.fabric.microsoft.com", fabricConf.GetHost())
+	assert.Equal(t, "analytics", fabricConf.GetDatabase())
+	fabricScope := fabricConf.GetScope()
+	require.NotNil(t, fabricScope)
+	require.Len(t, fabricScope.GetInclude(), 1)
+	assert.Equal(t, "analytics", fabricScope.GetInclude()[0].GetDatabase())
+	require.Len(t, fabricScope.GetExclude(), 1)
+	assert.Equal(t, "staging", fabricScope.GetExclude()[0].GetSchema())
+	assert.Equal(t, "tmp_*", fabricScope.GetExclude()[0].GetTable())
 }
 
 func TestToProtoConnection_DefaultName(t *testing.T) {
@@ -225,6 +241,100 @@ func TestToProtoConnection_SnowflakeOptionalFields(t *testing.T) {
 	assert.Equal(t, "CUSTOM_DB", sfConf.GetAccountUsageDb())
 	assert.True(t, sfConf.HasAuthType())
 	assert.Equal(t, "externalbrowser", sfConf.GetAuthType())
+}
+
+func TestToProtoConnection_FabricServicePrincipal(t *testing.T) {
+	conn := &Connection{
+		Fabric: &FabricConf{
+			Host:         "ws.datawarehouse.fabric.microsoft.com",
+			Database:     "WH",
+			ClientId:     "app-id",
+			ClientSecret: "sekret",
+			TenantId:     "tenant-id",
+		},
+	}
+
+	proto, err := ToProtoConnection("fabric", conn)
+	require.NoError(t, err)
+	fabricConf := proto.GetFabric()
+	require.NotNil(t, fabricConf)
+	assert.Equal(t, "ws.datawarehouse.fabric.microsoft.com", fabricConf.GetHost())
+	assert.Equal(t, "WH", fabricConf.GetDatabase())
+	assert.Equal(t, "app-id", fabricConf.GetClientId())
+	assert.Equal(t, "sekret", fabricConf.GetClientSecret())
+	assert.Equal(t, "tenant-id", fabricConf.GetTenantId())
+	assert.Empty(t, fabricConf.GetAuthType())
+	assert.Nil(t, fabricConf.GetScope(), "no scope configured")
+}
+
+func TestToProtoConnection_FabricAmbientAuth(t *testing.T) {
+	conn := &Connection{
+		Fabric: &FabricConf{
+			Host:     "ws.datawarehouse.fabric.microsoft.com",
+			AuthType: "azure_cli",
+		},
+	}
+
+	proto, err := ToProtoConnection("fabric", conn)
+	require.NoError(t, err)
+	fabricConf := proto.GetFabric()
+	require.NotNil(t, fabricConf)
+	assert.Equal(t, "azure_cli", fabricConf.GetAuthType())
+	assert.Empty(t, fabricConf.GetClientSecret())
+}
+
+func TestToProtoConnection_FabricAccessToken(t *testing.T) {
+	conn := &Connection{
+		Fabric: &FabricConf{
+			Host:        "ws.datawarehouse.fabric.microsoft.com",
+			AccessToken: "pre-acquired-token",
+		},
+	}
+
+	proto, err := ToProtoConnection("fabric", conn)
+	require.NoError(t, err)
+	fabricConf := proto.GetFabric()
+	require.NotNil(t, fabricConf)
+	assert.Equal(t, "pre-acquired-token", fabricConf.GetAccessToken())
+}
+
+func TestFromProtoConnection_Fabric(t *testing.T) {
+	proto := &agentdwhv1.Connection{
+		Name: "fab",
+		Config: &agentdwhv1.Connection_Fabric{
+			Fabric: &agentdwhv1.FabricConf{
+				Host:         "ws.datawarehouse.fabric.microsoft.com",
+				Database:     "WH",
+				AuthType:     "managed_identity",
+				ClientId:     "uami-id",
+				ClientSecret: "sekret",
+				TenantId:     "tenant-id",
+				AccessToken:  "tok",
+				Scope: &commonv1.ScopeFilter{
+					Include: []*commonv1.ScopeRule{{Database: "analytics"}},
+					Exclude: []*commonv1.ScopeRule{{Schema: "staging", Table: "tmp_*"}},
+				},
+			},
+		},
+	}
+
+	conn := FromProtoConnection(proto)
+	require.NotNil(t, conn)
+	assert.Equal(t, "fabric", conn.DialectType())
+	require.NotNil(t, conn.Fabric)
+	assert.Equal(t, "ws.datawarehouse.fabric.microsoft.com", conn.Fabric.Host)
+	assert.Equal(t, "WH", conn.Fabric.Database)
+	assert.Equal(t, "managed_identity", conn.Fabric.AuthType)
+	assert.Equal(t, "uami-id", conn.Fabric.ClientId)
+	assert.Equal(t, "sekret", conn.Fabric.ClientSecret)
+	assert.Equal(t, "tenant-id", conn.Fabric.TenantId)
+	assert.Equal(t, "tok", conn.Fabric.AccessToken)
+	require.NotNil(t, conn.Fabric.Scope)
+	require.Len(t, conn.Fabric.Scope.Include, 1)
+	assert.Equal(t, "analytics", conn.Fabric.Scope.Include[0].Database)
+	require.Len(t, conn.Fabric.Scope.Exclude, 1)
+	assert.Equal(t, "staging", conn.Fabric.Scope.Exclude[0].Schema)
+	assert.Equal(t, "tmp_*", conn.Fabric.Scope.Exclude[0].Table)
 }
 
 func TestRoundTrip_AllTypes(t *testing.T) {

--- a/yamlconfig/parse_test.go
+++ b/yamlconfig/parse_test.go
@@ -1,4 +1,3 @@
-
 package yamlconfig
 
 import (
@@ -18,7 +17,7 @@ func TestParseConnections_FullExample(t *testing.T) {
 	// Parse without env expansion — env vars remain as literal "${VAR}"
 	conns, err := ParseConnections(data, ParseOptions{})
 	require.NoError(t, err)
-	assert.Len(t, conns, 13)
+	assert.Len(t, conns, 14)
 
 	// Postgres
 	pg := conns["pg-local"]
@@ -123,6 +122,21 @@ func TestParseConnections_FullExample(t *testing.T) {
 	assert.Equal(t, "clickhouse", ch.DialectType())
 	require.NotNil(t, ch.Clickhouse)
 	assert.Equal(t, 9440, ch.Clickhouse.Port)
+
+	// Fabric
+	fabric := conns["fabric-prod"]
+	require.NotNil(t, fabric)
+	assert.Equal(t, "Fabric Warehouse", fabric.Name)
+	assert.Equal(t, "fabric", fabric.DialectType())
+	require.NotNil(t, fabric.Fabric)
+	assert.Equal(t, "my-workspace.datawarehouse.fabric.microsoft.com", fabric.Fabric.Host)
+	assert.Equal(t, "analytics", fabric.Fabric.Database)
+	require.NotNil(t, fabric.Fabric.Scope)
+	require.Len(t, fabric.Fabric.Scope.Include, 1)
+	assert.Equal(t, "analytics", fabric.Fabric.Scope.Include[0].Database)
+	require.Len(t, fabric.Fabric.Scope.Exclude, 1)
+	assert.Equal(t, "staging", fabric.Fabric.Scope.Exclude[0].Schema)
+	assert.Equal(t, "tmp_*", fabric.Fabric.Scope.Exclude[0].Table)
 }
 
 func TestParseConnections_EnvExpansion(t *testing.T) {

--- a/yamlconfig/schema_test.go
+++ b/yamlconfig/schema_test.go
@@ -25,7 +25,7 @@ func TestConnectionsSchema(t *testing.T) {
 	// Should contain all warehouse types
 	for _, wh := range []string{
 		"postgres", "snowflake", "bigquery", "redshift", "mysql",
-		"clickhouse", "trino", "databricks", "mssql", "oracle", "duckdb", "athena",
+		"clickhouse", "trino", "databricks", "mssql", "oracle", "duckdb", "athena", "fabric",
 	} {
 		assert.Contains(t, schemaStr, wh, "schema should contain %s", wh)
 	}

--- a/yamlconfig/schema_validation_test.go
+++ b/yamlconfig/schema_validation_test.go
@@ -1,0 +1,75 @@
+package yamlconfig
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xeipuuv/gojsonschema"
+	"gopkg.in/yaml.v3"
+)
+
+// connectionsUnderSchema builds the JSON document ({"connections": {...}}) that
+// the ConnectionsSchema wrapper describes, from raw YAML. It decodes into a
+// generic map so the JSON carries the YAML field names the schema is keyed on
+// (the reflector uses the "yaml" tag), then round-trips through JSON to
+// normalize scalar types for the validator.
+func connectionsUnderSchema(t *testing.T, rawYAML []byte) []byte {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(rawYAML, &doc))
+	require.Contains(t, doc, "connections", "fixture has no connections block")
+	out, err := json.Marshal(map[string]any{"connections": doc["connections"]})
+	require.NoError(t, err)
+	return out
+}
+
+func validateAgainstConnectionsSchema(t *testing.T, docJSON []byte) *gojsonschema.Result {
+	t.Helper()
+	schemaJSON, err := json.Marshal(ConnectionsSchema())
+	require.NoError(t, err)
+	res, err := gojsonschema.Validate(
+		gojsonschema.NewBytesLoader(schemaJSON),
+		gojsonschema.NewBytesLoader(docJSON),
+	)
+	require.NoError(t, err)
+	return res
+}
+
+// TestFullExampleMatchesSchema guards against drift between the generated JSON
+// schema (ConnectionsSchema) and the documented full_example.yaml fixture: every
+// connection in the fixture must validate against the schema, including required
+// fields, additionalProperties:false, and nested $ref types (scope). Parsed
+// without env expansion, so all scalar types stay as authored (secrets remain
+// literal "${VAR}" strings, which are valid for the string-typed fields).
+func TestFullExampleMatchesSchema(t *testing.T) {
+	raw, err := os.ReadFile("testdata/full_example.yaml")
+	require.NoError(t, err)
+
+	res := validateAgainstConnectionsSchema(t, connectionsUnderSchema(t, raw))
+	if !res.Valid() {
+		for _, e := range res.Errors() {
+			t.Errorf("full_example.yaml does not match generated schema: %s", e)
+		}
+	}
+}
+
+// TestSchemaRejectsInvalidConnection confirms the schema check above is
+// meaningful — the validator must catch a missing required field, an unknown
+// property, and an unknown property inside the nested scope $ref. If this ever
+// passes, ConnectionsSchema has silently become too permissive and
+// TestFullExampleMatchesSchema can no longer be trusted.
+func TestSchemaRejectsInvalidConnection(t *testing.T) {
+	bad := `{"connections":{"x":{"fabric":{"database":"d","bogus_field":1,"scope":{"include":[{"nope":"y"}]}}}}}`
+	res := validateAgainstConnectionsSchema(t, []byte(bad))
+	require.False(t, res.Valid(), "expected invalid connection to be rejected by the schema")
+
+	var msgs string
+	for _, e := range res.Errors() {
+		msgs += e.String() + "\n"
+	}
+	require.Contains(t, msgs, "host is required")
+	require.Contains(t, msgs, "bogus_field")
+	require.Contains(t, msgs, "nope") // nested $ref (ScopeConf → ScopeRuleConf) is resolved
+}

--- a/yamlconfig/testdata/full_example.yaml
+++ b/yamlconfig/testdata/full_example.yaml
@@ -116,6 +116,21 @@ connections:
       password: ${REDSHIFT_PASSWORD}
       freshness_from_query_logs: true
 
+  "fabric-prod":
+    name: "Fabric Warehouse"
+    fabric:
+      host: my-workspace.datawarehouse.fabric.microsoft.com
+      database: analytics
+      client_id: ${FABRIC_CLIENT_ID}
+      client_secret: ${FABRIC_CLIENT_SECRET}
+      tenant_id: ${FABRIC_TENANT_ID}
+      scope:
+        include:
+          - database: analytics
+        exclude:
+          - schema: staging
+            table: tmp_*
+
   "athena-prod":
     athena:
       region: eu-central-1

--- a/yamlconfig/types.go
+++ b/yamlconfig/types.go
@@ -243,11 +243,16 @@ type FabricConf struct {
 	// scrapping and generated metrics SQL are fully database-qualified, so this
 	// only affects unqualified queries — it is a different axis from scope.
 	Database string `yaml:"database,omitempty"`
-	// Authentication method, matched case-insensitively. Empty defaults to a
-	// service principal (client_id + client_secret). Ambient modes authenticate
-	// as the host's own Azure identity with no stored credential (on-prem agents
-	// only): "azure_cli" (reuse `az login`), "default" (DefaultAzureCredential
-	// chain), "managed_identity" (set client_id for a user-assigned identity).
+	// Authentication method. Accepts the dbt-fabric names ("ServicePrincipal",
+	// "CLI", "auto"), Microsoft's ODBC values ("ActiveDirectoryServicePrincipal",
+	// ...) or our canonical snake_case, matched case- and separator-insensitively.
+	// Empty defaults to a service principal (client_id + client_secret). Canonical
+	// values: "service_principal" (default), "azure_cli" (alias "CLI" — reuse
+	// `az login`), "default" (alias "auto" — DefaultAzureCredential chain),
+	// "managed_identity" (alias "MSI"; set client_id for a user-assigned
+	// identity). The ambient modes (azure_cli/default/managed_identity)
+	// authenticate as the host's own Azure identity and are intended for on-prem
+	// agents only.
 	AuthType string `yaml:"auth_type,omitempty"`
 	// Entra application (client) ID of the service principal, or the
 	// user-assigned identity client ID when auth_type is "managed_identity".

--- a/yamlconfig/types.go
+++ b/yamlconfig/types.go
@@ -227,47 +227,54 @@ type MSSQLConf struct {
 	ApplicationClientId string `yaml:"application_client_id,omitempty"`
 }
 
-// FabricConf contains Microsoft Fabric Warehouse / Lakehouse SQL analytics
-// endpoint connection parameters. Fabric speaks T-SQL over TDS; TLS, the TDS
-// port and the Entra auth workflow are fixed internally, so only the fields
-// below are exposed. Authentication defaults to an Entra service principal
-// (client_id + client_secret). Set access_token to supply a pre-acquired Entra
-// OAuth token, or set auth_type to an ambient mode to authenticate as the host's
-// own Azure identity with no stored secret (on-prem agents only).
+// FabricConf contains the connection settings for a Microsoft Fabric Warehouse
+// or Lakehouse SQL analytics endpoint. A single connection covers the whole
+// Fabric workspace: every warehouse and lakehouse in it is exposed as a
+// database. Encryption, the network port and the Microsoft Entra ID sign-in
+// flow are handled automatically, so only the fields below need to be set.
+//
+// Authentication defaults to an Entra ID service principal — set client_id,
+// client_secret and (optionally) tenant_id. Alternatively supply a pre-acquired
+// access_token, or, for the on-prem agent only, set auth_type to sign in as the
+// machine's own Azure identity.
 type FabricConf struct {
-	// Workspace SQL analytics endpoint host, e.g.
-	// "<workspace-id>.datawarehouse.fabric.microsoft.com".
-	Host string `yaml:"host" jsonschema:"required"`
-	// Default execution database for unqualified ad-hoc/monitor SQL. Optional:
-	// defaults to "master" (the always-present workspace entry point). Metadata
-	// scrapping and generated metrics SQL are fully database-qualified, so this
-	// only affects unqualified queries — it is a different axis from scope.
-	Database string `yaml:"database,omitempty"`
-	// Authentication method. Accepts the dbt-fabric names ("ServicePrincipal",
-	// "CLI", "auto"), Microsoft's ODBC values ("ActiveDirectoryServicePrincipal",
-	// ...) or our canonical snake_case, matched case- and separator-insensitively.
-	// Empty defaults to a service principal (client_id + client_secret). Canonical
-	// values: "service_principal" (default), "azure_cli" (alias "CLI" — reuse
-	// `az login`), "default" (alias "auto" — DefaultAzureCredential chain),
-	// "managed_identity" (alias "MSI"; set client_id for a user-assigned
-	// identity). The ambient modes (azure_cli/default/managed_identity)
-	// authenticate as the host's own Azure identity and are intended for on-prem
-	// agents only.
-	AuthType string `yaml:"auth_type,omitempty"`
-	// Entra application (client) ID of the service principal, or the
-	// user-assigned identity client ID when auth_type is "managed_identity".
-	ClientId string `yaml:"client_id,omitempty"`
-	// Service principal client secret.
-	ClientSecret string `yaml:"client_secret,omitempty"`
-	// Entra tenant (directory) ID. Optional: inferred from the endpoint when empty.
-	TenantId string `yaml:"tenant_id,omitempty"`
-	// Pre-acquired Entra OAuth access token for the SQL scope
-	// (https://database.windows.net/.default). When set, takes precedence over
-	// all other authentication methods.
-	AccessToken string `yaml:"access_token,omitempty"`
-	// Scope filter for include/exclude filtering. Mapping: ScopeRule.database =
-	// Fabric database/warehouse, ScopeRule.schema = schema, ScopeRule.table =
-	// table/view. Unset means the whole workspace.
+	// Hostname of the workspace's SQL analytics endpoint. Copy it from the
+	// Fabric portal: open your Warehouse or Lakehouse, then Settings → SQL
+	// connection string.
+	Host string `yaml:"host" jsonschema:"required,example=my-workspace.datawarehouse.fabric.microsoft.com"`
+	// Default database for queries that don't name one explicitly. Optional —
+	// defaults to "master". Because metadata and metric queries are always
+	// fully qualified, this only affects ad-hoc SQL that omits the database.
+	Database string `yaml:"database,omitempty" jsonschema:"example=my_warehouse"`
+	// How to authenticate to Fabric. Optional — defaults to a service principal
+	// (client_id + client_secret). Values are matched case-insensitively, and
+	// the equivalent dbt-fabric and Microsoft ODBC spellings are also accepted:
+	//   - "service_principal" (default): Entra ID service principal. Set
+	//     client_id, client_secret and, if needed, tenant_id.
+	//   - "azure_cli": reuse the machine's `az login` session. On-prem agent only.
+	//   - "default": try Azure's default credential chain (environment, managed
+	//     identity, CLI, ...). On-prem agent only.
+	//   - "managed_identity": use an Azure managed identity; set client_id to
+	//     select a user-assigned identity. On-prem agent only.
+	AuthType string `yaml:"auth_type,omitempty" jsonschema:"example=service_principal,example=azure_cli,example=default,example=managed_identity"`
+	// Application (client) ID of the Entra ID service principal. When auth_type
+	// is "managed_identity", this instead selects a user-assigned identity.
+	ClientId string `yaml:"client_id,omitempty" jsonschema:"example=00000000-0000-0000-0000-000000000000"`
+	// Client secret for the service principal. Supply it through an environment
+	// variable (e.g. ${FABRIC_CLIENT_SECRET}) rather than committing it in plain
+	// text.
+	ClientSecret string `yaml:"client_secret,omitempty" jsonschema:"example=${FABRIC_CLIENT_SECRET}"`
+	// Entra ID tenant (directory) ID. Optional — inferred from the endpoint
+	// hostname when omitted. Set it only when the service principal lives in a
+	// different tenant than the workspace.
+	TenantId string `yaml:"tenant_id,omitempty" jsonschema:"example=00000000-0000-0000-0000-000000000000"`
+	// A pre-acquired Entra ID OAuth access token for the SQL scope
+	// (https://database.windows.net/.default). Optional — when set it overrides
+	// every other authentication method. Mainly for hosted deployments that mint
+	// their own token.
+	AccessToken string `yaml:"access_token,omitempty" jsonschema:"example=${FABRIC_ACCESS_TOKEN}"`
+	// Optional include/exclude filter that limits which databases, schemas and
+	// tables are scanned. When omitted, the whole workspace is scanned.
 	Scope *ScopeConf `yaml:"scope,omitempty"`
 }
 

--- a/yamlconfig/types.go
+++ b/yamlconfig/types.go
@@ -31,6 +31,7 @@ type Connection struct {
 	Oracle     *OracleConf     `yaml:"oracle,omitempty"`
 	DuckDB     *DuckDBConf     `yaml:"duckdb,omitempty"`
 	Athena     *AthenaConf     `yaml:"athena,omitempty"`
+	Fabric     *FabricConf     `yaml:"fabric,omitempty"`
 }
 
 // DialectType returns the warehouse type string for this connection, or empty if none is set.
@@ -60,6 +61,8 @@ func (c *Connection) DialectType() string {
 		return "duckdb"
 	case c.Athena != nil:
 		return "athena"
+	case c.Fabric != nil:
+		return "fabric"
 	default:
 		return ""
 	}
@@ -222,6 +225,45 @@ type MSSQLConf struct {
 	AccessToken string `yaml:"access_token,omitempty"`
 	// Azure AD application client ID for service principal auth.
 	ApplicationClientId string `yaml:"application_client_id,omitempty"`
+}
+
+// FabricConf contains Microsoft Fabric Warehouse / Lakehouse SQL analytics
+// endpoint connection parameters. Fabric speaks T-SQL over TDS; TLS, the TDS
+// port and the Entra auth workflow are fixed internally, so only the fields
+// below are exposed. Authentication defaults to an Entra service principal
+// (client_id + client_secret). Set access_token to supply a pre-acquired Entra
+// OAuth token, or set auth_type to an ambient mode to authenticate as the host's
+// own Azure identity with no stored secret (on-prem agents only).
+type FabricConf struct {
+	// Workspace SQL analytics endpoint host, e.g.
+	// "<workspace-id>.datawarehouse.fabric.microsoft.com".
+	Host string `yaml:"host" jsonschema:"required"`
+	// Default execution database for unqualified ad-hoc/monitor SQL. Optional:
+	// defaults to "master" (the always-present workspace entry point). Metadata
+	// scrapping and generated metrics SQL are fully database-qualified, so this
+	// only affects unqualified queries — it is a different axis from scope.
+	Database string `yaml:"database,omitempty"`
+	// Authentication method, matched case-insensitively. Empty defaults to a
+	// service principal (client_id + client_secret). Ambient modes authenticate
+	// as the host's own Azure identity with no stored credential (on-prem agents
+	// only): "azure_cli" (reuse `az login`), "default" (DefaultAzureCredential
+	// chain), "managed_identity" (set client_id for a user-assigned identity).
+	AuthType string `yaml:"auth_type,omitempty"`
+	// Entra application (client) ID of the service principal, or the
+	// user-assigned identity client ID when auth_type is "managed_identity".
+	ClientId string `yaml:"client_id,omitempty"`
+	// Service principal client secret.
+	ClientSecret string `yaml:"client_secret,omitempty"`
+	// Entra tenant (directory) ID. Optional: inferred from the endpoint when empty.
+	TenantId string `yaml:"tenant_id,omitempty"`
+	// Pre-acquired Entra OAuth access token for the SQL scope
+	// (https://database.windows.net/.default). When set, takes precedence over
+	// all other authentication methods.
+	AccessToken string `yaml:"access_token,omitempty"`
+	// Scope filter for include/exclude filtering. Mapping: ScopeRule.database =
+	// Fabric database/warehouse, ScopeRule.schema = schema, ScopeRule.table =
+	// table/view. Unset means the whole workspace.
+	Scope *ScopeConf `yaml:"scope,omitempty"`
 }
 
 // OracleConf contains Oracle Database connection parameters.

--- a/yamlconfig/zz_scratch_validate_test.go
+++ b/yamlconfig/zz_scratch_validate_test.go
@@ -1,0 +1,31 @@
+package yamlconfig
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/xeipuuv/gojsonschema"
+	"gopkg.in/yaml.v3"
+)
+
+func TestScratchValidateFixture(t *testing.T) {
+	schemaJSON, _ := json.Marshal(ConnectionsSchema())
+	raw, _ := os.ReadFile("testdata/full_example.yaml")
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	docJSON, _ := json.Marshal(map[string]interface{}{"connections": doc["connections"]})
+	res, err := gojsonschema.Validate(gojsonschema.NewBytesLoader(schemaJSON), gojsonschema.NewBytesLoader(docJSON))
+	if err != nil {
+		t.Fatalf("VALIDATOR ERROR: %v", err)
+	}
+	if res.Valid() {
+		t.Logf("FIXTURE VALID against generated schema")
+	} else {
+		for _, e := range res.Errors() {
+			t.Errorf("SCHEMA MISMATCH: %s", e)
+		}
+	}
+}


### PR DESCRIPTION
Completes the `connect.go` + `go.mod` wiring that #200 deferred until the agent `FabricConf` proto was published to the BSR module.

## Changes
- **go.mod**: bump `getsynq/api` protobuf module to the revision that adds `FabricConf` / `Connection.fabric` (`go mod tidy` also re-classifies `otel/sdk` as direct, pulled in by the new module graph).
- **connect**: add the `Fabric()` constructor and the `Connection_Fabric` case in `Connect()`. `athenaScopeFromProto` is renamed to `scopeFromProto` since the Athena and Fabric scrappers now share the same buf→runtime scope conversion (kept in `connect` to keep proto-generated imports out of `scrapper/scope`).
- **yamlconfig**: add `FabricConf` (host, database, auth_type, client_id, client_secret, tenant_id, access_token, scope) with a `fabric` field on `Connection`, a `DialectType()` case, and forward/reverse proto conversion mirroring the existing Athena scope handling.

## Auth vocabulary (industry-aligned)
Fabric users author auth config in several vocabularies. `auth_type` now accepts all of them — dbt-fabric (`ServicePrincipal`, `CLI`, `auto`), Microsoft's ODBC `Authentication=` keyword (`ActiveDirectoryServicePrincipal`, …), the Azure SDK credential names, and our own snake_case — matched case- and separator-insensitively, so a config copied from any of those sources works as-is. `exec/fabric.CanonicalAuthType` collapses them to a single canonical value (`service_principal` / `azure_cli` / `default` / `managed_identity`) so our own generated/suggested config stays consistent. `client_id`/`client_secret`/`tenant_id`/`database` already match dbt-fabric verbatim. The field name stays `auth_type` for consistency with our Snowflake connector (rather than dbt's `authentication`).

## Tests
- Extended `full_example.yaml` with a `fabric-prod` connection (service principal + include/exclude scope) and bumped the all-types counts (13 → 14).
- Added parse, forward-convert, reverse-convert and round-trip assertions, plus dedicated coverage for the service-principal, ambient-auth and pre-acquired access-token shapes.
- Extended the `ToMSSQLConf` table with dbt-fabric/ODBC/MSI aliases + an unrecognized-value fallback, and added `TestCanonicalAuthType` across all four vocabularies (mixed case/separators).
- Added `fabric` to the JSON-schema warehouse-type assertion.

The scrapper/executor/dialect layers themselves already landed in #200.

https://claude.ai/code/session_01HZPnYTpfTpfdkP7bEdYqtt