### PR TITLE
fabric,mssql: fix catalog + query-log failures on Fabric warehouses

### DIFF
--- a/scrapper/fabric/query_logs.go
+++ b/scrapper/fabric/query_logs.go
@@ -3,6 +3,7 @@ package fabric
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -33,11 +34,13 @@ var _ querylogs.QueryLogsProvider = &FabricScrapper{}
 // FetchQueryLogs streams query history from queryinsights.exec_requests_history.
 //
 // Fabric has no Query Store; queryinsights is the query-history source (retained
-// ~30 days). The view is per-database, so — consistent with the workspace-centric
-// scrapper — this reads it across every in-scope database via three-part names in
-// a single UNION ALL, feeding one iterator. The [from, to] window is inlined as
-// DATETIME2 literals rather than bound parameters so the same window applies to
-// every UNION branch.
+// ~30 days). The schema exists only in Warehouses — a workspace SQL endpoint also
+// exposes Lakehouse SQL endpoints, SQL databases and mirrored databases, none of
+// which have queryinsights. So rather than one UNION ALL (which fails entirely
+// the moment a single non-Warehouse database is in scope), this reads each
+// in-scope database independently and skips any that raise the "Invalid object
+// name" error for the queryinsights view. The [from, to] window is inlined as
+// DATETIME2 literals rather than bound parameters.
 func (e *FabricScrapper) FetchQueryLogs(
 	ctx context.Context,
 	from, to time.Time,
@@ -52,21 +55,20 @@ func (e *FabricScrapper) FetchQueryLogs(
 		return nil, err
 	}
 
-	rows, err := e.executor.QueryRows(ctx, buildQueryLogsUnion(databases, from, to))
-	if err != nil {
-		return nil, err
-	}
-
-	host := e.conf.Host
-	return querylogs.NewSqlxRowsIterator[FabricQueryLogSchema](
-		rows,
-		obfuscator,
-		e.DialectType(),
-		func(row *FabricQueryLogSchema, obfuscator querylogs.QueryObfuscator, sqlDialect string) (*querylogs.QueryLog, error) {
-			return convertFabricRowToQueryLog(row, obfuscator, sqlDialect, host)
-		},
-	), nil
+	return &fabricQueryLogsIterator{
+		e:          e,
+		databases:  databases,
+		from:       from,
+		to:         to,
+		obfuscator: obfuscator,
+		host:       e.conf.Host,
+	}, nil
 }
+
+// queryInsightsView is the queryinsights object read for query history. It is
+// present only in Fabric Warehouses; the "Invalid object name" error naming it
+// is how a non-Warehouse database in scope is recognised and skipped.
+const queryInsightsView = "queryinsights.exec_requests_history"
 
 // queryLogsSelect is the per-database projection over queryinsights. %[1]s is the
 // bracket-quoted database prefix and %[2]s/%[3]s are the DATETIME2 window bounds.
@@ -75,24 +77,107 @@ const queryLogsSelect = `SELECT
     CAST(distributed_statement_id AS VARCHAR(64)) AS query_id,
     login_name, submit_time, start_time, end_time,
     total_elapsed_time_ms, row_count, status, statement_type, command
-FROM %[1]s.queryinsights.exec_requests_history
+FROM %[1]s.` + queryInsightsView + `
 WHERE submit_time >= %[2]s AND submit_time < %[3]s`
 
