### PR TITLE
sqldialect: cap rows with TOP on mssql/fabric instead of OFFSET/FETCH

### DIFF
--- a/metrics/ProfileColumns/fabric.snap
+++ b/metrics/ProfileColumns/fabric.snap
@@ -1,6 +1,6 @@
 
 [TestProfileSuite/TestProfileColumns/fabric_multi_condition_multi_segmentation - 1]
-select
+select top (1000)
   SUBSTRING(CAST(workspace AS VARCHAR(MAX)), 1, 100) as [segment], 
   SUBSTRING(CAST(run_status AS VARCHAR(MAX)), 1, 100) as [segment2], 
   SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100) as [segment3], 
@@ -35,11 +35,11 @@ group by
   SUBSTRING(CAST(workspace AS VARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_status AS VARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/fabric_multi_condition_no_segmentation - 1]
-select
+select top (1000)
   COUNT(*) as [num_rows], 
   COUNT(workspace) as [workspace__num_not_null], 
   COUNT(distinct workspace) as [workspace__num_unique], 
@@ -67,11 +67,11 @@ select
   SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [db].[default].[runs] 
 where (run_status > 0) and (run_type > 0)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/fabric_multi_condition_single_segmentation_all - 1]
-select
+select top (1000)
   SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100) as [segment], 
   COUNT(*) as [num_rows], 
   COUNT(workspace) as [workspace__num_not_null], 
@@ -101,11 +101,11 @@ select
 from [db].[default].[runs] 
 where (run_status > 0) and (run_type > 0)
 group by SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/fabric_no_conditions_multi_segmentation - 1]
-select
+select top (1000)
   SUBSTRING(CAST(workspace AS VARCHAR(MAX)), 1, 100) as [segment], 
   SUBSTRING(CAST(run_status AS VARCHAR(MAX)), 1, 100) as [segment2], 
   SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100) as [segment3], 
@@ -139,11 +139,11 @@ group by
   SUBSTRING(CAST(workspace AS VARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_status AS VARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/fabric_no_conditions_no_segmentation - 1]
-select
+select top (1000)
   COUNT(*) as [num_rows], 
   COUNT(workspace) as [workspace__num_not_null], 
   COUNT(distinct workspace) as [workspace__num_unique], 
@@ -170,11 +170,11 @@ select
   max(created_at) as [created_at__max], 
   SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [db].[default].[runs] 
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/fabric_no_conditions_single_segmentation_all - 1]
-select
+select top (1000)
   SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100) as [segment], 
   COUNT(*) as [num_rows], 
   COUNT(workspace) as [workspace__num_not_null], 
@@ -203,11 +203,11 @@ select
   SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [db].[default].[runs] 
 group by SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/fabric_single_condition_multi_segmentation - 1]
-select
+select top (1000)
   SUBSTRING(CAST(workspace AS VARCHAR(MAX)), 1, 100) as [segment], 
   SUBSTRING(CAST(run_status AS VARCHAR(MAX)), 1, 100) as [segment2], 
   SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100) as [segment3], 
@@ -242,11 +242,11 @@ group by
   SUBSTRING(CAST(workspace AS VARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_status AS VARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/fabric_single_condition_no_segmentation - 1]
-select
+select top (1000)
   COUNT(*) as [num_rows], 
   COUNT(workspace) as [workspace__num_not_null], 
   COUNT(distinct workspace) as [workspace__num_unique], 
@@ -274,11 +274,11 @@ select
   SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [db].[default].[runs] 
 where (1=1)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/fabric_single_condition_single_segmentation_all - 1]
-select
+select top (1000)
   SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100) as [segment], 
   COUNT(*) as [num_rows], 
   COUNT(workspace) as [workspace__num_not_null], 
@@ -308,5 +308,5 @@ select
 from [db].[default].[runs] 
 where (1=1)
 group by SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---

--- a/metrics/ProfileColumns/mssql.snap
+++ b/metrics/ProfileColumns/mssql.snap
@@ -1,6 +1,6 @@
 
 [TestProfileSuite/TestProfileColumns/mssql_multi_condition_multi_segmentation - 1]
