### PR TITLE
dwhsupport: convert Postgres array cells to JsonValue + address #205 review

### DIFF
--- a/cli/cmd/query.go
+++ b/cli/cmd/query.go
@@ -106,6 +106,15 @@ func columnValueToAny(v *scrapper.ColumnValue) any {
 		// Decode the canonical JSON so structured renderers (json/yaml/toon)
 		// nest it, rather than emitting a JSON string. Fall back to the raw
 		// text if it somehow fails to parse.
+		//
+		// Note: json.Unmarshal into `any` decodes JSON numbers as float64, so a
+		// nested integer beyond 2^53 loses its low digits in the CLI's
+		// structured output. This is display-only — the JsonValue wire text is
+		// lossless — and a full fix is blocked downstream: the shared
+		// output.Normalize re-decodes without UseNumber (which would quote every
+		// number in YAML), and the TOON encoder collapses json.Number to float64
+		// regardless. Preserved here as a known limitation rather than trading it
+		// for a broader regression.
 		var decoded any
 		if err := json.Unmarshal([]byte(val), &decoded); err == nil {
 			return decoded

--- a/cli/cmd/query_test.go
+++ b/cli/cmd/query_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/getsynq/dwhsupport/scrapper"
+)
+
+func TestColumnValueToAny(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *scrapper.ColumnValue
+		want any
+	}{
+		{"null_flag", &scrapper.ColumnValue{IsNull: true}, nil},
+		{"nil_value", &scrapper.ColumnValue{Value: nil}, nil},
+		{"string", &scrapper.ColumnValue{Value: scrapper.StringValue("hi")}, "hi"},
+		{"int", &scrapper.ColumnValue{Value: scrapper.IntValue(42)}, int64(42)},
+		{"double", &scrapper.ColumnValue{Value: scrapper.DoubleValue(3.5)}, 3.5},
+		{
+			// A JSON object must decode into a nested map so structured renderers
+			// emit an object, not a double-encoded string.
+			"json_object_nested",
+			&scrapper.ColumnValue{Value: scrapper.JsonValue(`{"a":1,"items":[1,2]}`)},
+			map[string]any{"a": float64(1), "items": []any{float64(1), float64(2)}},
+		},
+		{
+			"json_array_nested",
+			&scrapper.ColumnValue{Value: scrapper.JsonValue(`[1,"x",true]`)},
+			[]any{float64(1), "x", true},
+		},
+		{
+			"malformed_json_falls_back_to_text",
+			&scrapper.ColumnValue{Value: scrapper.JsonValue(`{not json`)},
+			`{not json`,
+		},
+		{
+			// Documents the known display-only precision limitation: nested
+			// integers beyond 2^53 collapse to float64 on the CLI's structured
+			// output path (the JsonValue wire text itself stays lossless). Pinned
+			// so a future change that preserves precision updates this on purpose.
+			"nested_big_int_collapses_to_float64",
+			&scrapper.ColumnValue{Value: scrapper.JsonValue(`[9223372036854775807]`)},
+			[]any{float64(9223372036854775807)},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := columnValueToAny(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("columnValueToAny() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}

--- a/scrapper/stdsql/pgarray.go
+++ b/scrapper/stdsql/pgarray.go
@@ -1,0 +1,176 @@
+package stdsql
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// parsePostgresArrayLiteral parses a PostgreSQL array output literal — the text
+// form lib/pq (and the Redshift driver) hand back for array columns when
+// scanning into an untyped destination, e.g. `{1,2,3}`, `{a,b}`, `{"a,b","c"}`,
+// `{{1,2},{3,4}}`, `{NULL,1}`, `{}`. It returns a JSON-able tree ([]any of
+// json.Number / string / bool / nil / nested []any) and ok=false when the input
+// is not a well-formed array literal (so the caller keeps it as a string).
+//
+// elemType is the element's Postgres type name without the leading underscore
+// (e.g. "INT4", "TEXT", "BOOL"); it decides how unquoted tokens are typed.
+// Quoted tokens are always strings; the bareword NULL (case-insensitive) is the
+// SQL null, while a quoted "NULL" is the literal string.
+func parsePostgresArrayLiteral(s, elemType string) (any, bool) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "{") {
+		return nil, false
+	}
+	p := &pgArrayParser{s: s, elem: strings.ToUpper(elemType)}
+	v, ok := p.parseArray()
+	if !ok {
+		return nil, false
+	}
+	p.skipSpace()
+	if p.i != len(p.s) {
+		return nil, false
+	}
+	return v, true
+}
+
+type pgArrayParser struct {
+	s    string
+	i    int
+	elem string
+}
+
+func (p *pgArrayParser) skipSpace() {
+	for p.i < len(p.s) {
+		switch p.s[p.i] {
+		case ' ', '\t', '\n', '\r':
+			p.i++
+		default:
+			return
+		}
+	}
+}
+
+// parseArray parses a `{...}` at the current position.
+func (p *pgArrayParser) parseArray() ([]any, bool) {
+	p.skipSpace()
+	if p.i >= len(p.s) || p.s[p.i] != '{' {
+		return nil, false
+	}
+	p.i++ // consume '{'
+	out := []any{}
+	p.skipSpace()
+	if p.i < len(p.s) && p.s[p.i] == '}' {
+		p.i++ // empty array
+		return out, true
+	}
+	for {
+		v, ok := p.parseElement()
+		if !ok {
+			return nil, false
+		}
+		out = append(out, v)
+		p.skipSpace()
+		if p.i >= len(p.s) {
+			return nil, false
+		}
+		switch p.s[p.i] {
+		case ',':
+			p.i++
+			continue
+		case '}':
+			p.i++
+			return out, true
+		default:
+			return nil, false
+		}
+	}
+}
+
+// parseElement parses a single element: a nested array, a quoted string, or a
+// bareword.
+func (p *pgArrayParser) parseElement() (any, bool) {
+	p.skipSpace()
+	if p.i >= len(p.s) {
+		return nil, false
+	}
+	switch p.s[p.i] {
+	case '{':
+		return p.parseArray()
+	case '"':
+		return p.parseQuoted()
+	default:
+		return p.parseBareword()
+	}
+}
+
+// parseQuoted parses a `"..."` token with PG escaping (\" and \\).
+func (p *pgArrayParser) parseQuoted() (any, bool) {
+	p.i++ // consume opening quote
+	var b strings.Builder
+	for p.i < len(p.s) {
+		c := p.s[p.i]
+		switch c {
+		case '\\':
+			if p.i+1 >= len(p.s) {
+				return nil, false
+			}
+			b.WriteByte(p.s[p.i+1])
+			p.i += 2
+		case '"':
+			p.i++ // consume closing quote
+			return b.String(), true
+		default:
+			b.WriteByte(c)
+			p.i++
+		}
+	}
+	return nil, false // unterminated
+}
+
+// parseBareword parses an unquoted token up to the next delimiter and types it
+// according to the element type. A bareword NULL is the SQL null.
+func (p *pgArrayParser) parseBareword() (any, bool) {
+	start := p.i
+	for p.i < len(p.s) {
+		switch p.s[p.i] {
+		case ',', '}', '{':
+			goto done
+		default:
+			p.i++
+		}
+	}
+done:
+	tok := strings.TrimSpace(p.s[start:p.i])
+	if tok == "" {
+		return nil, false
+	}
+	if strings.EqualFold(tok, "NULL") {
+		return nil, true
+	}
+	return p.typeToken(tok), true
+}
+
+// typeToken converts an unquoted, non-null token to the JSON value implied by
+// the array's element type. Unknown/unparseable tokens fall back to a string so
+// the output is never wrong, only less specific.
+func (p *pgArrayParser) typeToken(tok string) any {
+	switch p.elem {
+	case "INT2", "INT4", "INT8", "OID":
+		if _, err := strconv.ParseInt(tok, 10, 64); err == nil {
+			return json.Number(tok)
+		}
+	case "FLOAT4", "FLOAT8", "NUMERIC":
+		if _, err := strconv.ParseFloat(tok, 64); err == nil {
+			return json.Number(tok)
+		}
+	case "BOOL":
+		switch tok {
+		case "t":
+			return true
+		case "f":
+			return false
+		}
+	}
+	return tok
+}

--- a/scrapper/stdsql/pgarray_test.go
+++ b/scrapper/stdsql/pgarray_test.go
@@ -1,0 +1,61 @@
+package stdsql
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePostgresArrayLiteral(t *testing.T) {
+	tests := []struct {
+		name     string
+		literal  string
+		elemType string
+		want     string // JSON of the parsed tree
+	}{
+		{"int_array", `{1,2,3}`, "INT4", `[1,2,3]`},
+		{"bigint_preserves_precision", `{9223372036854775807}`, "INT8", `[9223372036854775807]`},
+		{"text_array_unquoted", `{a,b}`, "TEXT", `["a","b"]`},
+		{"text_array_quoted", `{"a","b"}`, "TEXT", `["a","b"]`},
+		{"quoted_with_comma", `{"a,b","c"}`, "TEXT", `["a,b","c"]`},
+		{"quoted_with_escapes", `{"a\"b","c\\d"}`, "TEXT", `["a\"b","c\\d"]`},
+		{"empty_array", `{}`, "INT4", `[]`},
+		{"null_element", `{NULL,1}`, "INT4", `[null,1]`},
+		{"quoted_null_is_string", `{"NULL"}`, "TEXT", `["NULL"]`},
+		{"nested_array", `{{1,2},{3,4}}`, "INT4", `[[1,2],[3,4]]`},
+		{"nested_ragged", `{{1},{2,3}}`, "INT4", `[[1],[2,3]]`},
+		{"float_array", `{1.5,2.25}`, "FLOAT8", `[1.5,2.25]`},
+		{"bool_array", `{t,f}`, "BOOL", `[true,false]`},
+		{"numeric_stays_number", `{1.10,2.00}`, "NUMERIC", `[1.10,2.00]`},
+		{"text_that_looks_numeric_stays_string", `{01,02}`, "TEXT", `["01","02"]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree, ok := parsePostgresArrayLiteral(tt.literal, tt.elemType)
+			require.True(t, ok)
+			got, err := json.Marshal(tree)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestParsePostgresArrayLiteral_Rejects(t *testing.T) {
+	// Composite/record literals and malformed input must be rejected so the
+	// caller keeps them as strings.
+	for _, in := range []string{
+		`(1,x)`,      // composite RECORD, not an array
+		`1,2,3`,      // no braces
+		`{1,2`,       // unterminated
+		`{1,2}extra`, // trailing garbage
+		`{"a}`,       // unterminated quote
+		``,           // empty string
+	} {
+		t.Run(in, func(t *testing.T) {
+			_, ok := parsePostgresArrayLiteral(in, "INT4")
+			assert.False(t, ok)
+		})
+	}
+}

--- a/scrapper/stdsql/run_raw_query.go
+++ b/scrapper/stdsql/run_raw_query.go
@@ -162,6 +162,12 @@ func convertToRawValue(v any, nativeType string) scrapper.Value {
 				return jv
 			}
 		}
+		// Postgres/Redshift array columns arrive as the PG array output literal
+		// (e.g. `{1,2,3}`) under a `_ELEM`-style type name, not as JSON or a Go
+		// slice.
+		if jv, ok := pgArrayToJson(nativeType, val); ok {
+			return jv
+		}
 		return scrapper.StringValue(sanitizeRawString(val))
 	case [16]byte:
 		// Native pgx (and google/uuid) surface UUIDs as a raw 16-byte array.
@@ -171,10 +177,19 @@ func convertToRawValue(v any, nativeType string) scrapper.Value {
 		if id, ok := tryUUIDFromBytes(val); ok {
 			return scrapper.StringValue(id)
 		}
+		// Postgres/Redshift array columns: lib/pq returns the PG array literal as
+		// []byte under a `_ELEM`-style type name (e.g. _INT4 → `{1,2,3}`).
+		if jv, ok := pgArrayToJson(nativeType, string(val)); ok {
+			return jv
+		}
 		// Redshift SUPER surfaces as a JSON []byte with an empty DatabaseTypeName;
 		// other engines expose JSON via a named type. Parse it as JSON only when
 		// the type signals JSON (or is unnamed) and the bytes actually parse, so
-		// genuine text/blob columns are left untouched.
+		// genuine text/blob columns are left untouched. This is a deliberate,
+		// narrow collision: a text/blob column that a driver surfaces with an
+		// empty DatabaseTypeName AND whose value is valid JSON would be promoted
+		// to JsonValue. No in-tree driver does this for text columns (lib/pq
+		// reports TEXT/VARCHAR); the empty-name case is Redshift SUPER.
 		if isJSONTextType(nativeType) || nativeType == "" {
 			if looksLikeJSON(val) {
 				if jv, ok := scrapper.NewJsonValueFromJSONText(string(val)); ok {
@@ -226,6 +241,23 @@ func isNativeNestedType(nativeType string) bool {
 			return false
 		}
 	}
+}
+
+// pgArrayToJson converts a Postgres/Redshift array cell to a JsonValue. lib/pq
+// (and the Redshift driver) return array columns as the PG array output literal
+// under a `_ELEM`-style type name (e.g. _INT4, _TEXT, _INT8) rather than as a Go
+// slice or JSON. Non-array types, or literals that fail to parse (e.g. composite
+// `RECORD` values like `(1,x)`), return ok=false so the caller keeps the raw
+// string.
+func pgArrayToJson(nativeType, raw string) (scrapper.JsonValue, bool) {
+	if !strings.HasPrefix(nativeType, "_") {
+		return "", false
+	}
+	tree, ok := parsePostgresArrayLiteral(raw, nativeType[1:])
+	if !ok {
+		return "", false
+	}
+	return scrapper.NewJsonValueFromGo(tree, false)
 }
 
 // isJSONTextType reports whether a column's DatabaseTypeName denotes a

--- a/scrapper/stdsql/run_raw_query_convert_test.go
+++ b/scrapper/stdsql/run_raw_query_convert_test.go
@@ -30,10 +30,28 @@ func TestConvertToRawValueComplex(t *testing.T) {
 		{"sf_array", "[\n  1,\n  2\n]", "ARRAY", scrapper.JsonValue(`[1,2]`)},
 		{"sf_object", `{"a": 1}`, "OBJECT", scrapper.JsonValue(`{"a":1}`)},
 
-		// Redshift SUPER: JSON []byte with empty native type.
+		// Redshift SUPER: JSON []byte with empty native type -> promoted to JSON.
 		{"super_bytes", []byte(`[1,2,3]`), "", scrapper.JsonValue(`[1,2,3]`)},
 		// A plain text column that merely looks like JSON must stay a string.
 		{"varchar_looks_json", "[not,json]", "VARCHAR", scrapper.StringValue("[not,json]")},
+		// Empty native type but NOT valid JSON stays a string (no false promote).
+		{"empty_type_not_json", []byte(`hello`), "", scrapper.StringValue("hello")},
+		// Documented, accepted collision: an empty-native-type []byte whose content
+		// is valid JSON is promoted, even though it could in theory be plain text.
+		// No in-tree driver surfaces text columns with an empty type name.
+		{"empty_type_json_object", []byte(`{"a":1}`), "", scrapper.JsonValue(`{"a":1}`)},
+		// A NAMED text type is never promoted even if the content is JSON, so a
+		// user's verbatim JSON-in-text round-trips as a string.
+		{"named_text_json_stays_string", []byte(`{"a":1}`), "TEXT", scrapper.StringValue(`{"a":1}`)},
+
+		// Postgres/Redshift array literals (lib/pq: []byte under _ELEM type name).
+		{"pg_int_array", []byte(`{1,2,3}`), "_INT4", scrapper.JsonValue(`[1,2,3]`)},
+		{"pg_text_array", []byte(`{a,b}`), "_TEXT", scrapper.JsonValue(`["a","b"]`)},
+		{"pg_bigint_array", []byte(`{9223372036854775807}`), "_INT8", scrapper.JsonValue(`[9223372036854775807]`)},
+		{"pg_nested_array", []byte(`{{1,2},{3}}`), "_INT4", scrapper.JsonValue(`[[1,2],[3]]`)},
+		{"pg_array_as_string_type", `{1,2,3}`, "_INT4", scrapper.JsonValue(`[1,2,3]`)},
+		// Postgres composite RECORD is not an array literal -> stays a string.
+		{"pg_composite_record", []byte(`(1,x)`), "RECORD", scrapper.StringValue(`(1,x)`)},
 
 		// Generic driver container from a dialect we do not special-case.
 		{"generic_slice", []any{int64(1), int64(2)}, "SOMETHING", scrapper.JsonValue(`[1,2]`)},


### PR DESCRIPTION
Follow-up to #205 addressing the review feedback (thanks @grasskode, @LiHRaM).

## 1. Postgres arrays now convert to JSON (@grasskode)

The generic reflection fallback never fired for Postgres: `lib/pq` returns array/composite columns as the **PG output literal** — a `[]byte` like `{1,2,3}` / `(1,x)` under a `_ELEM`-style type name (`_INT4`, `_TEXT`, …) — not a Go slice. So `looksLikeJSON("{1,2,3}")` was true but `json.Valid` was false and the cell stayed a raw PG-literal `StringValue`.

Added a proper **PG array-literal parser** and route `_`-prefixed columns through it. It handles:
- quoting and `\` escapes (`{"a,b","c"}` → `["a,b","c"]`)
- `NULL` bareword vs quoted `"NULL"` string
- nested / ragged arrays (`{{1,2},{3}}`)
- per-element typing from the `_ELEM` type name (int/float/bool/text), with unparseable tokens falling back to strings so output is never *wrong*

Composite `RECORD` literals correctly stay strings (no field names to key on).

**Verified end-to-end against Postgres staging:**
```
int_arr    JsonValue   [1,2,3]
text_arr   JsonValue   ["a","b,c"]        # quoted comma handled
big_arr    JsonValue   [9223372036854775807]
nested_arr JsonValue   [[1,2],[3,4]]
jb (jsonb) JsonValue   {"a":1,"items":[1,2]}
text_json  StringValue {"a":1}            # JSON-in-TEXT stays a string
s          StringValue plain
```
The PR body's Postgres coverage claim now holds.

## 2. `nativeType == ""` collision documented + pinned (@grasskode, @LiHRaM)

The empty-type `[]byte`→JSON branch exists for Redshift `SUPER` (empty `DatabaseTypeName()` + JSON bytes). Validated no in-tree driver emits an empty type name for genuine text columns (lib/pq reports `TEXT`/`VARCHAR`). Documented the narrow, accepted collision at the call site and pinned **both directions** with tests (valid-JSON empty-type promotes; non-JSON and named-`TEXT` stay strings).

## 3. CLI big-int precision documented (@LiHRaM, non-blocking)

The json/yaml/toon path decodes nested JSON numbers to `float64`, so integers > 2^53 lose low digits (display-only; the `JsonValue` wire text is lossless). A global fix is blocked downstream — I tested it:
- `output.Normalize` re-decodes without `UseNumber`; adding it **quotes every number in YAML** output across all commands.
- the `toon-go` encoder **collapses `json.Number` to `float64` regardless**, so TOON (the agent default) can't be fixed via the intermediate representation anyway.

Documented the limitation at the call site and pinned it with a test rather than trade it for a broader regression.

## Tests added
- PG array-literal parser: 14 positive cases + malformed/rejection cases
- `convertToRawValue`: PG int/text/bigint/nested arrays, composite-stays-string, empty-type collision both directions, named-text-stays-string
- `columnValueToAny` (CLI): JSON object/array decode, malformed fallback, big-int caveat (cli module kept lean — stdlib-only test, no testify)

https://claude.ai/code/session_01MbEzZS58ZxgyrdEQTE8GiP