-func buildQueryLogsUnion(databases []string, from, to time.Time) string {
-	fromLit := fabricDatetimeLiteral(from)
-	toLit := fabricDatetimeLiteral(to)
+func buildQueryLogsSelect(database string, from, to time.Time) string {
+	return fmt.Sprintf(queryLogsSelect, sqldialect.MSSQLQuoteIdentifier(database), fabricDatetimeLiteral(from), fabricDatetimeLiteral(to))
+}
 
-	// With no in-scope databases, run the connection's own queryinsights but
-	// select nothing, so the caller still gets a valid (empty) iterator.
-	if len(databases) == 0 {
-		return fmt.Sprintf(queryLogsSelect, "", fromLit, toLit) + " AND 1 = 0"
+// isQueryInsightsMissing reports whether err is the "Invalid object name" error
+// Fabric raises when a database has no queryinsights schema — i.e. it is a
+// Lakehouse SQL endpoint, SQL database or mirrored database rather than a
+// Warehouse. Only this exact error skips the database; every other error
+// (including permission denials) propagates so real misconfigurations surface.
+func isQueryInsightsMissing(err error) bool {
+	if err == nil {
+		return false
 	}
+	msg := err.Error()
+	return strings.Contains(msg, "Invalid object name") && strings.Contains(msg, queryInsightsView)
+}
 
-	branches := make([]string, 0, len(databases))
-	for _, db := range databases {
-		branches = append(branches, fmt.Sprintf(queryLogsSelect, sqldialect.MSSQLQuoteIdentifier(db), fromLit, toLit))
+// fabricQueryLogsIterator reads queryinsights across the in-scope databases one
+// at a time, lazily opening the next only when the current is exhausted, and
+// skipping databases whose queryinsights view is absent (non-Warehouses).
+type fabricQueryLogsIterator struct {
+	e          *FabricScrapper
+	databases  []string
+	from, to   time.Time
+	obfuscator querylogs.QueryObfuscator
+	host       string
+
+	idx     int
+	current querylogs.QueryLogIterator
+	closed  bool
+}
+
+func (it *fabricQueryLogsIterator) Next(ctx context.Context) (*querylogs.QueryLog, error) {
+	for {
+		if it.closed {
+			return nil, io.EOF
+		}
+
+		if it.current == nil {
+			// Advance to the next database that actually exposes queryinsights.
+			for it.idx < len(it.databases) {
+				select {
+				case <-ctx.Done():
+					it.Close()
+					return nil, ctx.Err()
+				default:
+				}
+
+				database := it.databases[it.idx]
+				it.idx++
+
+				rows, err := it.e.executor.QueryRows(ctx, buildQueryLogsSelect(database, it.from, it.to))
+				if err != nil {
+					if isQueryInsightsMissing(err) {
+						continue // non-Warehouse database: no query history to read
+					}
+					return nil, err
+				}
+
+				host := it.host
+				it.current = querylogs.NewSqlxRowsIterator[FabricQueryLogSchema](
+					rows,
+					it.obfuscator,
+					it.e.DialectType(),
+					func(row *FabricQueryLogSchema, obfuscator querylogs.QueryObfuscator, sqlDialect string) (*querylogs.QueryLog, error) {
+						return convertFabricRowToQueryLog(row, obfuscator, sqlDialect, host)
+					},
+				)
+				break
+			}
+
+			if it.current == nil {
+				it.Close()
+				return nil, io.EOF
+			}
+		}
+
+		log, err := it.current.Next(ctx)
+		if err == io.EOF {
+			it.current = nil // exhausted this database; move to the next
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		return log, nil
 	}
-	return strings.Join(branches, "\nUNION ALL\n")
+}
+
+func (it *fabricQueryLogsIterator) Close() error {
+	if it.closed {
+		return nil
+	}
+	it.closed = true
+	if it.current != nil {
+		return it.current.Close()
+	}
+	return nil
 }
 
 func fabricDatetimeLiteral(t time.Time) string {

--- a/scrapper/fabric/query_logs_test.go
+++ b/scrapper/fabric/query_logs_test.go
@@ -1,0 +1,51 @@
+package fabric
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+// TestIsQueryInsightsMissing pins the exact-match-then-skip behaviour: only the
+// "Invalid object name" error for the queryinsights view (raised for Lakehouse
+// SQL endpoints, SQL databases and mirrored databases that have no queryinsights
+// schema) marks a database skippable. Every other error — notably permission
+// denials — must propagate so real misconfigurations are not silently swallowed.
+func TestIsQueryInsightsMissing(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{
+			"invalid object name for queryinsights",
+			errors.New("mssql: Invalid object name 'COALESCE_DEV_TESTING.queryinsights.exec_requests_history'."),
+			true,
+		},
+		{
+			"invalid object name for some other object",
+			errors.New("mssql: Invalid object name 'MYDB.dbo.some_table'."),
+			false,
+		},
+		{
+			"permission denied on queryinsights must NOT skip",
+			errors.New(
+				"mssql: The SELECT permission or external policy action 'Microsoft.Sql/.../Select' was denied on the object 'exec_requests_history', database 'COALESCE_QUALITY_DWHTESTING', schema 'queryinsights'.",
+			),
+			false,
+		},
+		{
+			"unrelated error",
+			errors.New("mssql: Login failed"),
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isQueryInsightsMissing(tc.err); got != tc.want {
+				t.Fatalf("isQueryInsightsMissing(%q) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/scrapper/fabric/query_sql_definitions.sql
+++ b/scrapper/fabric/query_sql_definitions.sql
@@ -2,12 +2,17 @@
 --
 -- Fabric Warehouse has no materialized views, so is_materialized_view is always
 -- 0. sys.sql_modules.definition carries the CREATE VIEW text.
+--
+-- sys.sql_modules.definition is NULL when the connecting principal lacks
+-- VIEW DEFINITION on the object (e.g. a workspace Viewer service principal with
+-- no explicit grant) or for encrypted modules; COALESCE to '' so the row still
+-- scans into the non-nullable SqlDefinitionRow.Sql field instead of erroring.
 SELECT
     s.name                          AS [schema],
     v.name                          AS [table],
     1                               AS is_view,
     0                               AS is_materialized_view,
-    m.definition                    AS [sql]
+    COALESCE(m.definition, '')      AS [sql]
 FROM
     {{DB}}.sys.views v
     INNER JOIN {{DB}}.sys.schemas s

--- a/scrapper/mssql/query_sql_definitions.sql
+++ b/scrapper/mssql/query_sql_definitions.sql
@@ -4,7 +4,9 @@ SELECT
     v.name                          AS [table],
     1                               AS is_view,
     0                               AS is_materialized_view,
-    m.definition                    AS [sql]
+    -- definition is NULL for encrypted modules (and some Fabric views);
+    -- COALESCE to '' so the row scans into the non-nullable Sql field.
+    COALESCE(m.definition, '')      AS [sql]
 FROM
     sys.views v
     INNER JOIN sys.schemas s


### PR DESCRIPTION
Two robustness fixes for the new Microsoft Fabric scrapper, verified against a real Fabric warehouse.

### 1. NULL view definitions crash catalog fetch (`fabric` + `mssql`)
`sys.sql_modules.definition` is NULL when the connecting principal lacks `VIEW DEFINITION` on the object (a Fabric workspace **Viewer** service principal with no explicit grant) or for encrypted modules. Scanning that NULL into the non-nullable `SqlDefinitionRow.Sql` aborted `QuerySqlDefinitions` with `converting NULL to string is unsupported`, which cancelled the sibling catalog queries and failed the **entire** catalog fetch on first run.

Fix: `COALESCE(m.definition, '')` so a definition-less view still yields a row (blank SQL). The `mssql` scrapper carried the identical latent bug for encrypted modules.

### 2. Query-log fetch fails on any non-Warehouse database (`fabric`)
The Fabric SQL endpoint is workspace-shared and exposes every Warehouse, Lakehouse SQL endpoint, Fabric SQL database and mirrored database. `queryinsights` (the query-history source) exists **only** in Warehouses, so the previous single cross-database `UNION ALL` failed entirely — `Invalid object name '<db>.queryinsights.exec_requests_history'` — the moment a non-Warehouse database was in scope, taking down the whole `FetchQueryLogs` job.

Fix: read each in-scope database independently via a lazy chained iterator and skip only databases raising that exact "Invalid object name" error for the queryinsights view. Every other error (including permission denials — `queryinsights` requires the Contributor+ workspace role) still propagates so real misconfigurations surface.

Customer-facing permission requirements are corrected in getsynq/docs#148.

https://claude.ai/code/session_01DB3c18orS3UkhVNRfE5rT9