-select
+select top (1000)
   SUBSTRING(CAST(workspace AS NVARCHAR(MAX)), 1, 100) as [segment], 
   SUBSTRING(CAST(run_status AS NVARCHAR(MAX)), 1, 100) as [segment2], 
   SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100) as [segment3], 
@@ -35,11 +35,11 @@ group by
   SUBSTRING(CAST(workspace AS NVARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_status AS NVARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/mssql_multi_condition_no_segmentation - 1]
-select
+select top (1000)
   COUNT(*) as [num_rows], 
   COUNT(workspace) as [workspace__num_not_null], 
   COUNT(distinct workspace) as [workspace__num_unique], 
@@ -67,11 +67,11 @@ select
   SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
 where (run_status > 0) and (run_type > 0)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/mssql_multi_condition_single_segmentation_all - 1]
-select
+select top (1000)
   SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100) as [segment], 
   COUNT(*) as [num_rows], 
   COUNT(workspace) as [workspace__num_not_null], 
@@ -101,11 +101,11 @@ select
 from [default].[runs] 
 where (run_status > 0) and (run_type > 0)
 group by SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/mssql_no_conditions_multi_segmentation - 1]
-select
+select top (1000)
   SUBSTRING(CAST(workspace AS NVARCHAR(MAX)), 1, 100) as [segment], 
   SUBSTRING(CAST(run_status AS NVARCHAR(MAX)), 1, 100) as [segment2], 
   SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100) as [segment3], 
@@ -139,11 +139,11 @@ group by
   SUBSTRING(CAST(workspace AS NVARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_status AS NVARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/mssql_no_conditions_no_segmentation - 1]
-select
+select top (1000)
   COUNT(*) as [num_rows], 
   COUNT(workspace) as [workspace__num_not_null], 
   COUNT(distinct workspace) as [workspace__num_unique], 
@@ -170,11 +170,11 @@ select
   max(created_at) as [created_at__max], 
   SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/mssql_no_conditions_single_segmentation_all - 1]
-select
+select top (1000)
   SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100) as [segment], 
   COUNT(*) as [num_rows], 
   COUNT(workspace) as [workspace__num_not_null], 
@@ -203,11 +203,11 @@ select
   SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
 group by SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/mssql_single_condition_multi_segmentation - 1]
-select
+select top (1000)
   SUBSTRING(CAST(workspace AS NVARCHAR(MAX)), 1, 100) as [segment], 
   SUBSTRING(CAST(run_status AS NVARCHAR(MAX)), 1, 100) as [segment2], 
   SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100) as [segment3], 
@@ -242,11 +242,11 @@ group by
   SUBSTRING(CAST(workspace AS NVARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_status AS NVARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/mssql_single_condition_no_segmentation - 1]
-select
+select top (1000)
   COUNT(*) as [num_rows], 
   COUNT(workspace) as [workspace__num_not_null], 
   COUNT(distinct workspace) as [workspace__num_unique], 
@@ -274,11 +274,11 @@ select
   SUM(CASE WHEN sku is not null THEN 1 ELSE 0 END) as [sku__num_not_null]
 from [default].[runs] 
 where (1=1)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---
 
 [TestProfileSuite/TestProfileColumns/mssql_single_condition_single_segmentation_all - 1]
-select
+select top (1000)
   SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100) as [segment], 
   COUNT(*) as [num_rows], 
   COUNT(workspace) as [workspace__num_not_null], 
@@ -308,5 +308,5 @@ select
 from [default].[runs] 
 where (1=1)
 group by SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100)
-order by [num_rows] desc OFFSET 0 ROWS FETCH NEXT 1000 ROWS ONLY
+order by [num_rows] desc 
 ---

--- a/metrics/SegmentsListQuery/fabric.snap
+++ b/metrics/SegmentsListQuery/fabric.snap
@@ -1,6 +1,6 @@
 
 [TestSegmentsSuite/TestSegmentQueries/fabric - 1]
-select
+select top (10)
   SUBSTRING(CAST(workspace AS VARCHAR(MAX)), 1, 100) as [segment], 
   SUBSTRING(CAST(run_status AS VARCHAR(MAX)), 1, 100) as [segment2], 
   SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100) as [segment3], 
