### PR TITLE
dwhsupport: preserve arrays/structs as JsonValue in RunRawQuery

### DIFF
--- a/cli/cmd/query.go
+++ b/cli/cmd/query.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/big"
@@ -100,6 +101,15 @@ func columnValueToAny(v *scrapper.ColumnValue) any {
 	}
 	switch val := v.Value.(type) {
 	case scrapper.StringValue:
+		return string(val)
+	case scrapper.JsonValue:
+		// Decode the canonical JSON so structured renderers (json/yaml/toon)
+		// nest it, rather than emitting a JSON string. Fall back to the raw
+		// text if it somehow fails to parse.
+		var decoded any
+		if err := json.Unmarshal([]byte(val), &decoded); err == nil {
+			return decoded
+		}
 		return string(val)
 	case scrapper.IntValue:
 		return int64(val)

--- a/scrapper/bigquery/run_raw_query.go
+++ b/scrapper/bigquery/run_raw_query.go
@@ -145,6 +145,18 @@ func bqValueToScrapperValue(v bigquery.Value) scrapper.Value {
 		return scrapper.StringValue(sanitizeUTF8(val))
 	case []byte:
 		return scrapper.StringValue(sanitizeUTF8(string(val)))
+	case []bigquery.Value:
+		// Repeated (array) fields, including arrays of STRUCTs.
+		if jv, ok := scrapper.NewJsonValueFromGo(val, false); ok {
+			return jv
+		}
+		return scrapper.StringValue(sanitizeUTF8(fmt.Sprint(v)))
+	case map[string]bigquery.Value:
+		// STRUCT / RECORD fields, arbitrarily nested.
+		if jv, ok := scrapper.NewJsonValueFromGo(val, false); ok {
+			return jv
+		}
+		return scrapper.StringValue(sanitizeUTF8(fmt.Sprint(v)))
 	default:
 		return scrapper.StringValue(sanitizeUTF8(fmt.Sprint(v)))
 	}

--- a/scrapper/jsonvalue.go
+++ b/scrapper/jsonvalue.go
@@ -1,0 +1,203 @@
+package scrapper
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// NewJsonValueFromGo converts an arbitrary driver-returned value — an
+// arbitrarily nested tree of Go slices, arrays, maps, pointers and scalars — into
+// a JsonValue holding canonical JSON text. It is the single normaliser used by
+// every RunRawQuery implementation for complex/nested cells so the wire format
+// is identical regardless of warehouse.
+//
+// bytesAsInts controls how a []byte / []uint8 is rendered, because Go cannot tell
+// a "small-int array" from a "byte blob" — both are []uint8:
+//
+//   - true  → the value is a native integer array (e.g. ClickHouse Array(UInt8),
+//     which the driver hands back as []uint8); render as a JSON array of numbers.
+//   - false → the value is a byte blob (BYTES/BLOB column); render as a JSON
+//     string (invalid UTF-8 scrubbed), matching the scalar []byte→string path.
+//
+// It returns ok=false only when the value cannot be represented as JSON at all;
+// unknown scalar types fall back to their fmt.Stringer / fmt.Sprint form so
+// nothing is silently dropped.
+func NewJsonValueFromGo(v any, bytesAsInts bool) (JsonValue, bool) {
+	norm, ok := jsonNormalize(v, bytesAsInts)
+	if !ok {
+		return "", false
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	// Keep raw JSON literals (json.Number for big ints/decimals) verbatim and
+	// avoid escaping <, >, & which are common inside string cells.
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(norm); err != nil {
+		return "", false
+	}
+	// Encoder appends a trailing newline; trim it.
+	return JsonValue(strings.TrimRight(buf.String(), "\n")), true
+}
+
+// NewJsonValueFromJSONText wraps text that is already JSON (Snowflake
+// ARRAY/OBJECT/VARIANT, Redshift SUPER, Fabric/MSSQL nvarchar JSON) into a
+// JsonValue, re-serialised to canonical (compact) form. Returns ok=false when
+// the text is not valid JSON so the caller can fall back to StringValue.
+func NewJsonValueFromJSONText(s string) (JsonValue, bool) {
+	if !json.Valid([]byte(s)) {
+		return "", false
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, []byte(s)); err != nil {
+		return "", false
+	}
+	return JsonValue(buf.String()), true
+}
+
+// jsonNormalize turns v into a json.Marshal-able tree of plain Go values.
+func jsonNormalize(v any, bytesAsInts bool) (any, bool) {
+	switch val := v.(type) {
+	case nil:
+		return nil, true
+	case string:
+		return sanitizeJSONString(val), true
+	case bool,
+		int, int8, int16, int32, int64,
+		uint, uint16, uint32, uint64,
+		float32, float64:
+		return val, true
+	case uint8:
+		// A bare uint8 reached here as an element of an []interface{} (e.g. a
+		// ClickHouse unnamed Tuple); it is a number, not a byte blob.
+		return val, true
+	case json.Number:
+		return val, true
+	case time.Time:
+		return val.UTC().Format(time.RFC3339Nano), true
+	case *big.Int:
+		if val == nil {
+			return nil, true
+		}
+		return json.Number(val.String()), true
+	case big.Int:
+		return json.Number(val.String()), true
+	case *big.Rat:
+		if val == nil {
+			return nil, true
+		}
+		return ratToJSONNumber(val), true
+	case big.Rat:
+		return ratToJSONNumber(&val), true
+	case *big.Float:
+		if val == nil {
+			return nil, true
+		}
+		return json.Number(val.Text('f', -1)), true
+	case []byte:
+		if bytesAsInts {
+			out := make([]any, len(val))
+			for i, b := range val {
+				out[i] = b
+			}
+			return out, true
+		}
+		return sanitizeJSONString(string(val)), true
+	case fmt.Stringer:
+		return sanitizeJSONString(val.String()), true
+	}
+
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if rv.IsNil() {
+			return nil, true
+		}
+		return jsonNormalize(rv.Elem().Interface(), bytesAsInts)
+	case reflect.Slice, reflect.Array:
+		// []byte was handled above; any other []uint8-kind slice arriving here is
+		// a native integer array, so recurse element-wise.
+		n := rv.Len()
+		out := make([]any, n)
+		for i := 0; i < n; i++ {
+			e, ok := jsonNormalize(rv.Index(i).Interface(), bytesAsInts)
+			if !ok {
+				return nil, false
+			}
+			out[i] = e
+		}
+		return out, true
+	case reflect.Map:
+		out := make(map[string]any, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			e, ok := jsonNormalize(iter.Value().Interface(), bytesAsInts)
+			if !ok {
+				return nil, false
+			}
+			out[stringifyMapKey(iter.Key())] = e
+		}
+		return out, true
+	case reflect.Struct:
+		// Types with their own JSON/text encoding (civil.Date, decimal libs, ...)
+		// serialise correctly through json.Marshal as-is.
+		if _, ok := v.(json.Marshaler); ok {
+			return v, true
+		}
+		if _, ok := v.(interface{ MarshalText() ([]byte, error) }); ok {
+			return v, true
+		}
+		return sanitizeJSONString(fmt.Sprint(v)), true
+	}
+	return nil, false
+}
+
+// stringifyMapKey renders a map key as a JSON object key. String keys pass
+// through; everything else (ClickHouse Map(Int, ...), etc.) is stringified.
+func stringifyMapKey(k reflect.Value) string {
+	if k.Kind() == reflect.Interface || k.Kind() == reflect.Pointer {
+		if k.IsNil() {
+			return "null"
+		}
+		k = k.Elem()
+	}
+	switch k.Kind() {
+	case reflect.String:
+		return sanitizeJSONString(k.String())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(k.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return strconv.FormatUint(k.Uint(), 10)
+	default:
+		return sanitizeJSONString(fmt.Sprint(k.Interface()))
+	}
+}
+
+// ratToJSONNumber renders an exact rational (e.g. a BigQuery NUMERIC/BIGNUMERIC
+// surfaced as *big.Rat) as a JSON number literal. Integers stay integral;
+// fractions use up to 38 decimal places (BIGNUMERIC's max scale) with trailing
+// zeros trimmed, which is exact for base-10 warehouse decimals.
+func ratToJSONNumber(r *big.Rat) json.Number {
+	if r.IsInt() {
+		return json.Number(r.Num().String())
+	}
+	s := r.FloatString(38)
+	if strings.Contains(s, ".") {
+		s = strings.TrimRight(s, "0")
+		s = strings.TrimRight(s, ".")
+	}
+	return json.Number(s)
+}
+
+func sanitizeJSONString(s string) string {
+	if !utf8.ValidString(s) {
+		s = strings.ToValidUTF8(s, "")
+	}
+	return s
+}

--- a/scrapper/jsonvalue_test.go
+++ b/scrapper/jsonvalue_test.go
@@ -1,0 +1,75 @@
+package scrapper
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewJsonValueFromGo(t *testing.T) {
+	u8 := uint8(7)
+	tests := []struct {
+		name        string
+		in          any
+		bytesAsInts bool
+		want        string
+	}{
+		{"int_slice", []int64{1, 2, 3}, false, `[1,2,3]`},
+		{"string_slice", []string{"a", "b"}, false, `["a","b"]`},
+		{"clickhouse_uint8_array", []uint8{1, 2, 3}, true, `[1,2,3]`},
+		{"byte_blob_as_string", []byte("hello"), false, `"hello"`},
+		{"map_string_key", map[string]uint8{"a": 1, "b": 2}, false, `{"a":1,"b":2}`},
+		{"map_int_key", map[int32]string{1: "x", 2: "y"}, false, `{"1":"x","2":"y"}`},
+		{"unnamed_tuple", []any{int64(1), "x", 3.5}, false, `[1,"x",3.5]`},
+		{"nested_array", [][]int64{{1, 2}, {3}}, false, `[[1,2],[3]]`},
+		{"array_of_tuple", [][]any{{int64(1), "a"}, {int64(2), "b"}}, false, `[[1,"a"],[2,"b"]]`},
+		{"pointer_elems_with_nil", []*uint8{&u8, nil}, false, `[7,null]`},
+		{"big_int", big.NewInt(9223372036854775807), false, `9223372036854775807`},
+		{"nested_struct_like", map[string]any{"items": []any{
+			map[string]any{"id": int64(1)},
+			map[string]any{"id": int64(2)},
+		}}, false, `{"items":[{"id":1},{"id":2}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := NewJsonValueFromGo(tt.in, tt.bytesAsInts)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestNewJsonValueFromGo_BigRatDecimal(t *testing.T) {
+	// BigQuery NUMERIC surfaces as *big.Rat; must render as an exact decimal.
+	r := new(big.Rat)
+	r.SetString("123.45")
+	got, ok := NewJsonValueFromGo([]any{r}, false)
+	require.True(t, ok)
+	assert.Equal(t, `[123.45]`, string(got))
+}
+
+func TestNewJsonValueFromGo_Time(t *testing.T) {
+	ts := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	got, ok := NewJsonValueFromGo([]any{ts}, false)
+	require.True(t, ok)
+	assert.Equal(t, `["2024-01-02T03:04:05Z"]`, string(got))
+}
+
+func TestNewJsonValueFromGo_InvalidUTF8Scrubbed(t *testing.T) {
+	got, ok := NewJsonValueFromGo([]string{"a\xffb"}, false)
+	require.True(t, ok)
+	assert.Equal(t, `["ab"]`, string(got))
+}
+
+func TestNewJsonValueFromJSONText(t *testing.T) {
+	// Pretty-printed Snowflake JSON compacts to canonical form.
+	got, ok := NewJsonValueFromJSONText("[\n  1,\n  2,\n  3\n]")
+	require.True(t, ok)
+	assert.Equal(t, `[1,2,3]`, string(got))
+
+	_, ok = NewJsonValueFromJSONText("not json")
+	assert.False(t, ok)
+}

--- a/scrapper/models.go
+++ b/scrapper/models.go
@@ -252,6 +252,26 @@ type StringValue string
 
 func (StringValue) isValue() {}
 
+// JsonValue carries a complex / nested cell — an array/list/vector, a
+// struct/record/named-tuple, a map, or a semi-structured object/variant — as
+// canonical JSON text. Warehouses expose these either as native nested values
+// (ClickHouse Array/Map/Tuple/Nested, BigQuery repeated fields & STRUCT/RECORD,
+// DuckDB LIST/STRUCT/MAP, Postgres arrays, Trino array/map/row) or as
+// JSON/semi-structured strings (Snowflake ARRAY/OBJECT/VARIANT, Redshift SUPER,
+// Fabric/MSSQL nvarchar JSON). Rather than flatten them to fmt.Sprint garbage or
+// lossy scalars, RunRawQuery normalises them to JSON so a single frontend
+// renderer can show a structured tree uniformly across every warehouse.
+//
+// The text is always valid JSON. Precision-sensitive scalars are encoded so the
+// JSON round-trip is lossless at the text level: arbitrary-precision integers as
+// JSON number literals, decimals as JSON numbers, and timestamps as RFC3339
+// strings. JsonValue is only emitted on the RunRawQuery path — the metrics /
+// profile path (QueryCustomMetrics) still collapses non-scalar cells to
+// IgnoredValue, since a nested cell cannot be a metric or a segment.
+type JsonValue string
+
+func (JsonValue) isValue() {}
+
 // BigIntValue represents arbitrary precision integers (e.g., DuckDB hugeint, uint128)
 type BigIntValue big.Int
 

--- a/scrapper/sanitize.go
+++ b/scrapper/sanitize.go
@@ -199,8 +199,11 @@ func (v *ColumnValue) Sanitize() {
 		return
 	}
 	v.Name = SanitizeString(v.Name)
-	if s, ok := v.Value.(StringValue); ok {
+	switch s := v.Value.(type) {
+	case StringValue:
 		v.Value = StringValue(SanitizeString(string(s)))
+	case JsonValue:
+		v.Value = JsonValue(SanitizeString(string(s)))
 	}
 }
 

--- a/scrapper/stdsql/run_raw_query.go
+++ b/scrapper/stdsql/run_raw_query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -108,7 +109,7 @@ func (it *rawRowsIterator) Next(ctx context.Context) ([]*scrapper.ColumnValue, e
 		raw := *(scanners[i].(*any))
 		cv := &scrapper.ColumnValue{Name: name, IsNull: raw == nil}
 		if raw != nil {
-			cv.Value = convertToRawValue(raw)
+			cv.Value = convertToRawValue(raw, it.columns[i].NativeType)
 		}
 		values[i] = cv
 	}
@@ -134,11 +135,33 @@ func (it *rawRowsIterator) closeLocked() error {
 
 // convertToRawValue mirrors convertToScrapperValue but preserves text
 // (string/[]byte → StringValue), renders UUIDs as their canonical string form,
-// and falls back to Stringer / fmt.Sprint for unknown driver types so
-// RunRawQuery never drops a value.
-func convertToRawValue(v any) scrapper.Value {
+// normalises complex/nested cells (arrays, structs, maps, JSON/variant columns)
+// to a single JsonValue, and falls back to Stringer / fmt.Sprint for unknown
+// scalar driver types so RunRawQuery never drops a value.
+//
+// nativeType is the column's DatabaseTypeName(); it disambiguates the two cases
+// Go types alone cannot: a native nested type (ClickHouse Array/Map/Tuple, whose
+// driver values may include []uint8 integer arrays) versus a JSON-string type
+// (Snowflake ARRAY/OBJECT/VARIANT), versus a plain text/blob column.
+func convertToRawValue(v any, nativeType string) scrapper.Value {
+	// Native nested types (ClickHouse Array/Map/Tuple/Nested): the driver returns
+	// nested Go slices/maps, and Array(UInt8) arrives as []uint8 — render bytes as
+	// an integer array, not a string.
+	if isNativeNestedType(nativeType) {
+		if jv, ok := scrapper.NewJsonValueFromGo(v, true); ok {
+			return jv
+		}
+	}
+
 	switch val := v.(type) {
 	case string:
+		// Semi-structured string columns (Snowflake ARRAY/OBJECT/VARIANT) carry
+		// JSON text; preserve their structure as JsonValue.
+		if isJSONTextType(nativeType) {
+			if jv, ok := scrapper.NewJsonValueFromJSONText(val); ok {
+				return jv
+			}
+		}
 		return scrapper.StringValue(sanitizeRawString(val))
 	case [16]byte:
 		// Native pgx (and google/uuid) surface UUIDs as a raw 16-byte array.
@@ -148,8 +171,30 @@ func convertToRawValue(v any) scrapper.Value {
 		if id, ok := tryUUIDFromBytes(val); ok {
 			return scrapper.StringValue(id)
 		}
+		// Redshift SUPER surfaces as a JSON []byte with an empty DatabaseTypeName;
+		// other engines expose JSON via a named type. Parse it as JSON only when
+		// the type signals JSON (or is unnamed) and the bytes actually parse, so
+		// genuine text/blob columns are left untouched.
+		if isJSONTextType(nativeType) || nativeType == "" {
+			if looksLikeJSON(val) {
+				if jv, ok := scrapper.NewJsonValueFromJSONText(string(val)); ok {
+					return jv
+				}
+			}
+		}
 		return scrapper.StringValue(sanitizeRawString(string(val)))
 	}
+
+	// Generic containers from any dialect (pgx arrays, DuckDB LIST/STRUCT/MAP,
+	// Trino array/map/row, ...) — anything the driver hands back as a Go
+	// slice/array/map that is not a []byte blob is a complex cell.
+	switch reflect.ValueOf(v).Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map:
+		if jv, ok := scrapper.NewJsonValueFromGo(v, false); ok {
+			return jv
+		}
+	}
+
 	converted := convertToScrapperValue(v)
 	if _, ignored := converted.(scrapper.IgnoredValue); ignored {
 		if s, ok := v.(fmt.Stringer); ok {
@@ -158,6 +203,56 @@ func convertToRawValue(v any) scrapper.Value {
 		return scrapper.StringValue(sanitizeRawString(fmt.Sprint(v)))
 	}
 	return converted
+}
+
+// isNativeNestedType reports whether a column's DatabaseTypeName denotes a type
+// whose driver value is a native nested Go structure (slice/map) rather than a
+// scalar or a JSON string. This is the ClickHouse family — Array(...), Map(...),
+// Tuple(...), Nested(...) — including LowCardinality/Nullable-wrapped forms.
+func isNativeNestedType(nativeType string) bool {
+	t := nativeType
+	for {
+		switch {
+		case strings.HasPrefix(t, "Array("),
+			strings.HasPrefix(t, "Map("),
+			strings.HasPrefix(t, "Tuple("),
+			strings.HasPrefix(t, "Nested("):
+			return true
+		case strings.HasPrefix(t, "LowCardinality("):
+			t = t[len("LowCardinality("):]
+		case strings.HasPrefix(t, "Nullable("):
+			t = t[len("Nullable("):]
+		default:
+			return false
+		}
+	}
+}
+
+// isJSONTextType reports whether a column's DatabaseTypeName denotes a
+// semi-structured type the driver surfaces as JSON text (Snowflake
+// ARRAY/OBJECT/VARIANT, Redshift SUPER, generic JSON/JSONB).
+func isJSONTextType(nativeType string) bool {
+	switch strings.ToUpper(nativeType) {
+	case "ARRAY", "OBJECT", "VARIANT", "SUPER", "JSON", "JSONB":
+		return true
+	}
+	return false
+}
+
+// looksLikeJSON reports whether b begins (ignoring leading whitespace) with a
+// JSON array or object delimiter, so we only attempt to parse plausible JSON.
+func looksLikeJSON(b []byte) bool {
+	for _, c := range b {
+		switch c {
+		case ' ', '\t', '\r', '\n':
+			continue
+		case '[', '{':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 // tryUUIDFromBytes recognises the two byte shapes a database driver might

--- a/scrapper/stdsql/run_raw_query_convert_test.go
+++ b/scrapper/stdsql/run_raw_query_convert_test.go
@@ -1,0 +1,57 @@
+package stdsql
+
+import (
+	"testing"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertToRawValueComplex(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         any
+		nativeType string
+		want       scrapper.Value
+	}{
+		// Scalars unchanged.
+		{"string", "hello", "String", scrapper.StringValue("hello")},
+		{"int", int64(42), "Int64", scrapper.IntValue(42)},
+		{"blob_stays_string", []byte("hi"), "String", scrapper.StringValue("hi")},
+
+		// ClickHouse native nested types -> JsonValue.
+		{"ch_array_int", []int32{1, 2, 3}, "Array(Int32)", scrapper.JsonValue(`[1,2,3]`)},
+		{"ch_array_uint8", []uint8{1, 2, 3}, "Array(UInt8)", scrapper.JsonValue(`[1,2,3]`)},
+		{"ch_map", map[string]int64{"a": 1}, "Map(String, Int64)", scrapper.JsonValue(`{"a":1}`)},
+		{"ch_tuple", []any{int64(1), "x"}, "Tuple(Int64, String)", scrapper.JsonValue(`[1,"x"]`)},
+		{"ch_nullable_array", []int32{1, 2}, "Array(Nullable(Int32))", scrapper.JsonValue(`[1,2]`)},
+
+		// JSON-text types (Snowflake ARRAY/OBJECT/VARIANT) -> JsonValue (compacted).
+		{"sf_array", "[\n  1,\n  2\n]", "ARRAY", scrapper.JsonValue(`[1,2]`)},
+		{"sf_object", `{"a": 1}`, "OBJECT", scrapper.JsonValue(`{"a":1}`)},
+
+		// Redshift SUPER: JSON []byte with empty native type.
+		{"super_bytes", []byte(`[1,2,3]`), "", scrapper.JsonValue(`[1,2,3]`)},
+		// A plain text column that merely looks like JSON must stay a string.
+		{"varchar_looks_json", "[not,json]", "VARCHAR", scrapper.StringValue("[not,json]")},
+
+		// Generic driver container from a dialect we do not special-case.
+		{"generic_slice", []any{int64(1), int64(2)}, "SOMETHING", scrapper.JsonValue(`[1,2]`)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, convertToRawValue(tt.in, tt.nativeType))
+		})
+	}
+}
+
+func TestIsNativeNestedType(t *testing.T) {
+	assert.True(t, isNativeNestedType("Array(Int32)"))
+	assert.True(t, isNativeNestedType("Map(String, Int64)"))
+	assert.True(t, isNativeNestedType("Tuple(Int64, String)"))
+	assert.True(t, isNativeNestedType("Nullable(Array(Int32))"))
+	assert.True(t, isNativeNestedType("LowCardinality(Array(String))"))
+	assert.False(t, isNativeNestedType("String"))
+	assert.False(t, isNativeNestedType("Int64"))
+	assert.False(t, isNativeNestedType("ARRAY")) // JSON-text type, not native nested
+}

--- a/scrapper/stdsql/run_raw_query_test.go
+++ b/scrapper/stdsql/run_raw_query_test.go
@@ -63,7 +63,7 @@ func TestConvertToRawValue(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := convertToRawValue(tc.in)
+			got := convertToRawValue(tc.in, "")
 			if tc.wantStr != "" {
 				sv, ok := got.(scrapper.StringValue)
 				assert.True(t, ok, "expected StringValue, got %T", got)
@@ -79,7 +79,7 @@ func TestConvertToRawValue_TimeStillTyped(t *testing.T) {
 	// time.Time is a Stringer but must keep going through convertToScrapperValue
 	// so it lands as TimeValue, not a string.
 	ts := time.Date(2026, 5, 11, 8, 0, 3, 0, time.UTC)
-	got := convertToRawValue(ts)
+	got := convertToRawValue(ts, "")
 	_, ok := got.(scrapper.TimeValue)
 	assert.True(t, ok, "expected TimeValue, got %T", got)
 }


### PR DESCRIPTION
## Summary

Data-preview cells (`RunRawQuery`) that are **arrays, structs/records, maps, or semi-structured objects** were flattened to a scalar via `fmt.Sprint`, producing unusable output on the frontend — e.g. `map[a:1 b:2]`, `[0xc0000b4018]`, or a Go-formatted slice. This made reconstruction and display of ClickHouse/BigQuery (and other warehouses') nested data poor.

This adds a single **`JsonValue` supertype**: `RunRawQuery` now normalises every complex/nested cell to **canonical JSON text**, so one frontend renderer can show a structured tree uniformly across all warehouses.

## How each warehouse is handled

Empirically validated what each driver actually returns (see table below) and normalised all of them:

| Warehouse | Native complex types | Driver returns | Now |
|---|---|---|---|
| ClickHouse | `Array`/`Map`/`Tuple`/`Nested` | nested Go slices/maps/pointers (`Array(UInt8)` → `[]uint8`) | reflect → JSON (byte-arrays rendered as int arrays) |
| BigQuery | repeated, `STRUCT`/`RECORD` | `[]bigquery.Value` / `map[string]bigquery.Value` | JSON |
| Snowflake | `ARRAY`/`OBJECT`/`VARIANT` | JSON string | re-serialised to canonical JSON |
| Redshift | `SUPER` | JSON `[]byte` (empty type name) | canonical JSON |
| DuckDB / Postgres / Trino / MySQL … | LIST/STRUCT/MAP, arrays, `JSON`/`JSONB` | Go containers / JSON text | JSON via the generic reflection fallback — **no per-dialect code** |

Precision-sensitive scalars stay lossless at the text level: big ints as JSON number literals, decimals (BigQuery `NUMERIC` `*big.Rat`) as exact decimals, timestamps as RFC3339.

The **metrics/profile path (`QueryCustomMetrics`) is intentionally unchanged** — a nested cell is never a metric or a segment.

## dwhctl

`columnValueToAny` decodes `JsonValue` so `json`/`yaml`/`toon` output nests it as a real object (no double-encoded string); `table`/`tsv` show compact JSON.

## Follow-ups (out of scope, noted for later)
- BigQuery **scalar** `NUMERIC` still renders as a `*big.Rat` `fmt.Sprint` (`2469/20`) — pre-existing, unrelated to nesting.
- Snowflake scalar numeric literals come back as strings from gosnowflake — pre-existing.

The cloud-side wiring (proto `json_value` field on `ColumnValue`, `dwh_service.go` conversion, frontend JSON-tree rendering) is tracked separately in a Linear issue.

https://claude.ai/code/session_01MbEzZS58ZxgyrdEQTE8GiP