@@ -14,5 +14,5 @@ group by
   SUBSTRING(CAST(workspace AS VARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_status AS VARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_type AS VARCHAR(MAX)), 1, 100)
-order by COUNT(*) desc OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY
+order by COUNT(*) desc 
 ---

--- a/metrics/SegmentsListQuery/mssql.snap
+++ b/metrics/SegmentsListQuery/mssql.snap
@@ -1,6 +1,6 @@
 
 [TestSegmentsSuite/TestSegmentQueries/mssql - 1]
-select
+select top (10)
   SUBSTRING(CAST(workspace AS NVARCHAR(MAX)), 1, 100) as [segment], 
   SUBSTRING(CAST(run_status AS NVARCHAR(MAX)), 1, 100) as [segment2], 
   SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100) as [segment3], 
@@ -14,5 +14,5 @@ group by
   SUBSTRING(CAST(workspace AS NVARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_status AS NVARCHAR(MAX)), 1, 100), 
   SUBSTRING(CAST(run_type AS NVARCHAR(MAX)), 1, 100)
-order by COUNT(*) desc OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY
+order by COUNT(*) desc 
 ---

--- a/sqldialect/Cte/fabric.snap
+++ b/sqldialect/Cte/fabric.snap
@@ -1,8 +1,8 @@
 
 [TestBaseSuite/TestCte/fabric - 1]
-with cte AS (select *
+with cte AS (select top (10) *
 from [proj].[default].[users] 
-order by created_at desc OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY)
+order by created_at desc )
 select *
 from cte 
  

--- a/sqldialect/Cte/mssql.snap
+++ b/sqldialect/Cte/mssql.snap
@@ -1,8 +1,8 @@
 
 [TestBaseSuite/TestCte/mssql - 1]
-with cte AS (select *
+with cte AS (select top (10) *
 from [default].[users] 
-order by created_at desc OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY)
+order by created_at desc )
 select *
 from cte 
  

--- a/sqldialect/Dialect/fabric.snap
+++ b/sqldialect/Dialect/fabric.snap
@@ -1,8 +1,8 @@
 
 [TestBaseSuite/TestDialect/fabric - 1]
-select
+select top (10)
   *, 
   DATEADD(DAY, 1, GETUTCDATE()) as [tomorrow]
 from [proj].[default].[users] 
-order by created_at desc OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY
+order by created_at desc 
 ---

--- a/sqldialect/Dialect/mssql.snap
+++ b/sqldialect/Dialect/mssql.snap
@@ -1,8 +1,8 @@
 
 [TestBaseSuite/TestDialect/mssql - 1]
-select
+select top (10)
   *, 
   DATEADD(DAY, 1, GETUTCDATE()) as [tomorrow]
 from [default].[users] 
-order by created_at desc OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY
+order by created_at desc 
 ---

--- a/sqldialect/LimitWithoutOrderBy/bigquery.snap
+++ b/sqldialect/LimitWithoutOrderBy/bigquery.snap
@@ -1,0 +1,7 @@
+
+[TestBaseSuite/TestLimitWithoutOrderBy/bigquery - 1]
+with _synq_preview_cte AS (select * from some_table)
+select *
+from _synq_preview_cte 
+ limit 100
+---

--- a/sqldialect/LimitWithoutOrderBy/clickhouse.snap
+++ b/sqldialect/LimitWithoutOrderBy/clickhouse.snap
@@ -1,0 +1,7 @@
+
+[TestBaseSuite/TestLimitWithoutOrderBy/clickhouse - 1]
+with _synq_preview_cte AS (select * from some_table)
+select *
+from _synq_preview_cte 
+ limit 100
+---

--- a/sqldialect/LimitWithoutOrderBy/databricks.snap
+++ b/sqldialect/LimitWithoutOrderBy/databricks.snap
@@ -1,0 +1,7 @@
+
+[TestBaseSuite/TestLimitWithoutOrderBy/databricks - 1]
+with _synq_preview_cte AS (select * from some_table)
+select *
+from _synq_preview_cte 
+ limit 100
+---

--- a/sqldialect/LimitWithoutOrderBy/duckdb.snap
+++ b/sqldialect/LimitWithoutOrderBy/duckdb.snap
@@ -1,0 +1,7 @@
+
+[TestBaseSuite/TestLimitWithoutOrderBy/duckdb - 1]
+with _synq_preview_cte AS (select * from some_table)
+select *
+from _synq_preview_cte 
+ limit 100
+---

--- a/sqldialect/LimitWithoutOrderBy/fabric.snap
+++ b/sqldialect/LimitWithoutOrderBy/fabric.snap
@@ -1,0 +1,7 @@
+
+[TestBaseSuite/TestLimitWithoutOrderBy/fabric - 1]
+with _synq_preview_cte AS (select * from some_table)
+select top (100) *
+from _synq_preview_cte 
+ 
+---

--- a/sqldialect/LimitWithoutOrderBy/mssql.snap
+++ b/sqldialect/LimitWithoutOrderBy/mssql.snap
@@ -1,0 +1,7 @@
+
+[TestBaseSuite/TestLimitWithoutOrderBy/mssql - 1]
+with _synq_preview_cte AS (select * from some_table)
+select top (100) *
+from _synq_preview_cte 
+ 
+---

--- a/sqldialect/LimitWithoutOrderBy/mysql.snap
+++ b/sqldialect/LimitWithoutOrderBy/mysql.snap
@@ -1,0 +1,7 @@
+
+[TestBaseSuite/TestLimitWithoutOrderBy/mysql - 1]
+with _synq_preview_cte AS (select * from some_table)
+select *
+from _synq_preview_cte 
+ limit 100
+---

--- a/sqldialect/LimitWithoutOrderBy/oracle.snap
+++ b/sqldialect/LimitWithoutOrderBy/oracle.snap
@@ -1,0 +1,7 @@
+
+[TestBaseSuite/TestLimitWithoutOrderBy/oracle - 1]
+with _synq_preview_cte AS (select * from some_table)
+select *
+from _synq_preview_cte 
+ FETCH FIRST 100 ROWS ONLY
+---

--- a/sqldialect/LimitWithoutOrderBy/postgres.snap
+++ b/sqldialect/LimitWithoutOrderBy/postgres.snap
@@ -1,0 +1,7 @@
+
+[TestBaseSuite/TestLimitWithoutOrderBy/postgres - 1]
+with _synq_preview_cte AS (select * from some_table)
+select *
+from _synq_preview_cte 
+ limit 100
+---

--- a/sqldialect/LimitWithoutOrderBy/redshift.snap
+++ b/sqldialect/LimitWithoutOrderBy/redshift.snap
@@ -1,0 +1,7 @@
+
+[TestBaseSuite/TestLimitWithoutOrderBy/redshift - 1]
+with _synq_preview_cte AS (select * from some_table)
+select *
+from _synq_preview_cte 
+ limit 100
+---

--- a/sqldialect/LimitWithoutOrderBy/snowflake.snap
+++ b/sqldialect/LimitWithoutOrderBy/snowflake.snap
@@ -1,0 +1,7 @@
+
+[TestBaseSuite/TestLimitWithoutOrderBy/snowflake - 1]
+with _synq_preview_cte AS (select * from some_table)
+select *
+from _synq_preview_cte 
+ limit 100
+---

--- a/sqldialect/LimitWithoutOrderBy/trino.snap
+++ b/sqldialect/LimitWithoutOrderBy/trino.snap
@@ -1,0 +1,7 @@
+
+[TestBaseSuite/TestLimitWithoutOrderBy/trino - 1]
+with _synq_preview_cte AS (select * from some_table)
+select *
+from _synq_preview_cte 
+ limit 100
+---

--- a/sqldialect/TableFn/fabric.snap
+++ b/sqldialect/TableFn/fabric.snap
@@ -1,6 +1,6 @@
 
 [TestBaseSuite/TestTableFn/fabric - 1]
-select *
+select top (10) *
 from SNOWFLAKE.CORE.GET_LINEAGE('my_database.sch.table_a', 'TABLE', 'DOWNSTREAM', 2) 
-order by created_at desc OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY
+order by created_at desc 
 ---

--- a/sqldialect/TableFn/mssql.snap
+++ b/sqldialect/TableFn/mssql.snap
@@ -1,6 +1,6 @@
 
 [TestBaseSuite/TestTableFn/mssql - 1]
-select *
+select top (10) *
 from SNOWFLAKE.CORE.GET_LINEAGE('my_database.sch.table_a', 'TABLE', 'DOWNSTREAM', 2) 
-order by created_at desc OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY
+order by created_at desc 
 ---

--- a/sqldialect/base.go
+++ b/sqldialect/base.go
@@ -57,6 +57,21 @@ type CteExpr interface {
 type LimitClauseExpr interface {
 	Expr
 	IsLimitExpr()
+	// rowsSql renders just the row-count operand (e.g. "100"). The Select
+	// builder needs it separately from ToSql so it can place the cap in the
+	// SELECT clause on TOP-style dialects (see SelectTopDialect).
+	rowsSql(dialect Dialect) (string, error)
+}
+
+// SelectTopDialect is implemented by dialects that cap the number of returned
+// rows with a SELECT-clause prefix — T-SQL's `TOP (n)` — instead of a trailing
+// LIMIT/FETCH clause. When a dialect implements this and a limit is set, the
+// Select builder places the cap right after SELECT (and such dialects' FormatLimit
+// returns "" so no trailing clause is emitted). This matters because T-SQL only
+// allows OFFSET/FETCH paging when an ORDER BY is present, whereas TOP works with
+// or without one.
+type SelectTopDialect interface {
+	FormatSelectTop(rowsSql string) string
 }
 
 type LimitExpr struct {
@@ -77,6 +92,10 @@ func (e *LimitExpr) ToSql(dialect Dialect) (string, error) {
 	}
 
 	return dialect.FormatLimit(rowsSql), nil
+}
+
+func (e *LimitExpr) rowsSql(dialect Dialect) (string, error) {
+	return e.rows.ToSql(dialect)
 }
 
 func (e *LimitExpr) IsLimitExpr() {}
@@ -286,11 +305,27 @@ func (s *Select) ToSql(dialect Dialect) (string, error) {
 	}
 
 	limitSql := ""
+	selectTopSql := ""
 	if s.limit != nil {
-		limitSql, err = s.limit.ToSql(dialect)
-		if err != nil {
-			return "", err
+		if topDialect, ok := dialect.(SelectTopDialect); ok {
+			// TOP-style dialect: the cap goes in the SELECT clause, not a
+			// trailing clause. FormatLimit returns "" for these, so skip it.
+			rowsSql, err := s.limit.rowsSql(dialect)
+			if err != nil {
+				return "", err
+			}
+			selectTopSql = topDialect.FormatSelectTop(rowsSql)
+		} else {
+			limitSql, err = s.limit.ToSql(dialect)
+			if err != nil {
+				return "", err
+			}
 		}
+	}
+
+	selectSegmentId := "select"
+	if selectTopSql != "" {
+		selectSegmentId = "select " + selectTopSql
 	}
 
 	// build cte sql
@@ -312,7 +347,7 @@ from %s %s
 %s
 %s %s`,
 		buildListSegment("with", ",\n", cteSqls),
-		buildListSegment("select", ", ", colsSql),
+		buildListSegment(selectSegmentId, ", ", colsSql),
 		tableSql,
 		strings.Join(joinsSql, " "),
 		buildListSegment("where", " and ", whereSql),

--- a/sqldialect/base_test.go
+++ b/sqldialect/base_test.go
@@ -34,6 +34,28 @@ func (s *BaseSuite) TestCte() {
 	}
 }
 
+// TestLimitWithoutOrderBy covers the data-preview shape: an arbitrary query
+// wrapped in a CTE and capped, with NO ORDER BY. T-SQL (mssql/fabric) rejects
+// OFFSET/FETCH paging without an ORDER BY, so the cap must render as `TOP (n)`
+// in the SELECT clause — this asserts every dialect produces a valid capped
+// query in that case.
+func (s *BaseSuite) TestLimitWithoutOrderBy() {
+	for _, dialect := range DialectsToTest() {
+		s.Run(dialect.Name, func() {
+			cteFqn := CteFqn("_synq_preview_cte")
+			sel := NewSelect().
+				Cte(cteFqn, Sql("select * from some_table")).
+				Cols(Star()).
+				From(cteFqn).
+				WithLimit(Limit(Int64(100)))
+
+			sql, err := sel.ToSql(dialect.Dialect)
+			s.Require().NoError(err)
+			snaps.WithConfig(snaps.Dir("LimitWithoutOrderBy"), snaps.Filename(dialect.Name)).MatchSnapshot(s.T(), sql)
+		})
+	}
+}
+
 func (s *BaseSuite) TestTableFn() {
 	for _, dialect := range DialectsToTest() {
 		s.Run(dialect.Name, func() {

--- a/sqldialect/dialect_fabric.go
+++ b/sqldialect/dialect_fabric.go
@@ -18,7 +18,7 @@ import (
 //     seed). So string casts must target VARCHAR(MAX), not NVARCHAR(MAX).
 //
 // Everything else the MSSQL dialect emits (LEN, DATEADD/DATEDIFF truncation,
-// CONCAT_WS, GETUTCDATE(), CAST AS FLOAT, OFFSET/FETCH paging, PERCENTILE_CONT
+// CONCAT_WS, GETUTCDATE(), CAST AS FLOAT, TOP row-capping, PERCENTILE_CONT
 // being window-only so Median→NULL, bracket quoting) is valid Fabric T-SQL.
 type FabricDialect struct {
 	*MSSQLDialect

--- a/sqldialect/dialect_mssql.go
+++ b/sqldialect/dialect_mssql.go
@@ -130,8 +130,19 @@ func (d *MSSQLDialect) StringLength(expr Expr) Expr {
 	return Fn("LEN", expr)
 }
 
+// FormatLimit returns "" because MSSQL caps rows in the SELECT clause via
+// FormatSelectTop (TOP), not a trailing clause. T-SQL's OFFSET/FETCH paging is
+// only valid when the query has an ORDER BY, whereas TOP works with or without
+// one — so TOP is the safe form for an arbitrary capped query (e.g. a preview).
 func (d *MSSQLDialect) FormatLimit(rowsSql string) string {
-	return fmt.Sprintf("OFFSET 0 ROWS FETCH NEXT %s ROWS ONLY", rowsSql)
+	return ""
+}
+
+var _ SelectTopDialect = (*MSSQLDialect)(nil)
+
+// FormatSelectTop renders the T-SQL `TOP (n)` row cap placed after SELECT.
+func (d *MSSQLDialect) FormatSelectTop(rowsSql string) string {
+	return fmt.Sprintf("top (%s)", rowsSql)
 }
 
 func MSSQLQuoteIdentifier(identifier string) string {


### PR DESCRIPTION
## Summary

T-SQL only permits `OFFSET/FETCH` paging when the query has an `ORDER BY`. The MSSQL and Fabric dialects rendered a row limit as `OFFSET 0 ROWS FETCH NEXT n ROWS ONLY`, so any capped query **without** an `ORDER BY` — e.g. a CTE-wrapped data preview `WITH cte AS (<query>) SELECT * FROM cte LIMIT n` — produced invalid SQL that the server rejected with `Incorrect syntax near '<n>'`.

This renders the cap as a SELECT-clause `TOP (n)` prefix instead, which is valid T-SQL with or without an `ORDER BY` and is semantically equivalent to the old form when an `ORDER BY` is present.

## Changes

- New optional `SelectTopDialect` interface — a dialect implements it to signal the row cap belongs in the SELECT clause (`TOP (n)`) rather than a trailing clause. The `Select` builder places the prefix after `SELECT` and skips the trailing clause for such dialects; every other dialect keeps its existing `LIMIT`/`FETCH` clause unchanged.
- MSSQL (`FormatLimit` → "", adds `FormatSelectTop`); Fabric inherits it via embedding.
- New `TestLimitWithoutOrderBy` snapshot across every dialect covering the preview shape. Existing metrics/segments snapshots for mssql/fabric updated to `TOP (n)` (still `ORDER BY`-backed, so equivalent).